### PR TITLE
Hide ListOfNeverNull from public view. Always build DLLs.

### DIFF
--- a/build/build.cake
+++ b/build/build.cake
@@ -28,7 +28,8 @@ var baseDir = MakeAbsolute(Directory("../")).ToString();
 var buildDir = $"{baseDir}/build";
 var toolsDir = $"{buildDir}/tools";
 
-var defaultConfigurations = new[] {"Lottie-Windows", "LottieGen"};
+var allConfigurations = new[] {"Lottie-Windows", "LottieGen", "dlls"};
+var configurationsProducingNugets = new[] {"Lottie-Windows", "LottieGen"};
 
 var binDir = $"{baseDir}/bin";
 var nupkgDir =$"{binDir}/nupkg";
@@ -165,7 +166,7 @@ Task("Clean")
     }
 
     // Run the clean target on the solution.
-    MSBuildSolution("Clean", defaultConfigurations);
+    MSBuildSolution("Clean", allConfigurations);
 });
 
 Task("Verify")
@@ -208,12 +209,12 @@ Task("Build")
     Information("\r\nBuilding Solution");
 
     // Restore NuGet packages.
-    MSBuildSolution("Restore", defaultConfigurations);
+    MSBuildSolution("Restore", allConfigurations);
     
     EnsureDirectoryExists(nupkgDir);
 
-    // Build once with normal dependency ordering
-    MSBuildSolution("Build", defaultConfigurations, ("GenerateLibraryLayout", "true"));
+    // Build.
+    MSBuildSolution("Build", allConfigurations, ("GenerateLibraryLayout", "true"));
 });
 
 Task("InheritDoc")
@@ -251,7 +252,7 @@ Task("Package")
     .Does(() =>
 {
     // Invoke the pack target to generate the code to be packed.
-    MSBuildSolution("Pack", defaultConfigurations, ("GenerateLibraryLayout", "true"), ("PackageOutputPath", nupkgDir));
+    MSBuildSolution("Pack", configurationsProducingNugets, ("GenerateLibraryLayout", "true"), ("PackageOutputPath", nupkgDir));
     
     foreach (var nuspec in GetFiles("./*.nuspec"))
     {

--- a/source/LottieToWinComp/LottieToWinCompTranslator.cs
+++ b/source/LottieToWinComp/LottieToWinCompTranslator.cs
@@ -207,7 +207,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             // Shape roots to a list of Visual roots by wrapping the Shape trees in ShapeVisuals.
             var translatedAsVisuals = VisualsAndShapesToVisuals(context, translatedLayers.Select(a => a.translatedLayer));
 
-            container.Children.AddRange(translatedAsVisuals);
+            var containerChildren = container.Children;
+            foreach (var translatedVisual in translatedAsVisuals)
+            {
+                containerChildren.Add(translatedVisual);
+            }
         }
 
         // Takes a list of Visuals and Shapes and returns a list of Visuals.

--- a/source/WinCompData/CompositionContainerShape.cs
+++ b/source/WinCompData/CompositionContainerShape.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Tools;
 
 namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData
@@ -13,11 +14,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData
     {
         internal CompositionContainerShape()
         {
-            Shapes = new ListOfNeverNull<CompositionShape>();
         }
 
         /// <inheritdoc/>
-        public ListOfNeverNull<CompositionShape> Shapes { get; }
+        public IList<CompositionShape> Shapes { get; } = new ListOfNeverNull<CompositionShape>();
 
         /// <inheritdoc/>
         public override CompositionObjectType Type => CompositionObjectType.CompositionContainerShape;

--- a/source/WinCompData/ContainerVisual.cs
+++ b/source/WinCompData/ContainerVisual.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Tools;
 
 namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData
@@ -13,10 +14,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData
     {
         internal ContainerVisual()
         {
-            Children = new ListOfNeverNull<Visual>();
         }
 
-        public ListOfNeverNull<Visual> Children { get; }
+        public IList<Visual> Children { get; } = new ListOfNeverNull<Visual>();
 
         /// <inheritdoc/>
         public override CompositionObjectType Type => CompositionObjectType.ContainerVisual;

--- a/source/WinCompData/IContainShapes.cs
+++ b/source/WinCompData/IContainShapes.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Tools;
+using System.Collections.Generic;
 
 namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData
 {
@@ -14,6 +14,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData
         /// <summary>
         /// The <see cref="CompositionShape"/>s that are contained by this object.
         /// </summary>
-        ListOfNeverNull<CompositionShape> Shapes { get; }
+        IList<CompositionShape> Shapes { get; }
     }
 }

--- a/source/WinCompData/ShapeVisual.cs
+++ b/source/WinCompData/ShapeVisual.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Tools;
 
 namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData
@@ -13,11 +14,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData
     {
         internal ShapeVisual()
         {
-            Shapes = new ListOfNeverNull<CompositionShape>();
         }
 
         /// <inheritdoc/>
-        public ListOfNeverNull<CompositionShape> Shapes { get; }
+        public IList<CompositionShape> Shapes { get; } = new ListOfNeverNull<CompositionShape>();
 
         public CompositionViewBox ViewBox { get; set; }
 

--- a/source/WinCompData/Tools/ListOfNeverNull.cs
+++ b/source/WinCompData/Tools/ListOfNeverNull.cs
@@ -8,9 +8,6 @@ using System.Collections.Generic;
 
 namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Tools
 {
-#if PUBLIC_WinCompData
-    public
-#endif
     sealed class ListOfNeverNull<T> : IList<T>, IReadOnlyList<T>
     {
         readonly List<T> _wrapped = new List<T>();
@@ -40,14 +37,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Tools
         public void Add(T item)
         {
             _wrapped.Add(AssertNotNull(item));
-        }
-
-        public void AddRange(IEnumerable<T> items)
-        {
-            foreach (var item in items)
-            {
-                Add(item);
-            }
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
ListOfNeverNull is an implementation detail so should not be public.
Always build the DLLs so that changes like these that can affect dependencies are checked during checkin.