### PR TITLE
Add a new type to represent Animatables that have been trimmed to the…

### DIFF
--- a/source/Lottie/Instantiator.cs
+++ b/source/Lottie/Instantiator.cs
@@ -950,7 +950,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
                 return result;
             }
 
-            result = CacheAndInitializeCompositionGeometry(obj, _c.CreatePathGeometry(GetCompositionPath(obj.Path)));
+            result = CacheAndInitializeCompositionGeometry(obj, _c.CreatePathGeometry(obj.Path == null ? null : GetCompositionPath(obj.Path)));
             StartAnimations(obj, result);
             return result;
         }

--- a/source/LottieData/AnimatableVector3.cs
+++ b/source/LottieData/AnimatableVector3.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Numerics;
 
 namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 {
@@ -16,12 +15,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
     sealed class AnimatableVector3 : Animatable<Vector3>, IAnimatableVector3
     {
         public AnimatableVector3(Vector3 initialValue, int? propertyIndex)
-            : this(initialValue, EmptyKeyFrames, propertyIndex)
+            : base(initialValue, propertyIndex)
         {
         }
 
-        public AnimatableVector3(Vector3 initialValue, IEnumerable<KeyFrame<Vector3>> keyframes, int? propertyIndex)
-            : base(initialValue, keyframes, propertyIndex)
+        public AnimatableVector3(IEnumerable<KeyFrame<Vector3>> keyFrames, int? propertyIndex)
+            : base(keyFrames, propertyIndex)
         {
         }
 

--- a/source/LottieData/Color.cs
+++ b/source/LottieData/Color.cs
@@ -26,6 +26,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 
         public static Color Black { get; } = new Color(1, 0, 0, 0);
 
+        public static Color TransparentBlack { get; } = new Color(0, 0, 0, 0);
+
         public double A { get; }
 
         public double R { get; }

--- a/source/LottieData/Optimization/Optimizer.cs
+++ b/source/LottieData/Optimization/Optimizer.cs
@@ -24,20 +24,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Optimization
         static readonly AnimatableComparer<Color> ColorComparer = new AnimatableComparer<Color>();
         static readonly AnimatableComparer<double> FloatComparer = new AnimatableComparer<double>();
         static readonly AnimatableComparer<Sequence<BezierSegment>> PathGeometryComparer = new AnimatableComparer<Sequence<BezierSegment>>();
-        readonly Dictionary<Animatable<Color>, Animatable<Color>> _animatableColorsCache;
-        readonly Dictionary<Animatable<double>, Animatable<double>> _animatableFloatsCache;
         readonly Dictionary<Animatable<Sequence<BezierSegment>>, Animatable<Sequence<BezierSegment>>> _animatablePathGeometriesCache;
 
         public Optimizer()
         {
-            _animatableColorsCache = new Dictionary<Animatable<Color>, Animatable<Color>>(ColorComparer);
-            _animatableFloatsCache = new Dictionary<Animatable<double>, Animatable<double>>(FloatComparer);
             _animatablePathGeometriesCache = new Dictionary<Animatable<Sequence<BezierSegment>>, Animatable<Sequence<BezierSegment>>>(PathGeometryComparer);
         }
-
-        public Animatable<Color> GetOptimized(Animatable<Color> value) => GetOptimized(value, _animatableColorsCache);
-
-        public Animatable<double> GetOptimized(Animatable<double> value) => GetOptimized(value, _animatableFloatsCache);
 
         public Animatable<Sequence<BezierSegment>> GetOptimized(Animatable<Sequence<BezierSegment>> value)
         {
@@ -329,7 +321,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Optimization
         /// <param name="animatable">An <see cref="Animatable{T}"/>.</param>
         /// <param name="startTime">The frame time at which rendering starts.</param>
         /// <param name="endTime">The frame time at which rendering ends.</param>
-        /// <returns>The key frames that are visible for rendering between <paramref name="startTime"/>
+        /// <returns>
+        /// The key frames that are visible for rendering between <paramref name="startTime"/>
         /// and <paramref name="endTime"/>, with other key frames removed.
         /// </returns>
         public static ReadOnlySpan<KeyFrame<T>> TrimKeyFrames<T>(Animatable<T> animatable, double startTime, double endTime)

--- a/source/LottieReader/Serialization/LottieCompositionReader.cs
+++ b/source/LottieReader/Serialization/LottieCompositionReader.cs
@@ -1370,7 +1370,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
 
             var propertyIndex = ReadInt(obj, "ix");
 
-            return new Animatable<Color>(initialValue, keyFrames, propertyIndex);
+            return keyFrames.Any()
+                ? new Animatable<Color>(keyFrames, propertyIndex)
+                : new Animatable<Color>(initialValue, propertyIndex);
         }
 
         // Reads the transform for a repeater. Repeater transforms are the same as regular transforms
@@ -1501,7 +1503,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
             {
                 s_animatableVector2Parser.ParseJson(this, obj, out IEnumerable<KeyFrame<Vector2>> keyFrames, out Vector2 initialValue);
                 AssertAllFieldsRead(obj);
-                return new Animatable<Vector2>(initialValue, keyFrames, propertyIndex);
+
+                return keyFrames.Any()
+                    ? new Animatable<Vector2>(keyFrames, propertyIndex)
+                    : new Animatable<Vector2>(initialValue, propertyIndex);
             }
 
             throw new LottieCompositionReaderException("Animatable Vector2 could not be read.");
@@ -1519,7 +1524,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
             {
                 s_animatableVector3Parser.ParseJson(this, obj, out IEnumerable<KeyFrame<Vector3>> keyFrames, out Vector3 initialValue);
                 AssertAllFieldsRead(obj);
-                return new AnimatableVector3(initialValue, keyFrames, propertyIndex);
+
+                return keyFrames.Any()
+                    ? new AnimatableVector3(keyFrames, propertyIndex)
+                    : new AnimatableVector3(initialValue, propertyIndex);
             }
             else
             {
@@ -1536,7 +1544,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
         {
             s_animatableGeometryParser.ParseJson(this, obj, out IEnumerable<KeyFrame<PathGeometry>> keyFrames, out PathGeometry initialValue);
             var propertyIndex = ReadInt(obj, "ix");
-            return new Animatable<PathGeometry>(initialValue, keyFrames, propertyIndex);
+
+            return keyFrames.Any()
+                ? new Animatable<PathGeometry>(keyFrames, propertyIndex)
+                : new Animatable<PathGeometry>(initialValue, propertyIndex);
         }
 
         Animatable<Sequence<GradientStop>> ReadAnimatableGradientStops(JObject obj)
@@ -1550,14 +1561,19 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
                 out Sequence<GradientStop> initialValue);
 
             var propertyIndex = ReadInt(obj, "ix");
-            return new Animatable<Sequence<GradientStop>>(initialValue, keyFrames, propertyIndex);
+            return keyFrames.Any()
+                ? new Animatable<Sequence<GradientStop>>(keyFrames, propertyIndex)
+                : new Animatable<Sequence<GradientStop>>(initialValue, propertyIndex);
         }
 
         Animatable<double> ReadAnimatableFloat(JObject obj)
         {
             s_animatableFloatParser.ParseJson(this, obj, out IEnumerable<KeyFrame<double>> keyFrames, out double initialValue);
             var propertyIndex = ReadInt(obj, "ix");
-            return new Animatable<double>(initialValue, keyFrames, propertyIndex);
+
+            return keyFrames.Any()
+                ? new Animatable<double>(keyFrames, propertyIndex)
+                : new Animatable<double>(initialValue, propertyIndex);
         }
 
         static Vector3 ReadVector3FromJsonArray(JArray array)

--- a/source/LottieToWinComp/ContainerShapeOrVisual.cs
+++ b/source/LottieToWinComp/ContainerShapeOrVisual.cs
@@ -1,0 +1,125 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Numerics;
+using Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData;
+
+namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
+{
+    /// <summary>
+    /// Helper for abstracting <see cref="CompositionContainerShape"/> and
+    /// <see cref="ContainerVisual"/> so that they can be treated the same
+    /// in some circumstances.
+    /// </summary>
+    /// <remarks>
+    /// Properties that are Vector2 on CompositionContainerShape but Vector3
+    /// on ContainerVisual are exposed as Vector2 and converted to Vector3
+    /// as necessary.
+    /// </remarks>
+    abstract class ContainerShapeOrVisual
+    {
+        readonly CompositionObject _compositionObject;
+
+        ContainerShapeOrVisual(CompositionObject compositionObject)
+        {
+            _compositionObject = compositionObject;
+        }
+
+        public abstract bool IsShape { get; }
+
+        public CompositionPropertySet Properties => _compositionObject.Properties;
+
+        public abstract Vector2? CenterPoint { get; set; }
+
+        public abstract Vector2? Offset { get; set; }
+
+        public abstract Vector2? Scale { get; set; }
+
+        public abstract float? RotationAngleInDegrees { get; set; }
+
+        sealed class WrappedContainerShape : ContainerShapeOrVisual
+        {
+            readonly CompositionContainerShape _wrapped;
+
+            internal WrappedContainerShape(CompositionContainerShape wrapped)
+                : base(wrapped)
+            {
+                _wrapped = wrapped;
+            }
+
+            public override bool IsShape => true;
+
+            public override Vector2? CenterPoint
+            {
+                get => _wrapped.CenterPoint;
+                set => _wrapped.CenterPoint = value;
+            }
+
+            public override Vector2? Offset
+            {
+                get => _wrapped.Offset;
+                set => _wrapped.Offset = value;
+            }
+
+            public override Vector2? Scale
+            {
+                get => _wrapped.Scale;
+                set => _wrapped.Scale = value;
+            }
+
+            public override float? RotationAngleInDegrees
+            {
+                get => _wrapped.RotationAngleInDegrees;
+                set => _wrapped.RotationAngleInDegrees = value;
+            }
+        }
+
+        sealed class WrappedContainerVisual : ContainerShapeOrVisual
+        {
+            readonly ContainerVisual _wrapped;
+
+            internal WrappedContainerVisual(ContainerVisual wrapped)
+                : base(wrapped)
+            {
+                _wrapped = wrapped;
+            }
+
+            public override bool IsShape => false;
+
+            public override Vector2? CenterPoint
+            {
+                get => Vector2(_wrapped.CenterPoint);
+                set => _wrapped.CenterPoint = Vector3(value);
+            }
+
+            public override Vector2? Offset
+            {
+                get => Vector2(_wrapped.Offset);
+                set => _wrapped.Offset = Vector3(value);
+            }
+
+            public override Vector2? Scale
+            {
+                get => Vector2(_wrapped.Scale);
+                set => _wrapped.Scale = Vector3(value);
+            }
+
+            public override float? RotationAngleInDegrees
+            {
+                get => _wrapped.RotationAngleInDegrees;
+                set => _wrapped.RotationAngleInDegrees = value;
+            }
+        }
+
+        public static implicit operator ContainerShapeOrVisual(CompositionContainerShape shape) => new WrappedContainerShape(shape);
+
+        public static implicit operator ContainerShapeOrVisual(ContainerVisual visual) => new WrappedContainerVisual(visual);
+
+        public static implicit operator CompositionObject(ContainerShapeOrVisual containerShapeOrVisual) => containerShapeOrVisual._compositionObject;
+
+        static Vector2? Vector2(Vector3? value) => value.HasValue ? new Vector2(value.Value.X, value.Value.Y) : default(Vector2?);
+
+        static Vector3? Vector3(Vector2? value) => value.HasValue ? new Vector3(value.Value.X, value.Value.Y, 0) : default(Vector3?);
+    }
+}

--- a/source/LottieToWinComp/LottieToWinComp.projitems
+++ b/source/LottieToWinComp/LottieToWinComp.projitems
@@ -7,8 +7,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)CanvasGeometryCombiner.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ContainerShapeOrVisual.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ExpressionFactory.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)LottieToWinCompTranslator.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TranslationContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TranslationIssues.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TrimmedAnimatable.cs" />
   </ItemGroup>
 </Project>

--- a/source/LottieToWinComp/TranslationContext.cs
+++ b/source/LottieToWinComp/TranslationContext.cs
@@ -1,0 +1,85 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.Toolkit.Uwp.UI.Lottie.LottieData;
+using Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Optimization;
+
+namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
+{
+    /// <summary>
+    /// The context in which to translate a composition. This is used to ensure that
+    /// layers in a PreComp are translated in the context of the PreComp, and to carry
+    /// around other context-specific state.
+    /// </summary>
+    sealed class TranslationContext
+    {
+        Layer Layer { get; }
+
+        internal TranslationContext ContainingContext { get; }
+
+        // A set of layers that can be referenced by id.
+        internal LayerCollection Layers { get; }
+
+        internal double Width { get; }
+
+        internal double Height { get; }
+
+        // The start time of the current layer, in composition time.
+        internal double StartTime { get; }
+
+        internal double EndTime => StartTime + DurationInFrames;
+
+        internal double DurationInFrames { get; }
+
+        // Constructs the root context.
+        internal TranslationContext(LottieComposition lottieComposition)
+        {
+            Layers = lottieComposition.Layers;
+            StartTime = lottieComposition.InPoint;
+            DurationInFrames = lottieComposition.OutPoint - lottieComposition.InPoint;
+            Width = lottieComposition.Width;
+            Height = lottieComposition.Height;
+        }
+
+        // Constructs a context for the given layer.
+        internal TranslationContext(TranslationContext context, PreCompLayer layer, LayerCollection layers)
+        {
+            Layer = layer;
+
+            // Precomps define a new temporal and spatial space.
+            Width = layer.Width;
+            Height = layer.Height;
+            StartTime = context.StartTime - layer.StartTime;
+
+            ContainingContext = context;
+            Layers = layers;
+            DurationInFrames = context.DurationInFrames;
+        }
+
+        internal TrimmedAnimatable<Vector3> TrimAnimatable(IAnimatableVector3 animatable)
+        {
+            return TrimAnimatable<Vector3>((AnimatableVector3)animatable);
+        }
+
+        internal TrimmedAnimatable<T> TrimAnimatable<T>(Animatable<T> animatable)
+            where T : IEquatable<T>
+        {
+            if (animatable.IsAnimated)
+            {
+                var trimmedKeyFrames = Optimizer.RemoveRedundantKeyFrames(Optimizer.TrimKeyFrames(animatable, StartTime, EndTime));
+                return new TrimmedAnimatable<T>(
+                    this,
+                    trimmedKeyFrames.Length == 0
+                        ? animatable.InitialValue
+                        : trimmedKeyFrames[0].Value,
+                    trimmedKeyFrames);
+            }
+            else
+            {
+                return new TrimmedAnimatable<T>(this, animatable.InitialValue, animatable.KeyFrames);
+            }
+        }
+    }
+}

--- a/source/LottieToWinComp/TrimmedAnimatable.cs
+++ b/source/LottieToWinComp/TrimmedAnimatable.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.Toolkit.Uwp.UI.Lottie.LottieData;
+
+namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
+{
+    /// <summary>
+    /// An <see cref="LottieData.Animatable{T}"/> that has had its key frames trimmed
+    /// to include only those that affect a particular time period.
+    /// </summary>
+    /// <typeparam name="T">The type of the key frames.</typeparam>
+    ref struct TrimmedAnimatable<T>
+        where T : IEquatable<T>
+    {
+        internal TrimmedAnimatable(TranslationContext context, T initialValue, ReadOnlySpan<KeyFrame<T>> keyFrames)
+        {
+            Context = context;
+            InitialValue = initialValue;
+            KeyFrames = keyFrames;
+        }
+
+        internal TrimmedAnimatable(TranslationContext context, T initialValue)
+        {
+            Context = context;
+            InitialValue = initialValue;
+            KeyFrames = default(ReadOnlySpan<KeyFrame<T>>);
+        }
+
+        /// <summary>
+        /// Gets the initial value.
+        /// </summary>
+        internal T InitialValue { get; }
+
+        /// <summary>
+        /// Gets the keyframes that describe how the value should be animated.
+        /// </summary>
+        internal ReadOnlySpan<KeyFrame<T>> KeyFrames { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the <see cref="Animatable{T}"/> has any key frames.
+        /// </summary>
+        internal bool IsAnimated => KeyFrames.Length > 1;
+
+        internal TranslationContext Context { get; }
+    }
+}

--- a/source/WinCompData/CodeGen/InstantiatorGeneratorBase.cs
+++ b/source/WinCompData/CodeGen/InstantiatorGeneratorBase.cs
@@ -1182,8 +1182,16 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.CodeGen
         bool GenerateCompositionPathGeometryFactory(CodeBuilder builder, CompositionPathGeometry obj, ObjectData node)
         {
             WriteObjectFactoryStart(builder, node);
-            var path = _objectGraph[obj.Path];
-            WriteCreateAssignment(builder, node, $"_c{Deref}CreatePathGeometry({CallFactoryFromFor(node, path)})");
+            if (obj.Path == null)
+            {
+                WriteCreateAssignment(builder, node, $"_c{Deref}CreatePathGeometry()");
+            }
+            else
+            {
+                var path = _objectGraph[obj.Path];
+                WriteCreateAssignment(builder, node, $"_c{Deref}CreatePathGeometry({CallFactoryFromFor(node, path)})");
+            }
+
             InitializeCompositionGeometry(builder, obj, node);
             StartAnimations(builder, obj, node);
             WriteObjectFactoryEnd(builder);

--- a/source/WinCompData/CodeGen/Optimizer.cs
+++ b/source/WinCompData/CodeGen/Optimizer.cs
@@ -1002,7 +1002,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.CodeGen
                 return result;
             }
 
-            result = CacheAndInitializeCompositionGeometry(obj, _c.CreatePathGeometry(GetCompositionPath(obj.Path)));
+            result = CacheAndInitializeCompositionGeometry(obj, _c.CreatePathGeometry(obj.Path == null ? null : GetCompositionPath(obj.Path)));
             StartAnimationsAndFreeze(obj, result);
             return result;
         }

--- a/source/WinCompData/Tools/ObjectGraph.cs
+++ b/source/WinCompData/Tools/ObjectGraph.cs
@@ -405,7 +405,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Tools
         bool VisitCompositionPathGeometry(CompositionPathGeometry obj, T node)
         {
             VisitCompositionGeometry(obj, node);
-            Reference(node, obj.Path);
+            if (obj.Path != null)
+            {
+                Reference(node, obj.Path);
+            }
+
             return true;
         }
 


### PR DESCRIPTION
…ir context.

During translation, Animatables need to be considered in context. For example,
if an Animatable has its last key frame before the start time of the composition's inPoint,
its initial value is the value of its last key frame. To handle that, we add the TrimmedAnimatable
struct which is a wrapper around the contents of an Animatable.

Use the TrimmedAnimatable in the translator to ensure all IsAnimated checks are done
on the trimmed set of key frames, and that the InitialValue is correct in context.

Ensure values are not set on CompositionObjects if they have an animation. We always use
a key frame for the initial value if the object is animated so there is no need to
set the values directly on the object. Previously we did this optimally sometimes. Should
be much more consistent now.

Add a ContainerShapeOrVisual class so we only need one version of the TransformAndApplyTransform methods.

Make Animatable's constructors be explicit about animated-versus-non-animated versions. Previously
we would pass the InitialValue when constructing an animated Animatable but that was always the
value of the first keyframe. Rather than requiring the callers to get that right, add a constructor
that does the right thing for animated Animatables. This allows us to reason about Animatables
better because we now know by construction that the InitialValue is always the first keyframe value.

Make IsAnimated mean that an animatable has > 1 keyframes (was previously > 0). A single keyframe
does not represent an animation - you need at least 2.