### PR TITLE
Handle file patterns that have a drive letter and a relative path.

### DIFF
--- a/LottieGen/InstallLottieGenFromLocalBuild.cmd
+++ b/LottieGen/InstallLottieGenFromLocalBuild.cmd
@@ -7,4 +7,4 @@ dotnet tool uninstall -g LottieGen
 @for /f "tokens=2,3,4,5,6 delims=." %%A in ('dir /b %~dp0\..\bin\nupkg\LottieGen.*.nupkg') do @set PackageVersion=%%A.%%B.%%C.%%D.%%E
 
 :: Install
-dotnet tool install LottieGen -g --version 1.0.0-build.24.gd874495984 --add-source f:\GitHub\Lottie-Windows\bin\nupkg
+dotnet tool install LottieGen -g --version %PackageVersion% --add-source f:\GitHub\Lottie-Windows\bin\nupkg

--- a/LottieGen/Program.cs
+++ b/LottieGen/Program.cs
@@ -59,13 +59,21 @@ sealed class Program
 
     static IEnumerable<string> ExpandWildcards(string path)
     {
-        var directoryPath = Path.GetDirectoryName(path);
+        // Separate the path root (e.g. "C:" or "C:\" or "") from the rest of
+        // the path so that GetDirectoryName returns just the directory. If we
+        // don't do that, C:foobar will return C: as the directory path.
+        var pathRoot = Path.GetPathRoot(path);
+        var pathWithoutRoot = path.Substring(pathRoot.Length);
+
+        var directoryPath = Path.GetDirectoryName(pathWithoutRoot);
         if (string.IsNullOrWhiteSpace(directoryPath))
         {
             directoryPath = ".";
         }
 
-        return Directory.EnumerateFiles(directoryPath, Path.GetFileName(path));
+        var searchPattern = Path.GetFileName(path);
+
+        return Directory.EnumerateFiles(pathRoot + directoryPath, searchPattern);
     }
 
     // Helper for writing info lines to the info stream.


### PR DESCRIPTION
Paths such as c:mystuff\foo.json were not being parsed correctly.
Also, fix the install script for LottieGen - I'd accidentally left a hard-coded version number in there.