### PR TITLE
Remove transparent shapes

### DIFF
--- a/source/WinCompData/CodeGen/TreeReducer.cs
+++ b/source/WinCompData/CodeGen/TreeReducer.cs
@@ -170,9 +170,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.CodeGen
 
         static float DegreesToRadians(float angle) => (float)(Math.PI * angle / 180.0);
 
-        static void IsBrushTransparent(CompositionBrush brush)
+        static bool IsBrushTransparent(CompositionBrush brush)
         {
-            return brush == null || (!brush.Animators.Any() && (brush  s CompositionColorBrush)?.Color.A == 0);
+            return brush == null || (!brush.Animators.Any() && (brush as CompositionColorBrush)?.Color.A == 0);
         }
 
         static void RemoveTransparentShapes(ObjectGraph<Node> graph)


### PR DESCRIPTION
Add an optimization to remove shapes that have no brushes or transparent brushes. The shapes can't be seen, so let's not render them.