### PR TITLE
Fixes NullReferenceException caused by codegen optimizer hole.

### DIFF
--- a/source/WinCompData/CompositionObject.cs
+++ b/source/WinCompData/CompositionObject.cs
@@ -15,14 +15,17 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData
     abstract class CompositionObject : IDisposable, IDescribable
     {
         readonly ListOfNeverNull<Animator> _animators = new ListOfNeverNull<Animator>();
-        CompositionPropertySet _propertySet;
 
         protected private CompositionObject()
         {
             if (Type == CompositionObjectType.CompositionPropertySet)
             {
                 // The property set on a property set is itself.
-                _propertySet = (CompositionPropertySet)this;
+                Properties = (CompositionPropertySet)this;
+            }
+            else
+            {
+                Properties = new CompositionPropertySet(this);
             }
         }
 
@@ -42,14 +45,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData
         /// </summary>
         public string ShortDescription { get; set; }
 
-        public CompositionPropertySet Properties
-        {
-            get
-            {
-                if (_propertySet == null) { _propertySet = new CompositionPropertySet(this); }
-                return _propertySet;
-            }
-        }
+        public CompositionPropertySet Properties { get; }
 
         /// <summary>
         /// Binds an animation to a property.

--- a/source/WinCompData/Tools/ObjectGraph.cs
+++ b/source/WinCompData/Tools/ObjectGraph.cs
@@ -166,15 +166,43 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Tools
             }
 
             // Reference the animators after referencing all the other contents of the object. This is
-            // done to ensure the position of animators is higher than the position of other
+            // done to ensure the Position of animators is greater than the position of other
             // references. This ordering is consistent with how CompositionObjects are initialized:
             // 1. Instantiate the object
-            // 2. Assign the values for the object's properties
-            // 3. Start the animations
-            foreach (var animator in obj.Animators)
+            // 2. Assign the values for the object's properties and property set properties
+            // 3. Start the animations for the object's properties
+            // 4. Start the animations for the object's property set properties.
+            //
+            // Treat CompositionPropertySet specially: Start the animations on an object's property
+            // set when starting the animations on the owning object, unless there is no owning object
+            // (i.e. it's a property set that was directly created rather than being implicitly
+            // created by a CompositionObject's .Properties property).
+            if (obj.Type == CompositionObjectType.CompositionPropertySet)
             {
-                Reference(node, animator.Animation);
-                Reference(node, animator.Controller);
+                if (((CompositionPropertySet)obj).Owner == null)
+                {
+                    // Unowned CompositionPropertySet - can't have animations referenced
+                    // from its owner, so reference them here.
+                    foreach (var animator in obj.Animators)
+                    {
+                        Reference(node, animator.Animation);
+                        Reference(node, animator.Controller);
+                    }
+                }
+            }
+            else
+            {
+                foreach (var animator in obj.Animators)
+                {
+                    Reference(node, animator.Animation);
+                    Reference(node, animator.Controller);
+                }
+
+                foreach (var animator in obj.Properties.Animators)
+                {
+                    Reference(node, animator.Animation);
+                    Reference(node, animator.Controller);
+                }
             }
         }
 

--- a/source/WinCompData/Tools/ObjectGraph.cs
+++ b/source/WinCompData/Tools/ObjectGraph.cs
@@ -192,16 +192,19 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Tools
             }
             else
             {
+                // Reference the animations for the object's properties
                 foreach (var animator in obj.Animators)
                 {
                     Reference(node, animator.Animation);
                     Reference(node, animator.Controller);
                 }
 
-                foreach (var animator in obj.Properties.Animators)
+                var propertySet = obj.Properties;
+                var propertySetNode = this[propertySet];
+                foreach (var animator in propertySet.Animators)
                 {
-                    Reference(node, animator.Animation);
-                    Reference(node, animator.Controller);
+                    Reference(propertySetNode, animator.Animation);
+                    Reference(propertySetNode, animator.Controller);
                 }
             }
         }


### PR DESCRIPTION
On rare cases the codegen optimizer that replaces methods calls with field accesses would pull from a field before it had been initialized. This was caused by the code generator generating nodes in a different order from what the ObjectGraph visited them. I've updated the ObjectGraph to visit the nodes in the same order as the code generator.