### PR TITLE
Add ability to dump Lottie files as YAML.

### DIFF
--- a/LottieGen/CommandLineOptions.cs
+++ b/LottieGen/CommandLineOptions.cs
@@ -18,6 +18,7 @@ internal enum Lang
     Cx,
     WinrtCpp,
     LottieXml,
+    LottieYaml,
     WinCompXml,
     WinCompDgml,
     Stats,
@@ -76,6 +77,7 @@ sealed class CommandLineOptions
                 .AddKeyword("cx", Lang.Cx)
                 .AddKeyword("winrtcpp", Lang.WinrtCpp)
                 .AddKeyword("lottiexml", Lang.LottieXml)
+                .AddKeyword("lottieyaml", Lang.LottieYaml)
                 .AddKeyword("wincompxml", Lang.WinCompXml)
                 .AddKeyword("dgml", Lang.WinCompDgml)
                 .AddKeyword("stats", Lang.Stats);

--- a/LottieGen/Program.cs
+++ b/LottieGen/Program.cs
@@ -114,12 +114,18 @@ sealed class Program
 #if DO_NOT_PROCESS_IN_PARALLEL
         foreach (var (file, relativePath) in matchingInputFiles)
         {
-            succeeded &= LottieFileProcessor.ProcessFile(_options, _reporter, file, Path.Combine(outputFolder, relativePath));
+            if (!LottieFileProcessor.ProcessFile(_options, _reporter, file, Path.Combine(outputFolder, relativePath)))
+            {
+                succeeded = false;
+            }
         }
 #else
         Parallel.ForEach(matchingInputFiles, (inputFile) =>
         {
-            succeeded &= LottieFileProcessor.ProcessFile(_options, _reporter, inputFile.path, Path.Combine(outputFolder, inputFile.relativePath));
+            if (!LottieFileProcessor.ProcessFile(_options, _reporter, inputFile.path, Path.Combine(outputFolder, inputFile.relativePath)))
+            {
+                succeeded = false;
+            }
         });
 #endif
         return succeeded ? RunResult.Success : RunResult.Failure;
@@ -149,7 +155,7 @@ Usage: {0} -InputFile LOTTIEFILE -Language LANG [Other options]
 OVERVIEW:
        Generates source code from Lottie files for playing in the AnimatedVisualPlayer. 
        LOTTIEFILE is a Lottie .json file. LOTTIEFILE may contain wildcards.
-       LANG is one of cs, cppcx, winrtcpp, wincompxml, lottiexml, dgml, or stats.
+       LANG is one of cs, cppcx, winrtcpp, wincompxml, lottiexml, lottieyaml, dgml, or stats.
        -Language LANG may be specified multiple times.
 
        [Other options]

--- a/source/Lottie/LottieVisualDiagnostics.cs
+++ b/source/Lottie/LottieVisualDiagnostics.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
         public string GenerateLottieXml()
         {
             if (LottieComposition == null) { return null; }
-            return LottieData.Tools.LottieCompositionXmlSerializer.ToXml(LottieComposition).ToString();
+            return LottieData.Serialization.LottieCompositionXmlSerializer.ToXml(LottieComposition).ToString();
         }
 
         public string GenerateWinCompXml()

--- a/source/LottieData/LottieData.projitems
+++ b/source/LottieData/LottieData.projitems
@@ -6,6 +6,13 @@
     <SharedGUID>b3db16ee-a821-4474-a188-e64926529bbd</SharedGUID>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Serialization\LottieCompositionYamlSerializer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Serialization\YamlMap.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Serialization\YamlObject.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Serialization\YamlObjectKind.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Serialization\YamlScalar.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Serialization\YamlSequence.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Serialization\YamlWriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Animatable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ExtensionMethods.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\AnimatableVector3.cs" />

--- a/source/LottieData/Serialization/LottieCompositionXmlSerializer.cs
+++ b/source/LottieData/Serialization/LottieCompositionXmlSerializer.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Linq;
 
-namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Tools
+namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
 {
 #if PUBLIC_LottieData
     public

--- a/source/LottieData/Serialization/LottieCompositionYamlSerializer.cs
+++ b/source/LottieData/Serialization/LottieCompositionYamlSerializer.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
         {
             var result = new YamlMap
             {
-                { "Name", obj.Name }
+                { "Name", obj.Name },
             };
             return result;
         }

--- a/source/LottieData/Serialization/LottieCompositionYamlSerializer.cs
+++ b/source/LottieData/Serialization/LottieCompositionYamlSerializer.cs
@@ -1,0 +1,552 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
+{
+#if PUBLIC_LottieData
+    public
+#endif
+    sealed class LottieCompositionYamlSerializer
+    {
+        public static void WriteYaml(LottieComposition root, TextWriter writer, string comment = null)
+        {
+            var serializer = new LottieCompositionYamlSerializer();
+
+            // Convert the LottieComposition into the Yaml data model.
+            var yaml = serializer.FromLottieObject(root);
+
+            var yamlWriter = new YamlWriter(writer);
+            var documentStart = "--- !LottieComposition";
+            if (!string.IsNullOrWhiteSpace(comment))
+            {
+                documentStart += $" # {comment}";
+            }
+
+            yamlWriter.Write(documentStart);
+            yamlWriter.WriteObject(yaml);
+        }
+
+        YamlMap GetLottieObjectContent(LottieObject obj)
+        {
+            var result = new YamlMap
+            {
+                { "Name", obj.Name }
+            };
+            return result;
+        }
+
+        YamlObject FromLottieObject(LottieObject obj)
+        {
+            var superclassContent = GetLottieObjectContent(obj);
+
+            switch (obj.ObjectType)
+            {
+                case LottieObjectType.LottieComposition:
+                    return FromLottieComposition((LottieComposition)obj, superclassContent);
+
+                case LottieObjectType.Marker:
+                    return FromMarker((Marker)obj, superclassContent);
+
+                case LottieObjectType.ImageLayer:
+                case LottieObjectType.NullLayer:
+                case LottieObjectType.PreCompLayer:
+                case LottieObjectType.ShapeLayer:
+                case LottieObjectType.SolidLayer:
+                case LottieObjectType.TextLayer:
+                    return FromLayer((Layer)obj, superclassContent);
+
+                case LottieObjectType.Ellipse:
+                case LottieObjectType.LinearGradientFill:
+                case LottieObjectType.LinearGradientStroke:
+                case LottieObjectType.MergePaths:
+                case LottieObjectType.Polystar:
+                case LottieObjectType.RadialGradientFill:
+                case LottieObjectType.RadialGradientStroke:
+                case LottieObjectType.Rectangle:
+                case LottieObjectType.Repeater:
+                case LottieObjectType.RoundedCorner:
+                case LottieObjectType.Shape:
+                case LottieObjectType.ShapeGroup:
+                case LottieObjectType.SolidColorFill:
+                case LottieObjectType.SolidColorStroke:
+                case LottieObjectType.Transform:
+                case LottieObjectType.TrimPath:
+                    return FromShapeLayerContent((ShapeLayerContent)obj, superclassContent);
+
+                default:
+                    throw new InvalidOperationException();
+            }
+        }
+
+        YamlObject FromLottieComposition(LottieComposition lottieComposition, YamlMap superclassContent)
+        {
+            var result = superclassContent;
+            result.Add("Version", lottieComposition.Version);
+            result.Add("Width", lottieComposition.Width);
+            result.Add("Height", lottieComposition.Height);
+            result.Add("InPoint", lottieComposition.InPoint);
+            result.Add("OutPoint", lottieComposition.OutPoint);
+            result.Add("Duration", lottieComposition.Duration);
+            result.Add("Assets", FromEnumerable(lottieComposition.Assets, FromAsset));
+            result.Add("Layers", FromLayerCollection(lottieComposition.Layers));
+            result.Add("Markers", FromEnumerable(lottieComposition.Markers, FromMarker));
+            return result;
+        }
+
+        YamlSequence FromSequence<T>(Sequence<T> collection, Func<T, YamlObject> selector)
+        {
+            var result = new YamlSequence();
+            foreach (var item in collection.Items)
+            {
+                result.Add(selector(item));
+            }
+
+            return result;
+        }
+
+        YamlSequence FromEnumerable<T>(IEnumerable<T> collection, Func<T, YamlObject> selector)
+        {
+            var result = new YamlSequence();
+            foreach (var item in collection)
+            {
+                result.Add(selector(item));
+            }
+
+            return result;
+        }
+
+        YamlSequence FromSpan<T>(ReadOnlySpan<T> collection, Func<T, YamlObject> selector)
+        {
+            var result = new YamlSequence();
+            foreach (var item in collection)
+            {
+                result.Add(selector(item));
+            }
+
+            return result;
+        }
+
+        YamlObject FromAsset(Asset asset)
+        {
+            switch (asset.Type)
+            {
+                case Asset.AssetType.LayerCollection:
+                    return FromLayersAsset((LayerCollectionAsset)asset);
+                case Asset.AssetType.Image:
+                    return FromImageAsset((ImageAsset)asset);
+                default:
+                    throw new InvalidOperationException();
+            }
+        }
+
+        YamlObject FromLayersAsset(LayerCollectionAsset asset)
+        {
+            var result = new YamlMap
+            {
+                { "Id", asset.Id },
+                { "Layers", FromLayerCollection(asset.Layers) },
+            };
+            return result;
+        }
+
+        YamlObject FromImageAsset(ImageAsset asset)
+        {
+            return new YamlMap
+            {
+                { "Id", asset.Id },
+                { "Width", asset.Width },
+                { "Height", asset.Height },
+                { "Path", asset.Path },
+                { "Filename", asset.FileName },
+            };
+        }
+
+        YamlSequence FromLayerCollection(LayerCollection layers) =>
+            FromEnumerable(layers.GetLayersBottomToTop().Reverse(), FromLayer);
+
+        YamlObject FromLayer(Layer layer) => FromLayer(layer, GetLottieObjectContent(layer));
+
+        YamlObject FromLayer(Layer layer, YamlMap superclassContent)
+        {
+            superclassContent.Add("Type", layer.Type);
+            superclassContent.Add("Parent", layer.Parent);
+            superclassContent.Add("Index", layer.Index);
+            superclassContent.Add("IsHidden", layer.IsHidden);
+            superclassContent.Add("StartTime", layer.StartTime);
+            superclassContent.Add("InPoint", layer.InPoint);
+            superclassContent.Add("OutPoint", layer.OutPoint);
+            superclassContent.Add("TimeStretch", layer.TimeStretch);
+            superclassContent.Add("Transform", FromShapeLayerContent(layer.Transform));
+            superclassContent.Add("Masks", FromSpan(layer.Masks, FromMask));
+
+            switch (layer.Type)
+            {
+                case Layer.LayerType.PreComp:
+                    return FromPreCompLayer((PreCompLayer)layer, superclassContent);
+                case Layer.LayerType.Solid:
+                    return FromSolidLayer((SolidLayer)layer, superclassContent);
+                case Layer.LayerType.Image:
+                    return FromImageLayer((ImageLayer)layer, superclassContent);
+                case Layer.LayerType.Null:
+                    return FromNullLayer((NullLayer)layer, superclassContent);
+                case Layer.LayerType.Shape:
+                    return FromShapeLayer((ShapeLayer)layer, superclassContent);
+                case Layer.LayerType.Text:
+                    return FromTextLayer((TextLayer)layer, superclassContent);
+                default:
+                    throw new InvalidOperationException();
+            }
+        }
+
+        YamlObject FromPreCompLayer(PreCompLayer layer, YamlMap superclassContent)
+        {
+            var result = superclassContent;
+            result.Add("Width", layer.Width);
+            result.Add("Height", layer.Height);
+            result.Add("RefId", layer.RefId);
+            return result;
+        }
+
+        YamlObject FromSolidLayer(SolidLayer layer, YamlMap superclassContent)
+        {
+            var result = superclassContent;
+            result.Add("Width", layer.Width);
+            result.Add("Height", layer.Height);
+            result.Add("Color", layer.Color);
+            return result;
+        }
+
+        YamlObject FromImageLayer(ImageLayer layer, YamlMap superclassContent)
+        {
+            var result = superclassContent;
+            result.Add("RefId", layer.RefId);
+            return result;
+        }
+
+        YamlObject FromNullLayer(NullLayer layer, YamlMap superclassContent)
+        {
+            var result = superclassContent;
+            return result;
+        }
+
+        YamlObject FromShapeLayer(ShapeLayer layer, YamlMap superclassContent)
+        {
+            var result = superclassContent;
+            result.Add("Content", FromSpan(layer.Contents, FromShapeLayerContent));
+            return result;
+        }
+
+        YamlObject FromTextLayer(TextLayer layer, YamlMap superclassContent)
+        {
+            var result = superclassContent;
+            return result;
+        }
+
+        YamlObject FromShapeLayerContent(ShapeLayerContent content) => FromShapeLayerContent(content, GetLottieObjectContent(content));
+
+        YamlObject FromShapeLayerContent(ShapeLayerContent content, YamlMap superclassContent)
+        {
+            superclassContent.Add("MatchName", content.MatchName);
+            superclassContent.Add("ContentType", content.ContentType);
+
+            switch (content.ContentType)
+            {
+                case ShapeContentType.Group:
+                    return FromShapeGroup((ShapeGroup)content, superclassContent);
+                case ShapeContentType.SolidColorStroke:
+                    return FromSolidColorStroke((SolidColorStroke)content, superclassContent);
+                case ShapeContentType.LinearGradientStroke:
+                    return FromLinearGradientStroke((LinearGradientStroke)content, superclassContent);
+                case ShapeContentType.RadialGradientStroke:
+                    return FromRadialGradientStroke((RadialGradientStroke)content, superclassContent);
+                case ShapeContentType.SolidColorFill:
+                    return FromSolidColorFill((SolidColorFill)content, superclassContent);
+                case ShapeContentType.LinearGradientFill:
+                    return FromLinearGradientFill((LinearGradientFill)content, superclassContent);
+                case ShapeContentType.RadialGradientFill:
+                    return FromRadialGradientFill((RadialGradientFill)content, superclassContent);
+                case ShapeContentType.Transform:
+                    return FromTransform((Transform)content, superclassContent);
+                case ShapeContentType.Path:
+                    return FromPath((Shape)content, superclassContent);
+                case ShapeContentType.Ellipse:
+                    return FromEllipse((Ellipse)content, superclassContent);
+                case ShapeContentType.Rectangle:
+                    return FromRectangle((Rectangle)content, superclassContent);
+                case ShapeContentType.Polystar:
+                    return FromPolystar((Polystar)content, superclassContent);
+                case ShapeContentType.TrimPath:
+                    return FromTrimPath((TrimPath)content, superclassContent);
+                case ShapeContentType.MergePaths:
+                    return FromMergePaths((MergePaths)content, superclassContent);
+                case ShapeContentType.Repeater:
+                    return FromRepeater((Repeater)content, superclassContent);
+                case ShapeContentType.RoundedCorner:
+                    return FromRoundedCorner((RoundedCorner)content, superclassContent);
+                default:
+                    throw new InvalidOperationException();
+            }
+        }
+
+        YamlObject FromMask(Mask mask)
+        {
+            var result = new YamlMap
+            {
+                { "Name", mask.Name },
+                { "Inverted", mask.Inverted },
+                { "Mode", mask.Mode },
+                { "Opacity", FromAnimatable(mask.Opacity) },
+                { "Points", FromAnimatable(mask.Points, p => FromSequence(p, FromBezierSegment)) },
+            };
+            return result;
+        }
+
+        YamlObject FromShapeGroup(ShapeGroup content, YamlMap superclassContent)
+        {
+            var result = superclassContent;
+            result.Add("Items", FromSpan(content.Items, FromShapeLayerContent));
+            return result;
+        }
+
+        YamlObject FromSolidColorStroke(SolidColorStroke content, YamlMap superclassContent)
+        {
+            var result = superclassContent;
+            result.Add("Color", FromAnimatable(content.Color, FromColor));
+            result.Add("OpacityPercent", FromAnimatable(content.OpacityPercent));
+            result.Add("Thickness", FromAnimatable(content.Thickness));
+            return result;
+        }
+
+        YamlObject FromLinearGradientStroke(LinearGradientStroke content, YamlMap superclassContent)
+        {
+            var result = superclassContent;
+            return result;
+        }
+
+        YamlObject FromRadialGradientStroke(RadialGradientStroke content, YamlMap superclassContent)
+        {
+            var result = superclassContent;
+            return result;
+        }
+
+        YamlObject FromSolidColorFill(SolidColorFill content, YamlMap superclassContent)
+        {
+            var result = superclassContent;
+            result.Add("Color", FromAnimatable(content.Color, FromColor));
+            result.Add("OpacityPercent", FromAnimatable(content.OpacityPercent));
+            return result;
+        }
+
+        YamlObject FromLinearGradientFill(LinearGradientFill content, YamlMap superclassContent)
+        {
+            var result = superclassContent;
+            result.Add("OpacityPercent", FromAnimatable(content.OpacityPercent));
+            result.Add("GradientStops", FromAnimatable(content.GradientStops, p => FromSequence(p, FromGradientStop)));
+            return result;
+        }
+
+        YamlObject FromRadialGradientFill(RadialGradientFill content, YamlMap superclassContent)
+        {
+            var result = superclassContent;
+            result.Add("OpacityPercent", FromAnimatable(content.OpacityPercent));
+            result.Add("GradientStops", FromAnimatable(content.GradientStops, p => FromSequence(p, FromGradientStop)));
+            return result;
+        }
+
+        YamlObject FromTransform(Transform content, YamlMap superclassContent)
+        {
+            var result = superclassContent;
+            result.Add("ScalePercent", FromAnimatable(content.ScalePercent));
+            result.Add("Position", FromAnimatable(content.Position));
+            result.Add("Anchor", FromAnimatable(content.Anchor));
+            result.Add("OpacityPercent", FromAnimatable(content.OpacityPercent));
+            result.Add("RotationDegrees", FromAnimatable(content.RotationDegrees));
+            return result;
+        }
+
+        YamlObject FromAnimatable(IAnimatableVector3 animatable)
+        {
+            switch (animatable.Type)
+            {
+                case AnimatableVector3Type.Vector3:
+                    return FromAnimatable<Vector3>((AnimatableVector3)animatable, FromVector3);
+                case AnimatableVector3Type.XYZ:
+                    {
+                        var xyz = (AnimatableXYZ)animatable;
+                        var result = new YamlMap
+                        {
+                            { "X", FromAnimatable(xyz.X) },
+                            { "Y", FromAnimatable(xyz.Y) },
+                            { "Z", FromAnimatable(xyz.Z) },
+                        };
+                        return result;
+                    }
+
+                default:
+                    throw new InvalidOperationException();
+            }
+        }
+
+        YamlObject FromAnimatable<T>(Animatable<T> animatable, Func<T, YamlObject> valueSelector)
+            where T : IEquatable<T>
+        {
+            if (!animatable.IsAnimated)
+            {
+                return valueSelector(animatable.InitialValue);
+            }
+            else
+            {
+                return FromSpan<KeyFrame<T>>(animatable.KeyFrames, kf => FromKeyFrame(kf, valueSelector));
+            }
+        }
+
+        YamlObject FromAnimatable(Animatable<double> animatable)
+            => FromAnimatable(animatable, FromDouble);
+
+        static YamlObject FromDouble(double value) => (YamlScalar)value;
+
+        static YamlObject FromColor(Color value) => (YamlScalar)value.ToString();
+
+        static YamlObject FromVector3(Vector3 value)
+        {
+            var result = new YamlMap
+            {
+                { "X", value.X },
+                { "Y", value.Y },
+                { "Z", value.Z },
+            };
+            return result;
+        }
+
+        static YamlObject FromVector2(Vector2 value)
+        {
+            var result = new YamlMap
+            {
+                { "X", value.X },
+                { "Y", value.Y },
+            };
+            return result;
+        }
+
+        static YamlObject FromBezierSegment(BezierSegment value)
+        {
+            var result = new YamlMap
+            {
+                { "ControlPoint0", FromVector2(value.ControlPoint0) },
+                { "ControlPoint1", FromVector2(value.ControlPoint1) },
+                { "ControlPoint2", FromVector2(value.ControlPoint2) },
+                { "ControlPoint3", FromVector2(value.ControlPoint3) },
+            };
+            return result;
+        }
+
+        static YamlObject FromGradientStop(GradientStop value)
+        {
+            var result = new YamlMap
+            {
+                { "Color", FromColor(value.Color) },
+                { "Offset", value.Offset },
+                { "Opacity", value.Opacity },
+            };
+            return result;
+        }
+
+        static YamlMap FromKeyFrame<T>(KeyFrame<T> keyFrame, Func<T, YamlObject> valueSelector)
+            where T : IEquatable<T>
+        {
+            var result = new YamlMap
+            {
+                { "Frame", keyFrame.Frame },
+                { "Value", valueSelector(keyFrame.Value) },
+                { "Easing", keyFrame.Easing.Type },
+            };
+
+            if (keyFrame is KeyFrame<Vector3>)
+            {
+                var v3kf = (KeyFrame<Vector3>)(object)keyFrame;
+                var cp1 = v3kf.SpatialControlPoint1;
+                var cp2 = v3kf.SpatialControlPoint2;
+                if (cp1 != Vector3.Zero || cp2 != Vector3.Zero)
+                {
+                    // Spatial bezier
+                    result.Add("ControlPoint1", FromVector3(cp1));
+                    result.Add("ControlPoint2", FromVector3(cp2));
+                }
+            }
+
+            return result;
+        }
+
+        YamlObject FromPath(Shape content, YamlMap superclassContent)
+        {
+            var result = superclassContent;
+            return result;
+        }
+
+        YamlMap FromEllipse(Ellipse content, YamlMap superclassContent)
+        {
+            var result = superclassContent;
+            result.Add("Diameter", FromAnimatable(content.Diameter));
+            result.Add("Position", FromAnimatable(content.Position));
+            return result;
+        }
+
+        YamlObject FromRectangle(Rectangle content, YamlMap superclassContent)
+        {
+            var result = superclassContent;
+            result.Add("Size", FromAnimatable(content.Size));
+            result.Add("Position", FromAnimatable(content.Position));
+            result.Add("CornerRadius", FromAnimatable(content.CornerRadius));
+            return result;
+        }
+
+        YamlObject FromPolystar(Polystar content, YamlMap superclassContent)
+        {
+            var result = superclassContent;
+            return result;
+        }
+
+        YamlObject FromTrimPath(TrimPath content, YamlMap superclassContent)
+        {
+            var result = superclassContent;
+            result.Add("StartPercent", FromAnimatable(content.StartPercent));
+            result.Add("EndPercent", FromAnimatable(content.EndPercent));
+            result.Add("OffsetDegrees", FromAnimatable(content.OffsetDegrees));
+            return result;
+        }
+
+        YamlObject FromMarker(Marker obj) => FromMarker(obj, GetLottieObjectContent(obj));
+
+        YamlObject FromMarker(Marker obj, YamlMap superclassContent)
+        {
+            var result = superclassContent;
+            result.Add("Progress", obj.Progress);
+            return result;
+        }
+
+        YamlObject FromMergePaths(MergePaths content, YamlMap superclassContent)
+        {
+            var result = superclassContent;
+            return result;
+        }
+
+        YamlObject FromRoundedCorner(RoundedCorner content, YamlMap superclassContent)
+        {
+            var result = superclassContent;
+            result.Add("Radius", FromAnimatable(content.Radius));
+            return result;
+        }
+
+        YamlObject FromRepeater(Repeater content, YamlMap superclassContent)
+        {
+            var result = superclassContent;
+            return result;
+        }
+    }
+}

--- a/source/LottieData/Serialization/YamlMap.cs
+++ b/source/LottieData/Serialization/YamlMap.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
+{
+    sealed class YamlMap : YamlObject, IEnumerable<(string key, YamlObject value)>
+    {
+        readonly List<(string key, YamlObject value)> _keysAndValues = new List<(string key, YamlObject value)>();
+        readonly HashSet<string> _keys = new HashSet<string>();
+
+        internal YamlMap()
+        {
+        }
+
+        public IEnumerator<(string key, YamlObject value)> GetEnumerator()
+            => _keysAndValues.GetEnumerator();
+
+        internal override YamlObjectKind Kind => YamlObjectKind.Map;
+
+        internal void Add(string key, YamlScalar value) => Add(key, (YamlObject)value);
+
+        internal void Add(string key, YamlObject value)
+        {
+            if (!_keys.Add(key))
+            {
+                throw new InvalidOperationException();
+            }
+
+            _keysAndValues.Add((key, value));
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/source/LottieData/Serialization/YamlObject.cs
+++ b/source/LottieData/Serialization/YamlObject.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
+{
+    abstract class YamlObject
+    {
+        internal abstract YamlObjectKind Kind { get; }
+    }
+}

--- a/source/LottieData/Serialization/YamlObjectKind.cs
+++ b/source/LottieData/Serialization/YamlObjectKind.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
+{
+    enum YamlObjectKind
+    {
+        Unknown = 0,
+        Scalar,
+        Map,
+        Sequence,
+    }
+}

--- a/source/LottieData/Serialization/YamlScalar.cs
+++ b/source/LottieData/Serialization/YamlScalar.cs
@@ -1,0 +1,61 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
+{
+    sealed class YamlScalar : YamlObject
+    {
+        readonly object _value;
+        readonly string _presention;
+
+        YamlScalar(object value, string presentation)
+        {
+            _value = value;
+            _presention = presentation;
+        }
+
+        internal override YamlObjectKind Kind => YamlObjectKind.Scalar;
+
+        public static implicit operator YamlScalar(string value)
+        {
+            var escapedValue = value;
+            if (escapedValue == null)
+            {
+                escapedValue = "~";
+            }
+            else if (escapedValue.Length == 0)
+            {
+                escapedValue = "''";
+            }
+            else if (value.StartsWith(' ') || value.EndsWith(' ') || value.StartsWith('#'))
+            {
+                escapedValue = $"'{value}'";
+            }
+
+            return new YamlScalar(value, escapedValue);
+        }
+
+        public static implicit operator YamlScalar(double value) => new YamlScalar(value, value.ToString());
+
+        public static implicit operator YamlScalar(bool value) => new YamlScalar(value, value.ToString());
+
+        public static implicit operator YamlScalar(TimeSpan value) => new YamlScalar(value, value.ToString());
+
+        public static implicit operator YamlScalar(Color value) => new YamlScalar(value, $"'{value.ToString()}'");
+
+        public static implicit operator YamlScalar(Version value) => new YamlScalar(value, value.ToString());
+
+        public static implicit operator YamlScalar(Easing.EasingType type) => new YamlScalar(type, type.ToString());
+
+        public static implicit operator YamlScalar(Layer.LayerType type) => new YamlScalar(type, type.ToString());
+
+        public static implicit operator YamlScalar(Mask.MaskMode type) => new YamlScalar(type, type.ToString());
+
+        public static implicit operator YamlScalar(ShapeContentType type) => new YamlScalar(type, type.ToString());
+
+        public override string ToString() => _presention;
+    }
+}

--- a/source/LottieData/Serialization/YamlScalar.cs
+++ b/source/LottieData/Serialization/YamlScalar.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
             {
                 escapedValue = "''";
             }
-            else if (value.StartsWith(' ') || value.EndsWith(' ') || value.StartsWith('#'))
+            else if (value.StartsWith(" ") || value.EndsWith(" ") || value.StartsWith("#"))
             {
                 escapedValue = $"'{value}'";
             }

--- a/source/LottieData/Serialization/YamlSequence.cs
+++ b/source/LottieData/Serialization/YamlSequence.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
+{
+    sealed class YamlSequence : YamlObject, IEnumerable<YamlObject>
+    {
+        readonly List<YamlObject> _sequence = new List<YamlObject>();
+
+        public IEnumerator<YamlObject> GetEnumerator()
+        {
+            return ((IEnumerable<YamlObject>)_sequence).GetEnumerator();
+        }
+
+        internal override YamlObjectKind Kind => YamlObjectKind.Sequence;
+
+        internal void Add(YamlObject obj)
+        {
+            _sequence.Add(obj);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/source/LottieData/Serialization/YamlWriter.cs
+++ b/source/LottieData/Serialization/YamlWriter.cs
@@ -1,0 +1,253 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
+{
+    sealed class YamlWriter
+    {
+        const int _maximumWidth = 120;
+        const int _indentSize = 3;
+        readonly TextWriter _writer;
+        int _column;
+        int _indentColumn;
+        int _inlineColumn;
+
+        internal YamlWriter(TextWriter writer)
+        {
+            _writer = writer;
+        }
+
+        internal void Write(string value)
+        {
+            if (_indentColumn > _column)
+            {
+                _writer.Write(new string(' ', _indentColumn - _column));
+                _column = _indentColumn;
+            }
+
+            _writer.Write(value);
+            _column += value.Length;
+        }
+
+        void WriteInline(string value)
+        {
+            if (_inlineColumn > _column)
+            {
+                _writer.Write(new string(' ', _inlineColumn - _column));
+                _column = _inlineColumn;
+            }
+
+            _writer.Write(value);
+            _column += value.Length;
+        }
+
+        void WriteLine()
+        {
+            _writer.WriteLine();
+            _column = 0;
+        }
+
+        internal void WriteObject(YamlObject obj)
+        {
+            if (obj == null)
+            {
+                WriteInline("~");
+            }
+            else
+            {
+                switch (obj.Kind)
+                {
+                    case YamlObjectKind.Scalar:
+                        WriteScalar((YamlScalar)obj);
+                        break;
+                    case YamlObjectKind.Map:
+                        WriteMap((YamlMap)obj);
+                        break;
+                    case YamlObjectKind.Sequence:
+                        WriteSequence((YamlSequence)obj);
+                        break;
+                    default:
+                        throw new InvalidOperationException();
+                }
+            }
+        }
+
+        void WriteScalar(YamlScalar obj)
+        {
+            if (TryInlineScalar(obj, _maximumWidth - _indentColumn, out var inlined))
+            {
+                WriteInline(inlined);
+            }
+            else
+            {
+                Write(obj.ToString());
+            }
+        }
+
+        void WriteMap(YamlMap obj)
+        {
+            if (TryInlineMap(obj, _maximumWidth - _indentColumn, out var inlined))
+            {
+                WriteInline(inlined);
+            }
+            else
+            {
+                var maxKeyWidth = obj.Select(item => item.key.Length).Max();
+                var oldInlineColumn = _inlineColumn;
+                _inlineColumn = _indentColumn + maxKeyWidth + 2;
+
+                foreach (var (key, value) in obj)
+                {
+                    WriteLine();
+                    Write($"{key}:");
+                    _indentColumn += _indentSize;
+                    WriteObject(value);
+                    _indentColumn -= _indentSize;
+                }
+
+                _inlineColumn = oldInlineColumn;
+            }
+        }
+
+        void WriteSequence(YamlSequence obj)
+        {
+            if (TryInlineSequence(obj, _maximumWidth - _indentColumn, out var inlined))
+            {
+                WriteInline(inlined);
+            }
+            else
+            {
+                var oldInlineColumn = _inlineColumn;
+                _inlineColumn = _indentColumn + _indentSize;
+                foreach (var item in obj)
+                {
+                    WriteLine();
+                    Write("- ");
+                    _indentColumn += _indentSize;
+                    _inlineColumn = _indentColumn;
+                    WriteObject(item);
+                    _indentColumn -= _indentSize;
+                }
+
+                _inlineColumn = oldInlineColumn;
+            }
+        }
+
+        bool TryInlineObject(YamlObject obj, int maximumWidth, out string result)
+        {
+            if (maximumWidth < 1)
+            {
+                result = null;
+                return false;
+            }
+            else if (obj == null)
+            {
+                result = "~";
+                return true;
+            }
+            else
+            {
+                switch (obj.Kind)
+                {
+                    case YamlObjectKind.Scalar:
+                        return TryInlineScalar((YamlScalar)obj, maximumWidth, out result);
+                    case YamlObjectKind.Map:
+                        return TryInlineMap((YamlMap)obj, maximumWidth, out result);
+                    case YamlObjectKind.Sequence:
+                        return TryInlineSequence((YamlSequence)obj, maximumWidth, out result);
+                    default:
+                        throw new InvalidOperationException();
+                }
+            }
+        }
+
+        bool TryInlineScalar(YamlScalar obj, int maximumWidth, out string result)
+        {
+            result = obj.ToString();
+            if (result.Length > maximumWidth)
+            {
+                result = null;
+            }
+
+            return result != null;
+        }
+
+        bool TryInlineMap(YamlMap obj, int maximumWidth, out string result)
+        {
+            result = null;
+            var sb = new StringBuilder();
+            sb.Append("{ ");
+            var firstSeen = false;
+            foreach (var (key, value) in obj)
+            {
+                if (firstSeen)
+                {
+                    sb.Append(", ");
+                }
+
+                firstSeen = true;
+
+                sb.Append(key);
+                sb.Append(": ");
+                if (TryInlineObject(value, maximumWidth - sb.Length, out var valueInlined))
+                {
+                    sb.Append(valueInlined);
+                }
+                else
+                {
+                    result = null;
+                    return false;
+                }
+            }
+
+            sb.Append(firstSeen ? " }" : "}");
+            if (sb.Length <= maximumWidth)
+            {
+                result = sb.ToString();
+            }
+
+            return result != null;
+        }
+
+        bool TryInlineSequence(YamlSequence obj, int maximumWidth, out string result)
+        {
+            result = null;
+            var sb = new StringBuilder();
+            sb.Append("[ ");
+            var firstSeen = false;
+            foreach (var value in obj)
+            {
+                if (firstSeen)
+                {
+                    sb.Append(", ");
+                }
+
+                firstSeen = true;
+
+                if (TryInlineObject(value, maximumWidth - sb.Length, out var valueInlined))
+                {
+                    sb.Append(valueInlined);
+                }
+                else
+                {
+                    result = null;
+                    return false;
+                }
+            }
+
+            sb.Append(firstSeen ? " ]" : "]");
+            if (sb.Length <= maximumWidth)
+            {
+                result = sb.ToString();
+            }
+
+            return result != null;
+        }
+    }
+}


### PR DESCRIPTION
The YAML is easier to read than XML. The YAML output exists to help debug issues with Lottie files. It's much easier to read the YAML than the raw JSON. Note that the dump is not complete - some properties may not show up. It's at least as good as the XAML however so checking it in, and we can add more properties as needed.