### PR TITLE
Adding LottieGenCorpus for generating output for testing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -228,3 +228,6 @@ msbuild.binlog
 
 # Lottie project internal development directories
 /internal/
+
+# Output from running LottieGen over a corpus for testing
+LottieGenOutput-*/

--- a/source/WinCompData/Serialization/CompositionObjectXmlSerializer.cs
+++ b/source/WinCompData/Serialization/CompositionObjectXmlSerializer.cs
@@ -212,7 +212,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Tools
                     yield return item;
                 }
 
-                yield return FromCompositionPath(obj.Path);
+                if (obj.Path != null)
+                {
+                    yield return FromCompositionPath(obj.Path);
+                }
             }
         }
 

--- a/tests/CompareDirectories.cmd
+++ b/tests/CompareDirectories.cmd
@@ -1,0 +1,4 @@
+@pushd %~dp0
+@PowerShell.exe -file "%~dpn0.ps1" %*
+@popd
+@PAUSE

--- a/tests/CompareDirectories.ps1
+++ b/tests/CompareDirectories.ps1
@@ -1,0 +1,102 @@
+<#
+.SYNOPSIS
+Compares the contents of 2 directory trees.
+
+.DESCRIPTION
+Recursively compares all of the files and directories at 2 given paths
+and reports on any differences. This is useful for determining whether
+the output of a test run has regressed from a baseline.
+
+.PARAMETER Directory1
+Path to the first directory.
+
+.PARAMETER Directory2
+Path to the second directory.
+
+.EXAMPLE
+CompareDirectories Baseline TestOutput
+#>
+
+[CmdletBinding()]
+Param(
+    [parameter(Mandatory=$true)]
+    [ValidateScript({test-path $_ -PathType Container})]
+    $Directory1,
+    [parameter(Mandatory=$true)]
+    [ValidateScript({test-path $_ -PathType Container})]
+    $Directory2
+)
+
+$dir1Color = 'Green'
+$dir2Color = 'Magenta'
+
+write-host -NoNewLine 'Comparing '
+write-host -NoNewLine -ForegroundColor $dir1Color $Directory1
+write-host -NoNewLine ' with '
+write-host -ForegroundColor $dir2Color $Directory2
+
+function IndexDirectoryTree
+{
+    Param([IO.DirectoryInfo]$dir)
+
+    $directoryPrefixLength = $dir.FullName.Length + 1
+
+    $result = @{}
+    foreach($item in Get-ChildItem -r $dir)
+    {
+        $relativePath = $item.FullName.Substring($directoryPrefixLength)
+        $hash = Get-FileHash $item.FullName
+        if ($hash)
+        {
+            $result.Add($relativePath, $hash.Hash)
+        }
+    }
+
+    $result
+}
+
+$dir1Contents = IndexDirectoryTree $Directory1
+$dir2Contents = IndexDirectoryTree $Directory2
+
+if ($dir1Contents.Count -ne $dir2Contents.Count)
+{
+    $hasErrors = $true
+    write-host -ForegroundColor Red "Directories have different numbers of items ($($dir1Contents.Count) vs $($dir2Contents.Count))"
+}
+
+
+foreach($item in $dir1Contents.GetEnumerator() | sort-object 'Key')
+{
+    $key = $item.Key
+
+    if (!$dir2Contents.ContainsKey($key))
+    {
+        write-host -ForegroundColor $dir1Color "Only in `$Directory1: $key"
+        $hasErrors = $true
+    }
+    elseif ($item.Value -ne $dir2Contents[$key])
+    {
+        write-host -ForegroundColor DarkYellow "Different: $key"    
+        $hasErrors = $true
+    }
+}
+
+foreach($item in $dir2Contents.GetEnumerator() | sort-object 'Key')
+{
+    $key = $item.Key
+
+    if (!$dir2Contents.ContainsKey($key))
+    {
+        write-host -ForegroundColor $dir2Color "Only in `$Directory2: $key"
+        $hasErrors = $true
+    }
+}
+
+if ($hasErrors)
+{
+    write-host -ForegroundColor Red 'Directories are not equal'
+}
+else 
+{
+    write-host 'Directories are equal'
+}

--- a/tests/LottieGenCorpus.cmd
+++ b/tests/LottieGenCorpus.cmd
@@ -1,0 +1,4 @@
+@pushd %~dp0
+@PowerShell.exe -file "%~dpn0.ps1" %*
+@popd
+@PAUSE

--- a/tests/LottieGenCorpus.ps1
+++ b/tests/LottieGenCorpus.ps1
@@ -81,7 +81,7 @@ $errorLog = "$outputPath\Errors_and_Warnings.log"
 $lottieGenExitCode = 99
 $lottieGenTime = Measure-Command {
     &dotnet $lottieGenDll -i "$CorpusDirectory\**json" -o $outputPath -l cs -l cppcx -l lottiexml -l wincompxml -l dgml -l stats |
-        select-string '( warning )|( error )' | Sort-Object > $errorLog
+        select-string '\:( warning )|( error ) L' | Sort-Object > $errorLog
     $lottieGenExitCode = $LASTEXITCODE
 }
 

--- a/tests/LottieGenCorpus.ps1
+++ b/tests/LottieGenCorpus.ps1
@@ -1,0 +1,115 @@
+<#
+.SYNOPSIS
+Runs LottieGen over a corpus of Lottie files.
+
+.DESCRIPTION
+Runs the most recently built LottieGen tool over a corpus of Lottie
+files, saving the result in a directory named according to the version
+of LottieGen. The generated files can be used for comparing with a
+baseline.
+
+.PARAMETER CorpusDirectory
+Path to a directory under which the Lottie files are stored.
+
+.EXAMPLE
+LottieGenCorpus D:\Lottie\Corpus\TestInputs
+#>
+
+[CmdletBinding()]
+Param(
+    [parameter(Mandatory=$true)]
+    [string]
+    [ValidateScript({test-path $_ -PathType Container})]
+    $CorpusDirectory
+)
+
+# Find the most recently built LottieGen.dll.
+$lottieGenDll = 
+    Get-ChildItem LottieGen.dll -r -path "$PSScriptRoot\..\LottieGen\bin\" | 
+    Sort-Object -Property 'CreationTime' -Desc | 
+    Select-Object -first 1 |
+    ForEach-Object 'FullName'
+
+
+if (!$lottieGenDll)
+{
+    throw 'Could not find LottieGen.dll'
+}
+
+Write-Host -ForegroundColor Blue -NoNewline 'Using LottieGen binary: '
+Write-Host -ForegroundColor Green $lottieGenDll
+
+# Run LottieGen once to get its version number
+$lottieGenVersion =
+    &dotnet $lottieGenDll -help | 
+        select-string '^Lottie for Windows Code Generator version ' | 
+        ForEach-Object {$_  -replace '^Lottie for Windows Code Generator version (\d+\.\d+\.\d+\S*).*$','$1' }
+
+# Create a directory to output.
+$outputPath = join-path $PSScriptRoot "LottieGenOutput-$lottieGenVersion"
+
+if (Test-Path $outputPath)
+{
+    Write-Host -ForegroundColor Red -NoNewline 'Output directory exists. Delete '
+    Write-Host -ForegroundColor Yellow -NoNewline $outputPath
+    Write-Host -ForegroundColor Red -NoNewline ' ? [y/N] '
+    $userResponse = Read-Host
+    if ($userResponse -match '^\s*y(es|\s*)$')
+    {
+        Write-Host -ForegroundColor Yellow "Deleting $outputPath"
+        remove-item -path $outputPath -Recurse
+    }
+
+    if (Test-Path $outputPath)
+    {
+        throw "Output path already exists: $outputPath"
+    }
+}
+
+New-Item $outputPath -ItemType Directory >$null
+
+Write-Host -ForegroundColor Blue -NoNewline 'Output will be written to: '
+Write-Host -ForegroundColor Green $outputPath
+
+# Run LottieGen over everything in the corpus.
+Write-Host -ForegroundColor Blue -NoNewline 'Executing: '
+Write-Host -ForegroundColor Green "dotnet $lottieGenDll -i $CorpusDirectory\**json -o $outputPath -l cs -l cppcx -l lottiexml -l wincompxml -l dgml -l stats"
+Write-Host -ForegroundColor Blue '...'
+
+$errorLog = "$outputPath\Errors_and_Warnings.log"
+
+$lottieGenExitCode = 99
+$lottieGenTime = Measure-Command {
+    &dotnet $lottieGenDll -i "$CorpusDirectory\**json" -o $outputPath -l cs -l cppcx -l lottiexml -l wincompxml -l dgml -l stats |
+        select-string '( warning )|( error )' | Sort-Object > $errorLog
+    $lottieGenExitCode = $LASTEXITCODE
+}
+
+$minutes = [Math]::Floor($lottieGenTime.TotalMinutes)
+$seconds = $lottieGenTime.TotalSeconds - ($minutes * 60)
+$executionTime = "$seconds seconds"
+
+if ($minutes -gt 0)
+{
+    if ($minutes -eq 1)
+    {
+        $executionTime = "1 minute $executionTime"
+    }
+    else 
+    {
+        $executionTime = "$minutes minutes $executionTime"
+    }
+}
+
+write-host "Execution time: $executionTime"
+write-host 'Errors and warnings written to:'
+write-host $errorLog
+
+if ($lottieGenExitCode -ne 0)
+{
+    write-host -ForegroundColor Red "Execution failed error code: $lottieGenExitCode"
+}
+else 
+{
+    write-host 'Execution succeeded'
+}


### PR DESCRIPTION
LottieGenCorpus will create a directory with the output from running LottieGen over a corpus of Lottie files. The output can then be compared with a baseline run to detect regressions.

Add scripts to allow comparing the outputs of different versions of LottieGen