### PR TITLE
Add support for D2D geometry groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -231,3 +231,6 @@ msbuild.binlog
 
 # Output from running LottieGen over a corpus for testing
 LottieGenOutput-*/
+
+# Visual Studio debugging configuration file.
+launchSettings.json

--- a/LottieGen/LottieGen.csproj
+++ b/LottieGen/LottieGen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>LottieGen</ToolCommandName>
     

--- a/LottieGen/Properties/launchSettings.json
+++ b/LottieGen/Properties/launchSettings.json
@@ -1,8 +1,0 @@
-{
-  "profiles": {
-    "LottieGen": {
-      "commandName": "Project",
-      "commandLineArgs": "-i d:\\test\\icon_Animation_03_SnapAssist.json -l cs"
-    }
-  }
-}

--- a/LottieGen/Properties/launchSettings.json
+++ b/LottieGen/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "LottieGen": {
+      "commandName": "Project",
+      "commandLineArgs": "-i d:\\test\\icon_Animation_03_SnapAssist.json -l cs"
+    }
+  }
+}

--- a/source/Lottie/Instantiator.cs
+++ b/source/Lottie/Instantiator.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Numerics;
 using Microsoft.Graphics.Canvas.Geometry;
 using Wc = Windows.UI.Composition;
@@ -992,6 +993,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
                         ellipse.Y,
                         ellipse.RadiusX,
                         ellipse.RadiusY);
+                case Wd.Mgcg.CanvasGeometry.GeometryType.Group:
+                    var group = (Wd.Mgcg.CanvasGeometry.Group)canvasGeometry;
+                    return CanvasGeometry.CreateGroup(
+                        null,
+                        group.Geometries.Select(g => GetCanvasGeometry(g)).ToArray(),
+                        FilledRegionDetermination(group.FilledRegionDetermination));
                 case Wd.Mgcg.CanvasGeometry.GeometryType.Path:
                     using (var builder = new CanvasPathBuilder(null))
                     {

--- a/source/LottieToWinComp/CanvasGeometryCombiner.cs
+++ b/source/LottieToWinComp/CanvasGeometryCombiner.cs
@@ -109,6 +109,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                         ellipse.Y,
                         ellipse.RadiusX,
                         ellipse.RadiusY);
+                case Wcd.Mgcg.CanvasGeometry.GeometryType.Group:
+                    var group = (Wcd.Mgcg.CanvasGeometry.Group)geometry;
+                    var geometries = group.Geometries.Select(g => ToWin2dCanvasGeometry(g)).ToArray();
+                    return Win2D.CanvasGeometry.CreateGroup(
+                        null,
+                        geometries,
+                        group.FilledRegionDetermination);
                 case Wcd.Mgcg.CanvasGeometry.GeometryType.Path:
                     using (var builder = new Win2D.CanvasPathBuilder(null))
                     {

--- a/source/WinCompData/CodeGen/CSharpInstantiatorGenerator.cs
+++ b/source/WinCompData/CodeGen/CSharpInstantiatorGenerator.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Linq;
 using System.Numerics;
 using Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Mgcg;
 using Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Wui;
@@ -153,6 +154,17 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.CodeGen
             builder.Indent();
             builder.WriteLine($"null,");
             builder.WriteLine($"{Float(obj.X)}, {Float(obj.Y)}, {Float(obj.RadiusX)}, {Float(obj.RadiusY)});");
+            builder.UnIndent();
+        }
+
+        /// <inheritdoc/>
+        protected override void WriteCanvasGeometryGroupFactory(CodeBuilder builder, CanvasGeometry.Group obj, string typeName, string fieldName)
+        {
+            builder.WriteLine($"var result = {FieldAssignment(fieldName)}CanvasGeometry.CreateGroup(");
+            builder.Indent();
+            builder.WriteLine($"null,");
+            builder.WriteLine($"new CanvasGeometry[]{{{string.Join(",", obj.Geometries.Select(g => CallFactoryFor(g)) ) }}},");
+            builder.WriteLine($"{_stringifier.FilledRegionDetermination(obj.FilledRegionDetermination)});");
             builder.UnIndent();
         }
 

--- a/source/WinCompData/CodeGen/CxInstantiatorGenerator.cs
+++ b/source/WinCompData/CodeGen/CxInstantiatorGenerator.cs
@@ -271,6 +271,30 @@ public:
         }
 
         /// <inheritdoc/>
+        protected override void WriteCanvasGeometryGroupFactory(CodeBuilder builder, CanvasGeometry.Group obj, string typeName, string fieldName)
+        {
+            builder.WriteLine($"auto geometries = ComPtr<ID2D1Geometry>[{obj.Geometries.Length}];");
+            builder.OpenScope();
+            for (var i = 0; i < obj.Geometries.Length; i++)
+            {
+                var geometry = obj.Geometries[i];
+                builder.WriteLine($"{CallFactoryFor(geometry)}->GetGeometry(&geometries[{i}]);");
+            }
+
+            builder.CloseScope();
+            builder.WriteLine($"{typeName} result;");
+            builder.WriteLine("ComPtr<ID2D1GeometryGroup> group;");
+            builder.WriteLine("FFHR(_d2dFactory->CreateGeometryGroup(");
+            builder.Indent();
+            builder.WriteLine($"{FilledRegionDetermination(obj.FilledRegionDetermination)},");
+            builder.WriteLine("&geometries,");
+            builder.WriteLine($"{obj.Geometries.Length},");
+            builder.WriteLine("&group));");
+            builder.UnIndent();
+            builder.WriteLine($"result = {FieldAssignment(fieldName)}new GeoSource(group.Get());");
+        }
+
+        /// <inheritdoc/>
         protected override void WriteCanvasGeometryPathFactory(CodeBuilder builder, CanvasGeometry.Path obj, string typeName, string fieldName)
         {
             builder.WriteLine($"{typeName} result;");

--- a/source/WinCompData/CodeGen/InstantiatorGeneratorBase.cs
+++ b/source/WinCompData/CodeGen/InstantiatorGeneratorBase.cs
@@ -225,6 +225,19 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.CodeGen
             string fieldName);
 
         /// <summary>
+        /// Writes CanvasGeometery.Ellipse factory code.
+        /// </summary>
+        /// <param name="builder">A <see cref="CodeBuilder"/> used to create the code.</param>
+        /// <param name="obj">Describes the object that should be instantiated by the factory code.</param>
+        /// <param name="typeName">The type of the result.</param>
+        /// <param name="fieldName">If not null, the name of the field in which the result is stored.</param>
+        protected abstract void WriteCanvasGeometryGroupFactory(
+            CodeBuilder builder,
+            CanvasGeometry.Group obj,
+            string typeName,
+            string fieldName);
+
+        /// <summary>
         /// Writes CanvasGeometery.Path factory code.
         /// </summary>
         /// <param name="builder">A <see cref="CodeBuilder"/> used to create the code.</param>
@@ -528,22 +541,28 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.CodeGen
         bool GenerateCanvasGeometryFactory(CodeBuilder builder, CanvasGeometry obj, ObjectData node)
         {
             WriteObjectFactoryStart(builder, node);
+            var typeName = _stringifier.ReferenceTypeName(node.TypeName);
+            var fieldName = node.FieldName;
+
             switch (obj.Type)
             {
                 case CanvasGeometry.GeometryType.Combination:
-                    WriteCanvasGeometryCombinationFactory(builder, (CanvasGeometry.Combination)obj, _stringifier.ReferenceTypeName(node.TypeName), node.FieldName);
+                    WriteCanvasGeometryCombinationFactory(builder, (CanvasGeometry.Combination)obj, typeName, fieldName);
                     break;
                 case CanvasGeometry.GeometryType.Ellipse:
-                    WriteCanvasGeometryEllipseFactory(builder, (CanvasGeometry.Ellipse)obj, _stringifier.ReferenceTypeName(node.TypeName), node.FieldName);
+                    WriteCanvasGeometryEllipseFactory(builder, (CanvasGeometry.Ellipse)obj, typeName, fieldName);
+                    break;
+                case CanvasGeometry.GeometryType.Group:
+                    WriteCanvasGeometryGroupFactory(builder, (CanvasGeometry.Group)obj, typeName, fieldName);
                     break;
                 case CanvasGeometry.GeometryType.Path:
-                    WriteCanvasGeometryPathFactory(builder, (CanvasGeometry.Path)obj, _stringifier.ReferenceTypeName(node.TypeName), node.FieldName);
+                    WriteCanvasGeometryPathFactory(builder, (CanvasGeometry.Path)obj, typeName, fieldName);
                     break;
                 case CanvasGeometry.GeometryType.RoundedRectangle:
-                    WriteCanvasGeometryRoundedRectangleFactory(builder, (CanvasGeometry.RoundedRectangle)obj, _stringifier.ReferenceTypeName(node.TypeName), node.FieldName);
+                    WriteCanvasGeometryRoundedRectangleFactory(builder, (CanvasGeometry.RoundedRectangle)obj, typeName, fieldName);
                     break;
                 case CanvasGeometry.GeometryType.TransformedGeometry:
-                    WriteCanvasGeometryTransformedGeometryFactory(builder, (CanvasGeometry.TransformedGeometry)obj, _stringifier.ReferenceTypeName(node.TypeName), node.FieldName);
+                    WriteCanvasGeometryTransformedGeometryFactory(builder, (CanvasGeometry.TransformedGeometry)obj, typeName, fieldName);
                     break;
                 default:
                     throw new InvalidOperationException();

--- a/source/WinCompData/CodeGen/Optimizer.cs
+++ b/source/WinCompData/CodeGen/Optimizer.cs
@@ -1032,10 +1032,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.CodeGen
                 case CanvasGeometry.GeometryType.Combination:
                     {
                         var combination = (CanvasGeometry.Combination)canvasGeometry;
-                        result = CacheCanvasGeometry((CanvasGeometry)obj, GetCanvasGeometry(combination.A).CombineWith(
+                        result = GetCanvasGeometry(combination.A).CombineWith(
                             GetCanvasGeometry(combination.B),
                             combination.Matrix,
-                            combination.CombineMode));
+                            combination.CombineMode);
                         break;
                     }
 
@@ -1048,6 +1048,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.CodeGen
                         ellipse.RadiusX,
                         ellipse.RadiusY);
                     break;
+
+                case CanvasGeometry.GeometryType.Group:
+                    var group = (CanvasGeometry.Group)canvasGeometry;
+                    var geometries = group.Geometries.Select(g => GetCanvasGeometry(g)).ToArray();
+                    result = CanvasGeometry.CreateGroup(null, geometries, group.FilledRegionDetermination);
+                    break;
+
                 case CanvasGeometry.GeometryType.Path:
                     using (var builder = new CanvasPathBuilder(null))
                     {
@@ -1080,7 +1087,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.CodeGen
                             }
                         }
 
-                        result = CacheCanvasGeometry((CanvasGeometry)obj, CanvasGeometry.CreatePath(builder));
+                        result = CanvasGeometry.CreatePath(builder);
                     }
 
                     break;
@@ -1104,6 +1111,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.CodeGen
             }
 
             InitializeIDescribable(canvasGeometry, result);
+            CacheCanvasGeometry(canvasGeometry, result);
+
             return result;
         }
 

--- a/source/WinCompData/Mgc/CanvasDevice.cs
+++ b/source/WinCompData/Mgc/CanvasDevice.cs
@@ -9,5 +9,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Mgc
 #endif
     sealed class CanvasDevice
     {
+        // The CanvasDevice type only exists to match the signature
+        // for CanvasGeometry. It is never instantiated.
+        CanvasDevice()
+        {
+        }
     }
 }

--- a/source/WinCompData/Tools/ObjectGraph.cs
+++ b/source/WinCompData/Tools/ObjectGraph.cs
@@ -249,6 +249,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Tools
                     return VisitCombination((CanvasGeometry.Combination)obj, node);
                 case CanvasGeometry.GeometryType.Ellipse:
                     return VisitEllipse((CanvasGeometry.Ellipse)obj, node);
+                case CanvasGeometry.GeometryType.Group:
+                    return VisitGroup((CanvasGeometry.Group)obj, node);
                 case CanvasGeometry.GeometryType.Path:
                     return VisitPath((CanvasGeometry.Path)obj, node);
                 case CanvasGeometry.GeometryType.RoundedRectangle:
@@ -280,6 +282,16 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Tools
 
         bool VisitEllipse(CanvasGeometry.Ellipse obj, T node)
         {
+            return VisitCanvasGeometry(obj, node);
+        }
+
+        bool VisitGroup(CanvasGeometry.Group obj, T node)
+        {
+            foreach (var geometry in obj.Geometries)
+            {
+                Reference(node, geometry);
+            }
+
             return VisitCanvasGeometry(obj, node);
         }
 


### PR DESCRIPTION
Enables D2D geometry groups to be expressed, but doesn't use them in the translator yet.
Even though nothing is using the geometry groups yet, this does change the output a little as a result of making CanvasGeometry equatable and thus enabling the optimizer to share some geometries that previously were not considered shareable.