### PR TITLE
Handle some cases of shape groups that contain multiple paths.

### DIFF
--- a/LottieGen/LottieFileProcessor.cs
+++ b/LottieGen/LottieFileProcessor.cs
@@ -2,17 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
 using Microsoft.Toolkit.Uwp.UI.Lottie.LottieData;
 using Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization;
 using Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp;
 using Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData;
 using Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.CodeGen;
 using Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Tools;
-using System;
-using System.IO;
-using System.Linq;
-using System.Security.Cryptography;
-using System.Text;
 
 /// <summary>
 /// Processes a single Lottie file to produce various generated outputs.
@@ -51,10 +51,18 @@ sealed class LottieFileProcessor
 
     internal static bool ProcessFile(CommandLineOptions options, Reporter reporter, string file, string outputFolder)
     {
-        return new LottieFileProcessor(options, reporter, file, outputFolder).Run();
+        try
+        {
+            return new LottieFileProcessor(options, reporter, file, outputFolder).Run();
+        }
+        catch
+        {
+            reporter.ErrorStream.WriteLine($"Unhandled exception processing: {file}");
+            throw;
+        }
     }
 
-    internal bool Run()
+    bool Run()
     {
         // Make sure we can write to the output directory.
         if (!TryEnsureDirectoryExists(_outputFolder))

--- a/LottieGen/Program.cs
+++ b/LottieGen/Program.cs
@@ -2,12 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Toolkit.Uwp.UI.Lottie.LottieData;
 using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using Microsoft.Toolkit.Uwp.UI.Lottie.LottieData;
 
 sealed class Program
 {

--- a/dlls/LottieToWinComp/LottieToWinComp.dll.csproj
+++ b/dlls/LottieToWinComp/LottieToWinComp.dll.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <LangVersion>latest</LangVersion>
     <DefineConstants>PUBLIC_LottieToWinComp</DefineConstants>

--- a/source/WinCompData/CodeGen/CSharpInstantiatorGenerator.cs
+++ b/source/WinCompData/CodeGen/CSharpInstantiatorGenerator.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.CodeGen
             builder.WriteLine($"var result = {FieldAssignment(fieldName)}CanvasGeometry.CreateGroup(");
             builder.Indent();
             builder.WriteLine($"null,");
-            builder.WriteLine($"new CanvasGeometry[]{{{string.Join(",", obj.Geometries.Select(g => CallFactoryFor(g)) ) }}},");
+            builder.WriteLine($"new CanvasGeometry[] {{ {string.Join(",", obj.Geometries.Select(g => CallFactoryFor(g)) ) } }},");
             builder.WriteLine($"{_stringifier.FilledRegionDetermination(obj.FilledRegionDetermination)});");
             builder.UnIndent();
         }

--- a/source/WinCompData/CodeGen/CSharpInstantiatorGenerator.cs
+++ b/source/WinCompData/CodeGen/CSharpInstantiatorGenerator.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.CodeGen
             builder.WriteLine($"var result = {FieldAssignment(fieldName)}CanvasGeometry.CreateGroup(");
             builder.Indent();
             builder.WriteLine($"null,");
-            builder.WriteLine($"new CanvasGeometry[] {{ {string.Join(",", obj.Geometries.Select(g => CallFactoryFor(g)) ) } }},");
+            builder.WriteLine($"new CanvasGeometry[] {{ {string.Join(", ", obj.Geometries.Select(g => CallFactoryFor(g)) ) } }},");
             builder.WriteLine($"{_stringifier.FilledRegionDetermination(obj.FilledRegionDetermination)});");
             builder.UnIndent();
         }

--- a/source/WinCompData/CodeGen/InstantiatorGeneratorBase.cs
+++ b/source/WinCompData/CodeGen/InstantiatorGeneratorBase.cs
@@ -105,16 +105,16 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.CodeGen
                     // Node is referenced more than once, so it requires storage.
                     node.RequiresStorage = true;
                 }
-                else
-                {
-                    // Node is only referenced once.
+            }
 
-                    // Force inlining on CompositionPath nodes that are only referenced once, because they are always very simple.
-                    if (node.Type == Graph.NodeType.CompositionPath)
-                    {
-                        var pathSourceFactoryCall = CallFactoryFromFor(node, ((CompositionPath)node.Object).Source);
-                        node.ForceInline($"{New} CompositionPath({_stringifier.FactoryCall(pathSourceFactoryCall)})");
-                    }
+            // Force inlining on CompositionPath nodes that are only referenced once, because they are always very simple.
+            foreach (var node in _nodes)
+            {
+                if (node.Type == Graph.NodeType.CompositionPath && FilteredInRefs(node).Count() == 1)
+                {
+                    node.RequiresStorage = false;
+                    var pathSourceFactoryCall = CallFactoryFromFor(node, ((CompositionPath)node.Object).Source);
+                    node.ForceInline($"{New} CompositionPath({_stringifier.FactoryCall(pathSourceFactoryCall)})");
                 }
             }
 

--- a/tests/CompareDirectories.ps1
+++ b/tests/CompareDirectories.ps1
@@ -47,18 +47,20 @@ function IndexDirectoryTree
     $itemCount = 0
     foreach($item in $children)
     {
-        if ($itemCount++ % 2000)
-        {
-            $percentComplete = 100 * $itemCount / $children.Count
-            Write-Progress -Activity "Examining files in $dir" -PercentComplete $percentComplete -Status "$itemCount / $($children.Count)"
-        }
-
         $relativePath = $item.FullName.Substring($directoryPrefixLength)
         $hash = Get-FileHash $item.FullName
         if ($hash)
         {
             $result.Add($relativePath, $hash.Hash)
         }
+
+        if ($itemCount % 100 -eq 0)
+        {
+            $percentComplete = 100 * $itemCount / $children.Count
+            Write-Progress -Activity "Examining files in $dir" -PercentComplete $percentComplete -Status "$itemCount / $($children.Count)"
+        }
+
+        $itemCount++
     }
 
     Write-Progress -Activity "Examining files in $dir" -Completed


### PR DESCRIPTION
Use of Win2D geometry groups to group paths that are part of the same shape group. Previously we just drew the paths on top of each other, but that's not correct when the paths overlap. The typical case is concentric shapes where the space between them is used like a stroke.

There are many potential cases that we don't yet handle with this change, e.g. we don't handle animation of the shapes, or other shapes, but the concentric non-animated shapes as a stroke is common enough to be worth doing alone.