### PR TITLE
Detect and report cases where we can't combine shapes correctly.

### DIFF
--- a/source/LottieToWinComp/TranslationIssues.cs
+++ b/source/LottieToWinComp/TranslationIssues.cs
@@ -151,6 +151,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             Report("LT0026", "Mask with multiple shapes");
         }
 
+        internal void CombiningMultipleShapes()
+        {
+            Report("LT0027", "CombiningMultipleShapes");
+        }
+
         void Report(string code, string description)
         {
             _issues.Add((code, description));


### PR DESCRIPTION
If there are multiple shapes in a group or layer, in many cases we may not be combining them correctly. Report the cases we know that we have trouble with.

Also removed some allocations that can now be avoided due to our use of Span in the Repeater code.