### PR TITLE
Rename the Lottie Shape class to Path.

### DIFF
--- a/LottieGen/LottieFileProcessor.cs
+++ b/LottieGen/LottieFileProcessor.cs
@@ -45,7 +45,7 @@ sealed class LottieFileProcessor
         // Get an appropriate name for a generated class.
         _className =
             InstantiatorGeneratorBase.TrySynthesizeClassName(_options.ClassName) ??
-            InstantiatorGeneratorBase.TrySynthesizeClassName(Path.GetFileNameWithoutExtension(_file)) ??
+            InstantiatorGeneratorBase.TrySynthesizeClassName(System.IO.Path.GetFileNameWithoutExtension(_file)) ??
             InstantiatorGeneratorBase.TrySynthesizeClassName("Lottie");  // If all else fails, just call it Lottie.
     }
 
@@ -134,7 +134,7 @@ sealed class LottieFileProcessor
 
     bool TryGenerateCode()
     {
-        var outputFileBase = Path.Combine(_outputFolder, Path.GetFileNameWithoutExtension(_file));
+        var outputFileBase = System.IO.Path.Combine(_outputFolder, System.IO.Path.GetFileNameWithoutExtension(_file));
 
         var codeGenSucceeded = true;
         foreach (var lang in _options.Languages)
@@ -215,7 +215,7 @@ sealed class LottieFileProcessor
             "ExpressionAnimationCount,PropertySetPropertyCount,SpriteShapeCount");
         sb.Append($"\"{key}\"");
         AppendColumnValue(_file);
-        AppendColumnValue(Path.GetFileName(_file));
+        AppendColumnValue(System.IO.Path.GetFileName(_file));
         AppendColumnValue(_lottieStats.Version);
         AppendColumnValue(_lottieStats.Duration.TotalSeconds);
         AppendColumnValue(issues.Count());
@@ -377,7 +377,7 @@ sealed class LottieFileProcessor
                 (float)_lottieComposition.Width,
                 (float)_lottieComposition.Height,
                 _lottieComposition.Duration,
-                Path.GetFileName(outputHeaderFilePath),
+                System.IO.Path.GetFileName(outputHeaderFilePath),
                 out var cppText,
                 out var hText,
                 _options.DisableCodeGenOptimizer);

--- a/LottieGen/Program.cs
+++ b/LottieGen/Program.cs
@@ -120,9 +120,9 @@ sealed class Program
             }
         }
 #else
-        Parallel.ForEach(matchingInputFiles, (inputFile) =>
+        Parallel.ForEach(matchingInputFiles, ((string path, string relativePath) inputFile) =>
         {
-            if (!LottieFileProcessor.ProcessFile(_options, _reporter, inputFile.path, Path.Combine(outputFolder, inputFile.relativePath)))
+            if (!LottieFileProcessor.ProcessFile(_options, _reporter, inputFile.path, System.IO.Path.Combine(outputFolder, inputFile.relativePath)))
             {
                 succeeded = false;
             }
@@ -133,7 +133,7 @@ sealed class Program
 
     static string MakeAbsolutePath(string path)
     {
-        return Path.IsPathRooted(path) ? path : Path.Combine(Directory.GetCurrentDirectory(), path);
+        return System.IO.Path.IsPathRooted(path) ? path : System.IO.Path.Combine(Directory.GetCurrentDirectory(), path);
     }
 
     static void ShowHelp(TextWriter writer)
@@ -191,5 +191,5 @@ EXAMPLES:
        Generate Grotz.cs in the C:\temp directory from the Lottie file Bar.json:
 
          {0} -i Bar.json -L cs -ClassName Grotz -o C:\temp",
-Path.GetFileNameWithoutExtension(Assembly.GetEntryAssembly().ManifestModule.Name));
+System.IO.Path.GetFileNameWithoutExtension(Assembly.GetEntryAssembly().ManifestModule.Name));
 }

--- a/source/Lottie/LottieVisualDiagnostics.cs
+++ b/source/Lottie/LottieVisualDiagnostics.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
         public string SuggestedFileName =>
             string.IsNullOrWhiteSpace(FileName)
                 ? "MyComposition"
-                : Path.GetFileNameWithoutExtension(FileName);
+                : System.IO.Path.GetFileNameWithoutExtension(FileName);
 
         public string SuggestedClassName
         {

--- a/source/LottieData/LottieData.projitems
+++ b/source/LottieData/LottieData.projitems
@@ -6,15 +6,8 @@
     <SharedGUID>b3db16ee-a821-4474-a188-e64926529bbd</SharedGUID>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)Serialization\LottieCompositionYamlSerializer.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Serialization\YamlMap.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Serialization\YamlObject.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Serialization\YamlObjectKind.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Serialization\YamlScalar.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Serialization\YamlSequence.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Serialization\YamlWriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Animatable.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)ExtensionMethods.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\ExtensionMethods.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\AnimatableVector3.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\AnimatableXYZ.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Asset.cs" />
@@ -49,6 +42,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)\MergePaths.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\NullLayer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Optimization\Optimizer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Path.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Polystar.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\PreCompLayer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\RadialGradientFill.cs" />
@@ -59,7 +53,13 @@
     <Compile Include="$(MSBuildThisFileDirectory)\RoundedCorner.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Sequence.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Serialization\LottieCompositionXmlSerializer.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Shape.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Serialization\LottieCompositionYamlSerializer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Serialization\YamlMap.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Serialization\YamlObject.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Serialization\YamlObjectKind.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Serialization\YamlScalar.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Serialization\YamlSequence.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Serialization\YamlWriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\ShapeContentType.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\ShapeGroup.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\ShapeLayer.cs" />

--- a/source/LottieData/Path.cs
+++ b/source/LottieData/Path.cs
@@ -7,22 +7,22 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 #if PUBLIC_LottieData
     public
 #endif
-    sealed class Shape : ShapeLayerContent
+    sealed class Path : ShapeLayerContent
     {
-        public Shape(
+        public Path(
             string name,
             string matchName,
             bool direction,
-            Animatable<Sequence<BezierSegment>> geometry)
+            Animatable<Sequence<BezierSegment>> geometryData)
             : base(name, matchName)
         {
             Direction = direction;
-            PathData = geometry;
+            Data = geometryData;
         }
 
         public bool Direction { get; }
 
-        public Animatable<Sequence<BezierSegment>> PathData { get; }
+        public Animatable<Sequence<BezierSegment>> Data { get; }
 
         /// <inheritdoc/>
         public override ShapeContentType ContentType => ShapeContentType.Path;

--- a/source/LottieData/Serialization/LottieCompositionXmlSerializer.cs
+++ b/source/LottieData/Serialization/LottieCompositionXmlSerializer.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
                 case LottieObjectType.RoundedCorner:
                     return FromRoundedCorner((RoundedCorner)obj);
                 case LottieObjectType.Shape:
-                    return FromShape((Shape)obj);
+                    return FromShape((Path)obj);
                 case LottieObjectType.ShapeGroup:
                     return FromShapeGroup((ShapeGroup)obj);
                 case LottieObjectType.ShapeLayer:
@@ -336,7 +336,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
                 case ShapeContentType.Transform:
                     return FromTransform((Transform)content);
                 case ShapeContentType.Path:
-                    return FromPath((Shape)content);
+                    return FromPath((Path)content);
                 case ShapeContentType.Ellipse:
                     return FromEllipse((Ellipse)content);
                 case ShapeContentType.Rectangle:
@@ -539,7 +539,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
             return $"{keyFrame.Value}@{keyFrame.Frame}({keyFrame.Easing.Type})";
         }
 
-        XElement FromPath(Shape content)
+        XElement FromPath(Path content)
         {
             return new XElement("Path", GetContents());
             IEnumerable<XObject> GetContents()
@@ -566,9 +566,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
             }
         }
 
-        XElement FromShape(Shape content)
+        XElement FromShape(Path content)
         {
-            return new XElement("Shape", GetContents());
+            return new XElement("Path", GetContents());
             IEnumerable<XObject> GetContents()
             {
                 foreach (var item in GetShapeLayerContentContents(content))

--- a/source/LottieData/Serialization/LottieCompositionYamlSerializer.cs
+++ b/source/LottieData/Serialization/LottieCompositionYamlSerializer.cs
@@ -274,7 +274,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
                 case ShapeContentType.Transform:
                     return FromTransform((Transform)content, superclassContent);
                 case ShapeContentType.Path:
-                    return FromPath((Shape)content, superclassContent);
+                    return FromPath((Path)content, superclassContent);
                 case ShapeContentType.Ellipse:
                     return FromEllipse((Ellipse)content, superclassContent);
                 case ShapeContentType.Rectangle:
@@ -483,7 +483,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
             return result;
         }
 
-        YamlObject FromPath(Shape content, YamlMap superclassContent)
+        YamlObject FromPath(Path content, YamlMap superclassContent)
         {
             var result = superclassContent;
             return result;

--- a/source/LottieReader/Serialization/LottieCompositionReader.cs
+++ b/source/LottieReader/Serialization/LottieCompositionReader.cs
@@ -904,7 +904,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
                 case "rc":
                     return ReadRectangle(obj);
                 case "sh":
-                    return ReadShape(obj);
+                    return ReadPath(obj);
                 case "tm":
                     return ReadTrimPath(obj);
                 case "mm":
@@ -1268,7 +1268,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
             return new Rectangle(name.Name, name.MatchName, direction, position, size, cornerRadius);
         }
 
-        Shape ReadShape(JObject obj)
+        Path ReadPath(JObject obj)
         {
             // Not clear whether we need to read these fields.
             IgnoreFieldThatIsNotYetSupported(obj, "ind");
@@ -1281,7 +1281,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
             var geometry = ReadAnimatableGeometry(obj.GetNamedObject("ks"));
             var direction = ReadBool(obj, "d") == true;
             AssertAllFieldsRead(obj);
-            return new Shape(name.Name, name.MatchName, direction, geometry);
+            return new Path(name.Name, name.MatchName, direction, geometry);
         }
 
         TrimPath ReadTrimPath(JObject obj)


### PR DESCRIPTION
It was called Shape originally because its type code is "sh" and it is contained by a ShapeLayer, but it's not the right name. Path is the right name.