### PR TITLE
Allow color strings to be empty in Lottie json files.

### DIFF
--- a/LottieGen/LottieFileProcessor.cs
+++ b/LottieGen/LottieFileProcessor.cs
@@ -57,7 +57,7 @@ sealed class LottieFileProcessor
         }
         catch
         {
-            reporter.ErrorStream.WriteLine($"Unhandled exception processing: {file}");
+            reporter.WriteError($"Unhandled exception processing: {file}");
             throw;
         }
     }

--- a/source/LottieReader/Serialization/LottieCompositionReader.cs
+++ b/source/LottieReader/Serialization/LottieCompositionReader.cs
@@ -633,6 +633,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
                         var solidWidth = ReadInt(obj, "sw").Value;
                         var solidHeight = ReadInt(obj, "sh").Value;
                         var solidColor = ReadColorFromString(obj.GetNamedString("sc"));
+
                         AssertAllFieldsRead(obj);
                         return new SolidLayer(
                             name,
@@ -856,27 +857,34 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
 
         static Color ReadColorFromString(string hex)
         {
-            var index = 1; // Skip '#'
-
-            // '#AARRGGBB'
-            byte a = 255;
-            if (hex.Length == 9)
+            if (string.IsNullOrWhiteSpace(hex))
             {
-                a = Convert.ToByte(hex.Substring(index, 2), 16);
-                index += 2;
+                return Color.TransparentBlack;
             }
+            else
+            {
+                var index = 1; // Skip '#'
 
-            var r = Convert.ToByte(hex.Substring(index, 2), 16);
-            index += 2;
-            var g = Convert.ToByte(hex.Substring(index, 2), 16);
-            index += 2;
-            var b = Convert.ToByte(hex.Substring(index, 2), 16);
+                // '#AARRGGBB'
+                byte a = 255;
+                if (hex.Length == 9)
+                {
+                    a = Convert.ToByte(hex.Substring(index, 2), 16);
+                    index += 2;
+                }
 
-            return Color.FromArgb(
-                a / 255.0,
-                r / 255.0,
-                g / 255.0,
-                b / 255.0);
+                var r = Convert.ToByte(hex.Substring(index, 2), 16);
+                index += 2;
+                var g = Convert.ToByte(hex.Substring(index, 2), 16);
+                index += 2;
+                var b = Convert.ToByte(hex.Substring(index, 2), 16);
+
+                return Color.FromArgb(
+                    a / 255.0,
+                    r / 255.0,
+                    g / 255.0,
+                    b / 255.0);
+            }
         }
 
         ShapeLayerContent ReadShapeContent(JObject obj)

--- a/tests/LottieGenCorpus.ps1
+++ b/tests/LottieGenCorpus.ps1
@@ -80,8 +80,8 @@ $errorLog = "$outputPath\Errors_and_Warnings.log"
 
 $lottieGenExitCode = 99
 $lottieGenTime = Measure-Command {
-    &dotnet $lottieGenDll -i "$CorpusDirectory\**json" -o $outputPath -l cs -l cppcx -l lottiexml -l wincompxml -l dgml -l stats |
-        select-string '\:( warning )|( error ) L' | Sort-Object > $errorLog
+    &dotnet $lottieGenDll -i "$CorpusDirectory\**json" -o $outputPath -l cs -l cppcx -l lottiexml -l wincompxml -l dgml -l stats 2>&1 |
+        select-string '(\:( warning )|( error ) L)|(Error: )' | Sort-Object > $errorLog
     $lottieGenExitCode = $LASTEXITCODE
 }
 
@@ -107,7 +107,7 @@ write-host $errorLog
 
 if ($lottieGenExitCode -ne 0)
 {
-    write-host -ForegroundColor Red "Execution failed error code: $lottieGenExitCode"
+    write-host -ForegroundColor Red "Execution failed. See $errorLog. Error code: $lottieGenExitCode"
 }
 else 
 {


### PR DESCRIPTION
I came across a Lottie with an empty color string, so rather than failing, treat that as transparent.
Improved the way the LottieGenCorpus discovers errors by making it watch stderr as well as stdout.