### PR TITLE
Update LottieViewer splashscreen

### DIFF
--- a/LottieViewer/App.xaml.cs
+++ b/LottieViewer/App.xaml.cs
@@ -129,11 +129,6 @@ namespace LottieViewer
             // Start playing.
             await player.PlayAsync(fromProgress: 0, toProgress: 0.599, looped: false);
 
-            // Collapse splash screen visibility.
-            splashGrid.Visibility = player.Visibility = Visibility.Collapsed;
-
-            // Restore the original content.
-            splashGrid.Children.Clear();
             Window.Current.Content = originalWindowContent;
         }
 

--- a/LottieViewer/App.xaml.cs
+++ b/LottieViewer/App.xaml.cs
@@ -113,11 +113,12 @@ namespace LottieViewer
             // Insert splashGrid above the current window content.
             var originalWindowContent = Window.Current.Content;
             var splashGrid = new Grid();
+            splashGrid.Background = (SolidColorBrush)Current.Resources["LottieBasicBrush"];
             Window.Current.Content = splashGrid;
 
             var player = new AnimatedVisualPlayer
             {
-                Stretch = Stretch.UniformToFill,
+                Stretch = Stretch.Uniform,
                 AutoPlay = false,
                 Source = new LottieLogo(),
             };
@@ -128,24 +129,12 @@ namespace LottieViewer
             // Start playing.
             await player.PlayAsync(fromProgress: 0, toProgress: 0.599, looped: false);
 
-            // Fade out the splash screen
-            var storyboard = new Storyboard();
-            storyboard.Children.Add(new DoubleAnimation()
-            {
-                From = 1,
-                To = 0,
-                Duration = TimeSpan.FromSeconds(0.15),
-            });
-            Storyboard.SetTargetProperty(storyboard, "Opacity");
-            Storyboard.SetTarget(storyboard, player);
-            storyboard.Begin();
-            storyboard.Completed += (sender, e)
-                =>
-            {
-                // Restore the original content.
-                splashGrid.Children.Clear();
-                Window.Current.Content = originalWindowContent;
-            };
+            // Collapse splash screen visibility.
+            splashGrid.Visibility = player.Visibility = Visibility.Collapsed;
+
+            // Restore the original content.
+            splashGrid.Children.Clear();
+            Window.Current.Content = originalWindowContent;
         }
 
         /// <summary>


### PR DESCRIPTION
Achieves parity with store app by:

- setting Lottie's Stretch to Uniform

- removing fade-out storyboard (would like to add this back in after I've figured out how to use group opacity instead of push-down opacity in xaml)