### PR TITLE
Updating versions of various packages.

### DIFF
--- a/Lottie-Windows/Lottie-Windows.csproj
+++ b/Lottie-Windows/Lottie-Windows.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="Newtonsoft.Json">
       <Version>12.0.1</Version>
     </PackageReference>
-    <PackageReference Include="System.Memory" Version="4.5.1" />
+    <PackageReference Include="System.Memory" Version="4.5.2" />
     <PackageReference Include="System.Numerics.Vectors">
       <Version>4.5.0</Version>
     </PackageReference>

--- a/LottieGen/LottieGen.csproj
+++ b/LottieGen/LottieGen.csproj
@@ -28,7 +28,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Memory" Version="4.5.1" />
+    <PackageReference Include="System.Memory" Version="4.5.2" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
   </ItemGroup>

--- a/LottieViewer/LottieViewer.csproj
+++ b/LottieViewer/LottieViewer.csproj
@@ -206,7 +206,7 @@
       <Version>12.0.1</Version>
     </PackageReference>
     <PackageReference Include="System.Memory">
-      <Version>4.5.1</Version>
+      <Version>4.5.2</Version>
     </PackageReference>
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
       <Version>4.5.2</Version>
@@ -220,11 +220,9 @@
   <Import Project="..\source\LottieData\LottieData.projitems" Label="Shared" />
   <Import Project="..\source\LottieToWinComp\LottieToWinComp.projitems" Label="Shared" />
   <Import Project="..\source\WinCompData\WinCompData.projitems" Label="Shared" />
-
   <Target Name="Pack">
     <!-- Dummy target to mute warnings about attempts to create a NuPkg -->
   </Target>
-  
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>

--- a/dlls/LottieData/LottieData.dll.csproj
+++ b/dlls/LottieData/LottieData.dll.csproj
@@ -10,7 +10,7 @@
   <Import Project="..\..\source\LottieData\LottieData.projitems" Label="Shared" />
 
   <ItemGroup>
-    <PackageReference Include="System.Memory" Version="4.5.1" />
+    <PackageReference Include="System.Memory" Version="4.5.2" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
   </ItemGroup>
 </Project>

--- a/samples/LottieSamples/LottieSamples.csproj
+++ b/samples/LottieSamples/LottieSamples.csproj
@@ -233,10 +233,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.1.7</Version>
+      <Version>6.1.9</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Lottie">
-      <Version>5.0.0-prerelease2</Version>
+      <Version>5.1.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml">
       <Version>2.1.190131001-prerelease</Version>

--- a/samples/LottieSamples/Scenarios/JsonPage.xaml
+++ b/samples/LottieSamples/Scenarios/JsonPage.xaml
@@ -16,7 +16,7 @@
                     <Paragraph>
                         <Span>To render our first Lottie animation, we use</Span>
                         <Span FontFamily="Consolas">AnimatedVisuals/LottieLogo1.json</Span>
-                        which was generated from Adobe Afterffects using
+                        which was generated from Adobe AfterEffects using
                         <Hyperlink NavigateUri="http://aescripts.com/bodymovin/">Bodymovin</Hyperlink>.
                         You'll need to
                         <Span FontWeight="SemiBold">include</Span>:


### PR DESCRIPTION
Updating versions and fixing a typo in the LottieSamples app.
This change is mainly about getting the LottieSamples app onto the official Lottie-Windows package, but updating other packages while we're here, and fixing a typo in the LottieSamples app.