### PR TITLE
Override the default interpolation color space of ColorKeyFrameAnimation to align with After Effects

### DIFF
--- a/source/Lottie/Instantiator.cs
+++ b/source/Lottie/Instantiator.cs
@@ -514,6 +514,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
             }
 
             result = CacheAndInitializeKeyframeAnimation(obj, _c.CreateColorKeyFrameAnimation());
+
+            if (obj.InterpolationColorSpace != default(Wd.CompositionColorSpace))
+            {
+                result.InterpolationColorSpace = (Wc.CompositionColorSpace)obj.InterpolationColorSpace;
+            }
+
             foreach (var kf in obj.KeyFrames)
             {
                 switch (kf.Type)

--- a/source/LottieToWinComp/LottieToWinCompTranslator.cs
+++ b/source/LottieToWinComp/LottieToWinCompTranslator.cs
@@ -3534,9 +3534,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                     context,
                     color,
                     result,
-                    nameof(result.Color),
-                    "Color",
-                    null);
+                    targetPropertyName: nameof(result.Color),
+                    longDescription: "Color",
+                    shortDescription: null);
                 return result;
             }
             else
@@ -3674,7 +3674,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 
         ColorKeyFrameAnimation CreateColorKeyFrameAnimation()
         {
-            return _c.CreateColorKeyFrameAnimation();
+            var result = _c.CreateColorKeyFrameAnimation();
+
+            // BodyMovin always uses RGB interpolation. Composition defaults to
+            // HSL. Override the default to be compatible with BodyMovin.
+            result.InterpolationColorSpace = CompositionColorSpace.Rgb;
+            return result;
         }
 
         PathKeyFrameAnimation CreatePathKeyFrameAnimation()

--- a/source/UIData/CodeGen/InstantiatorGeneratorBase.cs
+++ b/source/UIData/CodeGen/InstantiatorGeneratorBase.cs
@@ -1160,6 +1160,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
             WriteCreateAssignment(builder, node, $"_c{Deref}CreateColorKeyFrameAnimation()");
             InitializeKeyFrameAnimation(builder, obj, node);
 
+            if (obj.InterpolationColorSpace != CompositionColorSpace.Auto)
+            {
+                builder.WriteLine($"result{Deref}InteroplationColorSpace = {ColorSpace(obj.InterpolationColorSpace)};");
+            }
+
             foreach (var kf in obj.KeyFrames)
             {
                 switch (kf.Type)
@@ -1718,6 +1723,25 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
         string Readonly(string value) => _stringifier.Readonly(value);
 
         string String(string value) => _stringifier.String(value);
+
+        string ColorSpace(CompositionColorSpace value)
+        {
+            switch (value)
+            {
+                case CompositionColorSpace.Auto:
+                    return $"CompositionColorSpace{ScopeResolve}Auto";
+                case CompositionColorSpace.Hsl:
+                    return $"CompositionColorSpace{ScopeResolve}Hsl";
+                case CompositionColorSpace.Rgb:
+                    return $"CompositionColorSpace{ScopeResolve}Rgb";
+                case CompositionColorSpace.HslLinear:
+                    return $"CompositionColorSpace{ScopeResolve}HslLinear";
+                case CompositionColorSpace.RgbLinear:
+                    return $"CompositionColorSpace{ScopeResolve}RgbLinear";
+                default:
+                    throw new InvalidOperationException();
+            }
+        }
 
         string StrokeCap(CompositionStrokeCap value)
         {

--- a/source/UIData/CodeGen/Optimizer.cs
+++ b/source/UIData/CodeGen/Optimizer.cs
@@ -570,6 +570,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
             }
 
             result = CacheAndInitializeKeyframeAnimation(obj, _c.CreateColorKeyFrameAnimation());
+            result.InterpolationColorSpace = obj.InterpolationColorSpace;
+
             foreach (var kf in obj.KeyFrames)
             {
                 switch (kf.Type)

--- a/source/WinCompData/ColorKeyFrameAnimation.cs
+++ b/source/WinCompData/ColorKeyFrameAnimation.cs
@@ -17,7 +17,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData
         ColorKeyFrameAnimation(ColorKeyFrameAnimation other)
             : base(other)
         {
+            InterpolationColorSpace = other.InterpolationColorSpace;
         }
+
+        public CompositionColorSpace InterpolationColorSpace { get; set; }
 
         /// <inheritdoc/>
         public override CompositionObjectType Type => CompositionObjectType.ColorKeyFrameAnimation;

--- a/source/WinCompData/CompositionColorSpace.cs
+++ b/source/WinCompData/CompositionColorSpace.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData
+{
+    /// <summary>
+    /// Specifies the color space for interpolating color values in <see cref="ColorKeyFrameAnimation"/>.
+    /// </summary>
+#if PUBLIC_WinCompData
+    public
+#endif
+    enum CompositionColorSpace
+    {
+        Auto = 0,
+        Hsl = 1,
+        Rgb = 2,
+        HslLinear = 3,
+        RgbLinear = 4,
+    }
+}

--- a/source/WinCompData/WinCompData.projitems
+++ b/source/WinCompData/WinCompData.projitems
@@ -12,6 +12,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CompositionBrush.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CompositionClip.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CompositionColorBrush.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CompositionColorSpace.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CompositionContainerShape.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CompositionEasingFunction.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CompositionEffectBrush.cs" />


### PR DESCRIPTION
After Effects (and the web) use RGB interpolation for color animations. Composition support HSL and RGB, but defaults to HSL. HSL is rarely useful if the animation goes through white or black because there are multiple representations of white and black so the interpolation is poorly specified.

With this change, Lottie-Windows always uses RGB interpolation.