### PR TITLE
Better stats for LottieGen

### DIFF
--- a/LottieGen/CommandLineOptions.cs
+++ b/LottieGen/CommandLineOptions.cs
@@ -47,8 +47,6 @@ sealed class CommandLineOptions
 
     internal bool DisableCodeGenOptimizer { get; private set; }
 
-    internal bool Verbose { get; private set; }
-
     enum Keyword
     {
         None,
@@ -61,7 +59,6 @@ sealed class CommandLineOptions
         Strict,
         DisableTranslationOptimizer,
         DisableCodeGenOptimizer,
-        Verbose,
     }
 
     // Returns the parsed command line. If ErrorDescription is non-null, then the parse failed.
@@ -117,8 +114,7 @@ sealed class CommandLineOptions
             .AddPrefixedKeyword("outputfolder", Keyword.OutputFolder)
             .AddPrefixedKeyword("strict", Keyword.Strict)
             .AddPrefixedKeyword("disablecodegenoptimizer", Keyword.DisableCodeGenOptimizer)
-            .AddPrefixedKeyword("disabletranslationoptimizer", Keyword.DisableTranslationOptimizer)
-            .AddPrefixedKeyword("verbose", Keyword.Verbose);
+            .AddPrefixedKeyword("disabletranslationoptimizer", Keyword.DisableTranslationOptimizer);
 
         // The last keyword recognized. This defines what the following parameter value is for,
         // or None if not expecting a parameter value.
@@ -151,9 +147,6 @@ sealed class CommandLineOptions
                             break;
                         case Keyword.DisableTranslationOptimizer:
                             DisableTranslationOptimizer = true;
-                            break;
-                        case Keyword.Verbose:
-                            Verbose = true;
                             break;
 
                         // The following keywords require a parameter as the next token.

--- a/LottieGen/DataTable.cs
+++ b/LottieGen/DataTable.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+sealed class DataTable
+{
+    static readonly IEqualityComparer<string> s_columnNameComparer = StringComparer.OrdinalIgnoreCase;
+    readonly List<(string, string)[]> _rows = new List<(string columnName, string value)[]>();
+
+    internal void AddRow(IEnumerable<(string columnName, string value)> columns)
+    {
+        _rows.Add(columns.ToArray());
+    }
+
+    internal (string[] columnNames, string[][] rows) GetData()
+    {
+        // Get the column names. Each row may contain different columns. Find the distinct names.
+        var columnNames =
+            (from row in _rows
+             from column in row
+             select column.Item1).Distinct(s_columnNameComparer).ToArray();
+
+        return (columnNames, GetRows(columnNames).ToArray());
+    }
+
+    IEnumerable<string[]> GetRows(string[] columnNames)
+    {
+        foreach (var row in _rows)
+        {
+            yield return GetRowData(columnNames, row).ToArray();
+        }
+    }
+
+    static IEnumerable<string> GetRowData(string[] columnNames, (string, string)[] row)
+    {
+        // Create a dictionary for the row. This is used to match the column name to the column index.
+        var rowDictionary = row.ToDictionary(c => c.Item1, s_columnNameComparer);
+        foreach (var name in columnNames)
+        {
+            // Return the row in the correct column order.
+            (string columnName, string columnValue) col;
+            yield return rowDictionary.TryGetValue(name, out col) ? col.columnValue : null;
+        }
+    }
+}

--- a/LottieGen/DataTable.cs
+++ b/LottieGen/DataTable.cs
@@ -6,6 +6,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+/// <summary>
+/// Stores data as rows of columns. Columns are created automatically when adding data.
+/// Column names are case insensitive.
+/// </summary>
 sealed class DataTable
 {
     static readonly IEqualityComparer<string> s_columnNameComparer = StringComparer.OrdinalIgnoreCase;

--- a/LottieGen/LottieFileProcessor.cs
+++ b/LottieGen/LottieFileProcessor.cs
@@ -177,7 +177,7 @@ sealed class LottieFileProcessor
         var translationStats = _afterOptimizationStats ?? _beforeOptimizationStats;
 
         // Write the profiler table.
-        _reporter.WriteDataRow(
+        _reporter.WriteDataTableRow(
             "Timing",
             new[]
             {
@@ -195,7 +195,7 @@ sealed class LottieFileProcessor
             });
 
         // Write the Lottie stats table.
-        _reporter.WriteDataRow(
+        _reporter.WriteDataTableRow(
             "Lottie",
             new[]
             {
@@ -220,7 +220,7 @@ sealed class LottieFileProcessor
             });
 
         // Write the WinComp stats table.
-        _reporter.WriteDataRow(
+        _reporter.WriteDataTableRow(
             "WinComp",
             new[]
             {
@@ -262,7 +262,7 @@ sealed class LottieFileProcessor
         // Write the WinComp optimization stats table.
         if (_afterOptimizationStats != null)
         {
-            _reporter.WriteDataRow(
+            _reporter.WriteDataTableRow(
                 "WinCompOptimization",
                 new[]
                 {
@@ -305,7 +305,7 @@ sealed class LottieFileProcessor
         // Write the error table.
         foreach (var (code, description) in issues)
         {
-            _reporter.WriteDataRow(
+            _reporter.WriteDataTableRow(
                 "Errors",
                 new[]
                 {

--- a/LottieGen/LottieFileProcessor.cs
+++ b/LottieGen/LottieFileProcessor.cs
@@ -105,29 +105,6 @@ sealed class LottieFileProcessor
 
         var codeGenResult = TryGenerateCode();
 
-        // Output extra information if the user specified verbose output.
-        if (_options.Verbose)
-        {
-            if (_profiler.HasAnyResults)
-            {
-                _reporter.WriteInfoNewLine();
-                _reporter.WriteInfo(" === Timings ===");
-                _profiler.WriteReport(_reporter.InfoStream);
-            }
-
-            if (_lottieStats != null)
-            {
-                _reporter.WriteInfoNewLine();
-                WriteLottieStatsReport(_reporter.InfoStream, _lottieStats);
-            }
-
-            if (_beforeOptimizationStats != null && _afterOptimizationStats != null)
-            {
-                _reporter.WriteInfoNewLine();
-                WriteCodeGenStatsReport(_reporter.InfoStream, _beforeOptimizationStats, _afterOptimizationStats);
-            }
-        }
-
         // Any error that was reported is treated as a failure.
         codeGenResult &= !_reportedErrors;
 
@@ -199,27 +176,131 @@ sealed class LottieFileProcessor
         var issues = _readerIssues.Concat(_translationIssues);
         var translationStats = _afterOptimizationStats ?? _beforeOptimizationStats;
 
-        // Write the main table.
+        // Write the profiler table.
         _reporter.WriteDataRow(
-            "Info",
+            "Timing",
+            new[]
+            {
+                ("Path", _file),
+                ("TotalSeconds", (_profiler.ParseTime +
+                                  _profiler.TranslateTime +
+                                  _profiler.OptimizationTime +
+                                  _profiler.CodegenTime +
+                                  _profiler.SerializationTime).TotalSeconds.ToString()),
+                ("ParseSeconds", _profiler.ParseTime.TotalSeconds.ToString()),
+                ("TranslateSeconds", _profiler.TranslateTime.TotalSeconds.ToString()),
+                ("OptimizationSeconds", _profiler.OptimizationTime.TotalSeconds.ToString()),
+                ("CodegenSeconds", _profiler.CodegenTime.TotalSeconds.ToString()),
+                ("SerializationSeconds", _profiler.SerializationTime.TotalSeconds.ToString()),
+            });
+
+        // Write the Lottie stats table.
+        _reporter.WriteDataRow(
+            "Lottie",
             new[]
             {
                     ("Path", _file),
-                    ("LottieVersion", _lottieStats.Version.ToString()),
+                    ("Name", _lottieStats.Name),
+                    ("BodyMovinVersion", _lottieStats.Version.ToString()),
                     ("DurationSeconds", _lottieStats.Duration.TotalSeconds.ToString()),
-                    ("ErrorCount", issues.Count().ToString()),
-                    ("PrecompLayerCount", _lottieStats.PreCompLayerCount.ToString()),
-                    ("ShapeLayerCount", _lottieStats.ShapeLayerCount.ToString()),
-                    ("SolidLayerCount", _lottieStats.SolidLayerCount.ToString()),
-                    ("ImageLayerCount", _lottieStats.ImageLayerCount.ToString()),
-                    ("TextLayerCount", _lottieStats.TextLayerCount.ToString()),
-                    ("MaskCount", _lottieStats.MaskCount.ToString()),
-                    ("ContainerShapeCount", translationStats.ContainerShapeCount.ToString()),
-                    ("ContainerVisualCount", translationStats.ContainerVisualCount.ToString()),
-                    ("ExpressionAnimationCount", translationStats.ExpressionAnimationCount.ToString()),
-                    ("PropertySetPropertyCount", translationStats.PropertySetPropertyCount.ToString()),
-                    ("SpriteShapeCount", translationStats.SpriteShapeCount.ToString()),
+                    ("Width", _lottieStats.Width.ToString()),
+                    ("Height", _lottieStats.Height.ToString()),
+                    ("Error", issues.Count().ToString()),
+                    ("ImageLayer", _lottieStats.ImageLayerCount.ToString()),
+                    ("NullLayer", _lottieStats.NullLayerCount.ToString()),
+                    ("PrecompLayer", _lottieStats.PreCompLayerCount.ToString()),
+                    ("ShapeLayer", _lottieStats.ShapeLayerCount.ToString()),
+                    ("SolidLayer", _lottieStats.SolidLayerCount.ToString()),
+                    ("TextLayer", _lottieStats.TextLayerCount.ToString()),
+                    ("Mask", _lottieStats.MaskCount.ToString()),
+                    ("LinearGradientFill", _lottieStats.LinearGradientFillCount.ToString()),
+                    ("LinearGradientStroke", _lottieStats.LinearGradientStrokeCount.ToString()),
+                    ("RadialGradientFill", _lottieStats.RadialGradientFillCount.ToString()),
+                    ("RadialGradientStroke", _lottieStats.RadialGradientStrokeCount.ToString()),
             });
+
+        // Write the WinComp stats table.
+        _reporter.WriteDataRow(
+            "WinComp",
+            new[]
+            {
+                    ("Path", _file),
+                    ("CanvasGeometry", translationStats.CanvasGeometryCount.ToString()),
+                    ("ColorBrush", translationStats.ColorBrushCount.ToString()),
+                    ("ColorGradientStop", translationStats.ColorGradientStopCount.ToString()),
+                    ("ColorKeyFrameAnimation", translationStats.ColorKeyFrameAnimationCount.ToString()),
+                    ("CompositionPath", translationStats.CompositionPathCount.ToString()),
+                    ("ContainerShape", translationStats.ContainerShapeCount.ToString()),
+                    ("ContainerVisual", translationStats.ContainerVisualCount.ToString()),
+                    ("CubicBezierEasingFunction", translationStats.CubicBezierEasingFunctionCount.ToString()),
+                    ("EffectBrush", translationStats.EffectBrushCount.ToString()),
+                    ("EllipseGeometry", translationStats.EllipseGeometryCount.ToString()),
+                    ("ExpressionAnimation", translationStats.ExpressionAnimationCount.ToString()),
+                    ("GeometricClip", translationStats.GeometricClipCount.ToString()),
+                    ("InsetClip", translationStats.InsetClipCount.ToString()),
+                    ("LinearEasingFunction", translationStats.LinearEasingFunctionCount.ToString()),
+                    ("LinearGradientBrush", translationStats.LinearGradientBrushCount.ToString()),
+                    ("PathGeometry", translationStats.PathGeometryCount.ToString()),
+                    ("PathKeyFrameAnimation", translationStats.PathKeyFrameAnimationCount.ToString()),
+                    ("Property value", translationStats.PropertySetPropertyCount.ToString()),
+                    ("PropertySet", translationStats.PropertySetCount.ToString()),
+                    ("RadialGradientBrush", translationStats.RadialGradientBrushCount.ToString()),
+                    ("RectangleGeometry", translationStats.RectangleGeometryCount.ToString()),
+                    ("RoundedRectangleGeometry", translationStats.RoundedRectangleGeometryCount.ToString()),
+                    ("ScalarKeyFrameAnimation", translationStats.ScalarKeyFrameAnimationCount.ToString()),
+                    ("ShapeVisual", translationStats.ShapeVisualCount.ToString()),
+                    ("SpriteShape", translationStats.SpriteShapeCount.ToString()),
+                    ("SpriteVisualCount", translationStats.SpriteVisualCount.ToString()),
+                    ("StepEasingFunction", translationStats.StepEasingFunctionCount.ToString()),
+                    ("SurfaceBrushCount", translationStats.SurfaceBrushCount.ToString()),
+                    ("Vector2KeyFrameAnimation", translationStats.Vector2KeyFrameAnimationCount.ToString()),
+                    ("Vector3KeyFrameAnimation", translationStats.Vector3KeyFrameAnimationCount.ToString()),
+                    ("ViewBox", translationStats.ViewBoxCount.ToString()),
+                    ("VisualSurfaceCount", translationStats.VisualSurfaceCount.ToString()),
+            });
+
+        // Write the WinComp optimization stats table.
+        if (_afterOptimizationStats != null)
+        {
+            _reporter.WriteDataRow(
+                "WinCompOptimization",
+                new[]
+                {
+                    ("Path", _file),
+                    ("CanvasGeometry", (_afterOptimizationStats.CanvasGeometryCount - _beforeOptimizationStats.CanvasGeometryCount).ToString()),
+                    ("ColorBrush", (_afterOptimizationStats.ColorBrushCount - _beforeOptimizationStats.ColorBrushCount).ToString()),
+                    ("ColorGradientStop", (_afterOptimizationStats.ColorGradientStopCount - _beforeOptimizationStats.ColorGradientStopCount).ToString()),
+                    ("ColorKeyFrameAnimation", (_afterOptimizationStats.ColorKeyFrameAnimationCount - _beforeOptimizationStats.ColorKeyFrameAnimationCount).ToString()),
+                    ("CompositionPath", (_afterOptimizationStats.CompositionPathCount - _beforeOptimizationStats.CompositionPathCount).ToString()),
+                    ("ContainerShape", (_afterOptimizationStats.ContainerShapeCount - _beforeOptimizationStats.ContainerShapeCount).ToString()),
+                    ("ContainerVisual", (_afterOptimizationStats.ContainerVisualCount - _beforeOptimizationStats.ContainerVisualCount).ToString()),
+                    ("CubicBezierEasingFunction", (_afterOptimizationStats.CubicBezierEasingFunctionCount - _beforeOptimizationStats.CubicBezierEasingFunctionCount).ToString()),
+                    ("EffectBrush", (_afterOptimizationStats.EffectBrushCount - _beforeOptimizationStats.EffectBrushCount).ToString()),
+                    ("EllipseGeometry", (_afterOptimizationStats.EllipseGeometryCount - _beforeOptimizationStats.EllipseGeometryCount).ToString()),
+                    ("ExpressionAnimation", (_afterOptimizationStats.ExpressionAnimationCount - _beforeOptimizationStats.ExpressionAnimationCount).ToString()),
+                    ("GeometricClip", (_afterOptimizationStats.GeometricClipCount - _beforeOptimizationStats.GeometricClipCount).ToString()),
+                    ("InsetClip", (_afterOptimizationStats.InsetClipCount - _beforeOptimizationStats.InsetClipCount).ToString()),
+                    ("LinearEasingFunction", (_afterOptimizationStats.LinearEasingFunctionCount - _beforeOptimizationStats.LinearEasingFunctionCount).ToString()),
+                    ("LinearGradientBrush", (_afterOptimizationStats.LinearGradientBrushCount - _beforeOptimizationStats.LinearGradientBrushCount).ToString()),
+                    ("PathGeometry", (_afterOptimizationStats.PathGeometryCount - _beforeOptimizationStats.PathGeometryCount).ToString()),
+                    ("PathKeyFrameAnimation", (_afterOptimizationStats.PathKeyFrameAnimationCount - _beforeOptimizationStats.PathKeyFrameAnimationCount).ToString()),
+                    ("Property value", (_afterOptimizationStats.PropertySetPropertyCount - _beforeOptimizationStats.PropertySetPropertyCount).ToString()),
+                    ("PropertySet", (_afterOptimizationStats.PropertySetCount - _beforeOptimizationStats.PropertySetCount).ToString()),
+                    ("RadialGradientBrush", (_afterOptimizationStats.RadialGradientBrushCount - _beforeOptimizationStats.RadialGradientBrushCount).ToString()),
+                    ("RectangleGeometry", (_afterOptimizationStats.RectangleGeometryCount - _beforeOptimizationStats.RectangleGeometryCount).ToString()),
+                    ("RoundedRectangleGeometry", (_afterOptimizationStats.RoundedRectangleGeometryCount - _beforeOptimizationStats.RoundedRectangleGeometryCount).ToString()),
+                    ("ScalarKeyFrameAnimation", (_afterOptimizationStats.ScalarKeyFrameAnimationCount - _beforeOptimizationStats.ScalarKeyFrameAnimationCount).ToString()),
+                    ("ShapeVisual", (_afterOptimizationStats.ShapeVisualCount - _beforeOptimizationStats.ShapeVisualCount).ToString()),
+                    ("SpriteShape", (_afterOptimizationStats.SpriteShapeCount - _beforeOptimizationStats.SpriteShapeCount).ToString()),
+                    ("SpriteVisualCount", (_afterOptimizationStats.SpriteVisualCount - _beforeOptimizationStats.SpriteVisualCount).ToString()),
+                    ("StepEasingFunction", (_afterOptimizationStats.StepEasingFunctionCount - _beforeOptimizationStats.StepEasingFunctionCount).ToString()),
+                    ("SurfaceBrushCount", (_afterOptimizationStats.SurfaceBrushCount - _beforeOptimizationStats.SurfaceBrushCount).ToString()),
+                    ("Vector2KeyFrameAnimation", (_afterOptimizationStats.Vector2KeyFrameAnimationCount - _beforeOptimizationStats.Vector2KeyFrameAnimationCount).ToString()),
+                    ("Vector3KeyFrameAnimation", (_afterOptimizationStats.Vector3KeyFrameAnimationCount - _beforeOptimizationStats.Vector3KeyFrameAnimationCount).ToString()),
+                    ("ViewBox", (_afterOptimizationStats.ViewBoxCount - _beforeOptimizationStats.ViewBoxCount).ToString()),
+                    ("VisualSurfaceCount", (_afterOptimizationStats.VisualSurfaceCount - _beforeOptimizationStats.VisualSurfaceCount).ToString()),
+                });
+        }
 
         // Write the error table.
         foreach (var (code, description) in issues)
@@ -507,122 +588,6 @@ sealed class LottieFileProcessor
 
             // Return just the first 8 characters of the base64 encoded hash.
             return hashedString.Substring(0, 8);
-        }
-    }
-
-    static void WriteCodeGenStatsReport(
-        TextWriter writer,
-        Stats beforeOptimization,
-        Stats afterOptimization)
-    {
-        if (beforeOptimization == null)
-        {
-            return;
-        }
-
-        writer.WriteLine(" === Translation output stats ===");
-
-        writer.WriteLine("                      Type   Count  Optimized away");
-
-        if (afterOptimization == null)
-        {
-            // No optimization was performed. Just report on the before stats.
-            afterOptimization = beforeOptimization;
-        }
-
-        // Report on the after stats and indicate how much optimization
-        // improved things (where it did).
-        WriteStatsLine("CanvasGeometry", s => s.CanvasGeometryCount);
-        WriteStatsLine("ColorBrush", s => s.ColorBrushCount);
-        WriteStatsLine("ColorGradientStop", s => s.ColorGradientStopCount);
-        WriteStatsLine("ColorKeyFrameAnimation", s => s.ColorKeyFrameAnimationCount);
-        WriteStatsLine("CompositionPath", s => s.CompositionPathCount);
-        WriteStatsLine("ContainerShape", s => s.ContainerShapeCount);
-        WriteStatsLine("ContainerVisual", s => s.ContainerVisualCount);
-        WriteStatsLine("CubicBezierEasingFunction", s => s.CubicBezierEasingFunctionCount);
-        WriteStatsLine("EffectBrush", s => s.EffectBrushCount);
-        WriteStatsLine("EllipseGeometry", s => s.EllipseGeometryCount);
-        WriteStatsLine("ExpressionAnimation", s => s.ExpressionAnimationCount);
-        WriteStatsLine("GeometricClip", s => s.GeometricClipCount);
-        WriteStatsLine("InsetClip", s => s.InsetClipCount);
-        WriteStatsLine("LinearEasingFunction", s => s.LinearEasingFunctionCount);
-        WriteStatsLine("LinearGradientBrush", s => s.LinearGradientBrushCount);
-        WriteStatsLine("PathGeometry", s => s.PathGeometryCount);
-        WriteStatsLine("PathKeyFrameAnimation", s => s.PathKeyFrameAnimationCount);
-        WriteStatsLine("Property value", s => s.PropertySetPropertyCount);
-        WriteStatsLine("PropertySet", s => s.PropertySetCount);
-        WriteStatsLine("RadialGradientBrush", s => s.RadialGradientBrushCount);
-        WriteStatsLine("RectangleGeometry", s => s.RectangleGeometryCount);
-        WriteStatsLine("RoundedRectangleGeometry", s => s.RoundedRectangleGeometryCount);
-        WriteStatsLine("ScalarKeyFrameAnimation", s => s.ScalarKeyFrameAnimationCount);
-        WriteStatsLine("ShapeVisual", s => s.ShapeVisualCount);
-        WriteStatsLine("SpriteShape", s => s.SpriteShapeCount);
-        WriteStatsLine("SpriteVisualCount", s => s.SpriteVisualCount);
-        WriteStatsLine("StepEasingFunction", s => s.StepEasingFunctionCount);
-        WriteStatsLine("SurfaceBrushCount", s => s.SurfaceBrushCount);
-        WriteStatsLine("Vector2KeyFrameAnimation", s => s.Vector2KeyFrameAnimationCount);
-        WriteStatsLine("Vector3KeyFrameAnimation", s => s.Vector3KeyFrameAnimationCount);
-        WriteStatsLine("ViewBox", s => s.ViewBoxCount);
-        WriteStatsLine("VisualSurfaceCount", s => s.VisualSurfaceCount);
-
-        void WriteStatsLine(string name, Func<Stats, int> selector)
-        {
-            var before = selector(beforeOptimization);
-            var after = selector(afterOptimization);
-
-            if (after > 0 || before > 0)
-            {
-                const int nameWidth = 26;
-                if (before != after)
-                {
-                    writer.WriteLine($"{name,nameWidth}  {after,6:n0} {before - after,6:n0}");
-                }
-                else
-                {
-                    writer.WriteLine($"{name,nameWidth}  {after,6:n0}");
-                }
-            }
-        }
-    }
-
-    static void WriteLottieStatsReport(
-        TextWriter writer,
-        Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Tools.Stats stats)
-    {
-        writer.WriteLine(" === Lottie info ===");
-        WriteStatsStringLine("BodyMovin Version", stats.Version.ToString());
-        WriteStatsStringLine("Name", stats.Name);
-        WriteStatsStringLine("Size", $"{stats.Width} x {stats.Height}");
-        WriteStatsStringLine("Duration", $"{stats.Duration.TotalSeconds.ToString("#,##0.0##")} seconds");
-        WriteStatsIntLine("Images", stats.ImageLayerCount);
-        WriteStatsIntLine("PreComps", stats.PreCompLayerCount);
-        WriteStatsIntLine("Shapes", stats.ShapeLayerCount);
-        WriteStatsIntLine("Solids", stats.SolidLayerCount);
-        WriteStatsIntLine("Nulls", stats.NullLayerCount);
-        WriteStatsIntLine("Texts", stats.TextLayerCount);
-        WriteStatsIntLine("Masks", stats.MaskCount);
-        WriteStatsIntLine("MaskAdditive", stats.MaskAdditiveCount);
-        WriteStatsIntLine("MaskDarken", stats.MaskDarkenCount);
-        WriteStatsIntLine("MaskDifference", stats.MaskDifferenceCount);
-        WriteStatsIntLine("MaskIntersect", stats.MaskIntersectCount);
-        WriteStatsIntLine("MaskLighten", stats.MaskLightenCount);
-        WriteStatsIntLine("MaskSubtract", stats.MaskSubtractCount);
-
-        const int nameWidth = 19;
-        void WriteStatsIntLine(string name, int value)
-        {
-            if (value > 0)
-            {
-                writer.WriteLine($"{name,nameWidth}  {value,6:n0}");
-            }
-        }
-
-        void WriteStatsStringLine(string name, string value)
-        {
-            if (!string.IsNullOrWhiteSpace(value))
-            {
-                writer.WriteLine($"{name,nameWidth}  {value}");
-            }
         }
     }
 

--- a/LottieGen/Profiler.cs
+++ b/LottieGen/Profiler.cs
@@ -4,8 +4,6 @@
 
 using System;
 using System.Diagnostics;
-using System.IO;
-using System.Linq;
 
 // Measures time spent in each phase.
 sealed class Profiler
@@ -19,6 +17,16 @@ sealed class Profiler
     TimeSpan _optimizationTime;
     TimeSpan _codegenTime;
     TimeSpan _serializationTime;
+
+    internal TimeSpan ParseTime => _parseTime;
+
+    internal TimeSpan TranslateTime => _translateTime;
+
+    internal TimeSpan OptimizationTime => _optimizationTime;
+
+    internal TimeSpan CodegenTime => _codegenTime;
+
+    internal TimeSpan SerializationTime => _serializationTime;
 
     internal void OnUnmeasuredFinished() => OnPhaseFinished(ref _unmeasuredTime);
 
@@ -36,34 +44,5 @@ sealed class Profiler
     {
         counter = _sw.Elapsed;
         _sw.Restart();
-    }
-
-    // True if there is at least one time value.
-    internal bool HasAnyResults
-        => new[]
-        {
-                _parseTime,
-                _translateTime,
-                _optimizationTime,
-                _codegenTime,
-                _serializationTime,
-        }.Any(ts => ts > TimeSpan.Zero);
-
-    internal void WriteReport(TextWriter writer)
-    {
-        WriteReportForPhase(writer, "parse", _parseTime);
-        WriteReportForPhase(writer, "translate", _translateTime);
-        WriteReportForPhase(writer, "optimization", _optimizationTime);
-        WriteReportForPhase(writer, "codegen", _codegenTime);
-        WriteReportForPhase(writer, "serialization", _serializationTime);
-    }
-
-    void WriteReportForPhase(TextWriter writer, string phaseName, TimeSpan value)
-    {
-        // Ignore phases that didn't occur.
-        if (value > TimeSpan.Zero)
-        {
-            writer.WriteLine($"{value} spent in {phaseName}.");
-        }
     }
 }

--- a/LottieGen/Program.cs
+++ b/LottieGen/Program.cs
@@ -136,7 +136,7 @@ sealed class Program
             // then written to files here after of the LottieFileProcessors have finished.
             foreach (var (dataTableName, columnNames, rows) in _reporter.GetDataTables())
             {
-                var tsvFilePath = System.IO.Path.Combine(outputFolder, $"Stats_{dataTableName}.tsv");
+                var tsvFilePath = System.IO.Path.Combine(outputFolder, $"LottieGen_{dataTableName}.tsv");
                 _reporter.WriteInfo($"Writing stats to {tsvFilePath}");
                 using (var tsvFile = File.CreateText(tsvFilePath))
                 {
@@ -215,7 +215,6 @@ OVERVIEW:
          -Strict       Fails on any parsing or translation issue. If not specified, 
                        a best effort will be made to create valid output, and any 
                        issues will be reported to STDOUT.
-         -Verbose      Outputs extra info to STDOUT.
 
 EXAMPLES:
 

--- a/LottieGen/Program.cs
+++ b/LottieGen/Program.cs
@@ -132,8 +132,8 @@ sealed class Program
 
         if (_options.Languages.Contains(Lang.Stats))
         {
-            // Write the stats. Stats for all the files are combined, so they are collected by the Reporter
-            // then written to files here after of the LottieFileProcessors have finished.
+            // Write the stats. Stats are collected by the Reporter from each LottieFileProcessor
+            // then written to files here after all of the LottieFileProcessors have finished.
             foreach (var (dataTableName, columnNames, rows) in _reporter.GetDataTables())
             {
                 var tsvFilePath = System.IO.Path.Combine(outputFolder, $"LottieGen_{dataTableName}.tsv");

--- a/LottieGen/Reporter.cs
+++ b/LottieGen/Reporter.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 sealed class Reporter
 {
@@ -58,7 +59,7 @@ sealed class Reporter
     // Returns the data for each dat table that was written.
     internal IEnumerable<(string dataTableName, string[] columnNames, string[][] rows)> GetDataTables()
     {
-        foreach (var (dataTableName, dataTable) in _dataTables)
+        foreach (var (dataTableName, dataTable) in _dataTables.OrderBy(dt => dt.Key))
         {
             var (columNames, rows) = dataTable.GetData();
             yield return (dataTableName, columNames, rows);

--- a/LottieGen/Reporter.cs
+++ b/LottieGen/Reporter.cs
@@ -2,38 +2,66 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections.Generic;
 using System.IO;
 
 sealed class Reporter
 {
-    readonly TextWriter _infoStream;
-    readonly TextWriter _errorStream;
+    readonly Dictionary<string, DataTable> _dataTables =
+        new Dictionary<string, DataTable>(StringComparer.OrdinalIgnoreCase);
 
     internal Reporter(TextWriter infoStream, TextWriter errorStream)
     {
-        _infoStream = infoStream;
-        _errorStream = errorStream;
+        InfoStream = infoStream;
+        ErrorStream = errorStream;
     }
 
-    internal TextWriter InfoStream => _infoStream;
+    internal TextWriter InfoStream { get; }
 
-    internal TextWriter ErrorStream => _errorStream;
+    internal TextWriter ErrorStream { get; }
 
     // Helper for writing errors to the error stream with a standard format.
     internal void WriteError(string errorMessage)
     {
-        _errorStream.WriteLine($"Error: {errorMessage}");
+        ErrorStream.WriteLine($"Error: {errorMessage}");
     }
 
     // Helper for writing info lines to the info stream.
     internal void WriteInfo(string infoMessage)
     {
-        _infoStream.WriteLine(infoMessage);
+        InfoStream.WriteLine(infoMessage);
     }
 
     // Writes a new line to the info stream.
     internal void WriteInfoNewLine()
     {
-        _infoStream.WriteLine();
+        InfoStream.WriteLine();
+    }
+
+    // Writes a row of data that can be retrieved later. Typically this is used to create CSV or TSV files
+    // containing information about the result of processing some Lottie files.
+    internal void WriteDataRow(string databaseName, IReadOnlyList<(string columnName, string value)> row)
+    {
+        lock (_dataTables)
+        {
+            if (!_dataTables.TryGetValue(databaseName, out var database))
+            {
+                database = new DataTable();
+                _dataTables.Add(databaseName, database);
+            }
+
+            database.AddRow(row);
+        }
+    }
+
+    // Returns the data for each dat table that was written.
+    internal IEnumerable<(string dataTableName, string[] columnNames, string[][] rows)> GetDataTables()
+    {
+        foreach (var (dataTableName, dataTable) in _dataTables)
+        {
+            var (columNames, rows) = dataTable.GetData();
+            yield return (dataTableName, columNames, rows);
+        }
     }
 }

--- a/source/LottieData/Tools/Stats.cs
+++ b/source/LottieData/Tools/Stats.cs
@@ -15,35 +15,16 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Tools
 #endif
     sealed class Stats
     {
-        readonly Version _version;
-        readonly string _name;
-        readonly double _width;
-        readonly double _height;
-        readonly TimeSpan _duration;
-        readonly int _preCompLayerCount;
-        readonly int _solidLayerCount;
-        readonly int _imageLayerCount;
-        readonly int _maskCount;
-        readonly int _nullLayerCount;
-        readonly int _shapeLayerCount;
-        readonly int _textLayerCount;
-        readonly int _maskAdditiveCount;
-        readonly int _maskDarkenCount;
-        readonly int _maskDifferenceCount;
-        readonly int _maskIntersectCount;
-        readonly int _maskLightenCount;
-        readonly int _maskSubtractiveCount;
-
         // Creates a string that describes the Lottie.
         public Stats(LottieComposition lottieComposition)
         {
             if (lottieComposition == null) { return; }
 
-            _name = lottieComposition.Name;
-            _version = lottieComposition.Version;
-            _width = lottieComposition.Width;
-            _height = lottieComposition.Height;
-            _duration = lottieComposition.Duration;
+            Name = lottieComposition.Name;
+            Version = lottieComposition.Version;
+            Width = lottieComposition.Width;
+            Height = lottieComposition.Height;
+            Duration = lottieComposition.Duration;
 
             // Get the layers stored in assets.
             var layersInAssets =
@@ -58,22 +39,23 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Tools
                 switch (layer.Type)
                 {
                     case Layer.LayerType.PreComp:
-                        _preCompLayerCount++;
+                        PreCompLayerCount++;
                         break;
                     case Layer.LayerType.Solid:
-                        _solidLayerCount++;
+                        SolidLayerCount++;
                         break;
                     case Layer.LayerType.Image:
-                        _imageLayerCount++;
+                        ImageLayerCount++;
                         break;
                     case Layer.LayerType.Null:
-                        _nullLayerCount++;
+                        NullLayerCount++;
                         break;
                     case Layer.LayerType.Shape:
-                        _shapeLayerCount++;
+                        ShapeLayerCount++;
+                        VisitShapeLayer((ShapeLayer)layer);
                         break;
                     case Layer.LayerType.Text:
-                        _textLayerCount++;
+                        TextLayerCount++;
                         break;
                     default:
                         throw new InvalidOperationException();
@@ -81,68 +63,138 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Tools
 
                 foreach (var mask in layer.Masks)
                 {
-                    _maskCount++;
+                    MaskCount++;
                     switch (mask.Mode)
                     {
                         case Mask.MaskMode.Additive:
-                            _maskAdditiveCount++;
+                            MaskAdditiveCount++;
                             break;
                         case Mask.MaskMode.Darken:
-                            _maskDarkenCount++;
+                            MaskDarkenCount++;
                             break;
                         case Mask.MaskMode.Difference:
-                            _maskDifferenceCount++;
+                            MaskDifferenceCount++;
                             break;
                         case Mask.MaskMode.Intersect:
-                            _maskIntersectCount++;
+                            MaskIntersectCount++;
                             break;
                         case Mask.MaskMode.Lighten:
-                            _maskLightenCount++;
+                            MaskLightenCount++;
                             break;
                         case Mask.MaskMode.Subtract:
-                            _maskSubtractiveCount++;
+                            MaskSubtractCount++;
                             break;
                     }
                 }
 
-                _maskCount += layer.Masks.Length;
+                MaskCount += layer.Masks.Length;
             }
         }
 
-        public int PreCompLayerCount => _preCompLayerCount;
+        public int PreCompLayerCount { get; }
 
-        public int SolidLayerCount => _solidLayerCount;
+        public int SolidLayerCount { get; }
 
-        public int ImageLayerCount => _imageLayerCount;
+        public int ImageLayerCount { get; }
 
-        public int MaskCount => _maskCount;
+        public int LinearGradientFillCount { get; private set; }
 
-        public int MaskAdditiveCount => _maskAdditiveCount;
+        public int LinearGradientStrokeCount { get; private set; }
 
-        public int MaskDarkenCount => _maskDarkenCount;
+        public int MaskCount { get; }
 
-        public int MaskDifferenceCount => _maskDifferenceCount;
+        public int MaskAdditiveCount { get; }
 
-        public int MaskIntersectCount => _maskIntersectCount;
+        public int MaskDarkenCount { get; }
 
-        public int MaskLightenCount => _maskLightenCount;
+        public int MaskDifferenceCount { get; }
 
-        public int MaskSubtractCount => _maskSubtractiveCount;
+        public int MaskIntersectCount { get; }
 
-        public int NullLayerCount => _nullLayerCount;
+        public int MaskLightenCount { get; }
 
-        public int ShapeLayerCount => _shapeLayerCount;
+        public int MaskSubtractCount { get; }
 
-        public int TextLayerCount => _textLayerCount;
+        public int NullLayerCount { get; }
 
-        public double Width => _width;
+        public int RadialGradientFillCount { get; private set; }
 
-        public double Height => _height;
+        public int RadialGradientStrokeCount { get; private set; }
 
-        public TimeSpan Duration => _duration;
+        public int ShapeLayerCount { get; }
 
-        public string Name => _name;
+        public int TextLayerCount { get; }
 
-        public Version Version => _version;
+        public double Width { get; }
+
+        public double Height { get; }
+
+        public TimeSpan Duration { get; }
+
+        public string Name { get; }
+
+        public Version Version { get; }
+
+        void VisitShapeLayer(ShapeLayer shapeLayer)
+        {
+            foreach (var content in shapeLayer.Contents)
+            {
+                VisitShapeLayerContent(content);
+            }
+        }
+
+        void VisitShapeGroup(ShapeGroup shapeGroup)
+        {
+            foreach (var content in shapeGroup.Items)
+            {
+                VisitShapeLayerContent(content);
+            }
+        }
+
+        void VisitShapeLayerContent(ShapeLayerContent content)
+        {
+            switch (content.ContentType)
+            {
+                case ShapeContentType.Ellipse:
+                    break;
+                case ShapeContentType.Group:
+                    VisitShapeGroup((ShapeGroup)content);
+                    break;
+                case ShapeContentType.LinearGradientFill:
+                    LinearGradientFillCount++;
+                    break;
+                case ShapeContentType.LinearGradientStroke:
+                    LinearGradientStrokeCount++;
+                    break;
+                case ShapeContentType.MergePaths:
+                    break;
+                case ShapeContentType.Path:
+                    break;
+                case ShapeContentType.Polystar:
+                    break;
+                case ShapeContentType.RadialGradientFill:
+                    RadialGradientFillCount++;
+                    break;
+                case ShapeContentType.RadialGradientStroke:
+                    RadialGradientStrokeCount++;
+                    break;
+                case ShapeContentType.Rectangle:
+                    break;
+                case ShapeContentType.Repeater:
+                    break;
+                case ShapeContentType.RoundedCorner:
+                    break;
+                case ShapeContentType.SolidColorFill:
+                    break;
+                case ShapeContentType.SolidColorStroke:
+                    break;
+                case ShapeContentType.Transform:
+                    break;
+                case ShapeContentType.TrimPath:
+                    break;
+                default:
+                    throw new InvalidOperationException();
+            }
+        }
     }
 }

--- a/source/LottieToWinComp/LottieToWinCompTranslator.cs
+++ b/source/LottieToWinComp/LottieToWinCompTranslator.cs
@@ -802,7 +802,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             //
 
             // Get the opacity of the layer.
-            var layerOpacityPercent = context.Layer.Transform.OpacityPercent;
+            var layerOpacityPercent = context.TrimAnimatable(context.Layer.Transform.OpacityPercent);
 
             // Convert the layer's in point and out point into absolute progress (0..1) values.
             var inProgress = GetInPointProgress(context);
@@ -835,7 +835,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 
                 if (layerOpacityPercent.IsAnimated)
                 {
-                    ApplyPercentKeyFrameAnimation(context, context.TrimAnimatable(layerOpacityPercent), opacityNode, "Opacity", "Layer opacity animation");
+                    ApplyPercentKeyFrameAnimation(context, layerOpacityPercent, opacityNode, "Opacity", "Layer opacity animation");
                 }
                 else
                 {
@@ -2553,7 +2553,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                 case ShapeFill.ShapeFillKind.LinearGradient:
                     return TranslateLinearGradientFill(context, (LinearGradientFill)shapeFill, opacityPercent);
                 case ShapeFill.ShapeFillKind.RadialGradient:
-                    /*return TranslateRadialGradientFill(context, (RadialGradientFill)shapeFill, opacityPercent);*/
+                /*return TranslateRadialGradientFill(context, (RadialGradientFill)shapeFill, opacityPercent);*/
                 default:
                     throw new InvalidOperationException();
             }
@@ -2599,7 +2599,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             {
                 var offset = stop.Offset;
                 var color = stop.Opacity.HasValue ? MultiplyColorByOpacityPercent(stop.Color, stop.Opacity.Value) : stop.Color;
-                colorStops.Add(_c.CreateColorGradientStop(Float(offset), color));
+                if (color != null)
+                {
+                    colorStops.Add(_c.CreateColorGradientStop(Float(offset), color));
+                }
             }
 
             return result;
@@ -3534,8 +3537,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         }
 
         static Color MultiplyColorByOpacityPercent(Color color, double opacityPercent)
-            => opacityPercent == 100 ? color
-            : LottieData.Color.FromArgb(color.A * opacityPercent / 100, color.R, color.G, color.B);
+            => color == null
+                ? null
+                : (opacityPercent == 100 ? color
+                    : LottieData.Color.FromArgb(color.A * opacityPercent / 100, color.R, color.G, color.B));
 
         CompositionColorBrush CreateAnimatedColorBrush(TranslationContext context, Color color, in TrimmedAnimatable<double> opacityPercent)
         {

--- a/source/LottieToWinComp/TrimmedAnimatable.cs
+++ b/source/LottieToWinComp/TrimmedAnimatable.cs
@@ -44,6 +44,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         /// </summary>
         internal bool IsAnimated => KeyFrames.Length > 1;
 
+        /// <summary>
+        /// Returns <c>true</c> if this value is always equal to the given value.
+        /// </summary>
+        /// <returns><c>true</c> if this value is always equal to the given value.</returns>
+        internal bool AlwaysEquals(T value) => !IsAnimated && value.Equals(InitialValue);
+
         internal TranslationContext Context { get; }
     }
 }


### PR DESCRIPTION
I'm doing this to get ready for testing gradients.
Previously we had an awkward CSV output and a verbose option for LottieGen. Now we have a general DataTable that allows any data to be written to a TSV file.
Fixed some edge-case bugs I found in translation around gradients during testing.