### PR TITLE
Remove class name option

### DIFF
--- a/LottieGen/CommandLineOptions.cs
+++ b/LottieGen/CommandLineOptions.cs
@@ -35,8 +35,6 @@ sealed class CommandLineOptions
 
     internal IEnumerable<Lang> Languages { get; private set; }
 
-    internal string ClassName { get; private set; }
-
     internal string OutputFolder { get; private set; }
 
     internal bool StrictMode { get; private set; }
@@ -54,7 +52,6 @@ sealed class CommandLineOptions
         Help,
         InputFile,
         Language,
-        ClassName,
         OutputFolder,
         Strict,
         DisableTranslationOptimizer,
@@ -110,7 +107,6 @@ sealed class CommandLineOptions
             .AddPrefixedKeyword("help", Keyword.Help)
             .AddPrefixedKeyword("inputfile", Keyword.InputFile)
             .AddPrefixedKeyword("language", Keyword.Language)
-            .AddPrefixedKeyword("classname", Keyword.ClassName)
             .AddPrefixedKeyword("outputfolder", Keyword.OutputFolder)
             .AddPrefixedKeyword("strict", Keyword.Strict)
             .AddPrefixedKeyword("disablecodegenoptimizer", Keyword.DisableCodeGenOptimizer)
@@ -152,7 +148,6 @@ sealed class CommandLineOptions
                         // The following keywords require a parameter as the next token.
                         case Keyword.InputFile:
                         case Keyword.Language:
-                        case Keyword.ClassName:
                         case Keyword.OutputFolder:
                             previousKeyword = keyword;
                             break;
@@ -174,15 +169,6 @@ sealed class CommandLineOptions
                     break;
                 case Keyword.Language:
                     _languageStrings.Add(arg);
-                    break;
-                case Keyword.ClassName:
-                    if (ClassName != null)
-                    {
-                        ErrorDescription = "class name specified more than once";
-                        return;
-                    }
-
-                    ClassName = arg;
                     break;
                 case Keyword.OutputFolder:
                     if (OutputFolder != null)

--- a/LottieGen/LottieFileProcessor.cs
+++ b/LottieGen/LottieFileProcessor.cs
@@ -2,12 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Security.Cryptography;
-using System.Text;
 using Microsoft.Toolkit.Uwp.UI.Lottie.LottieData;
 using Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization;
 using Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp;
@@ -15,6 +9,11 @@ using Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen;
 using Microsoft.Toolkit.Uwp.UI.Lottie.UIData.Tools;
 using Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData;
 using Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Tools;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
 
 /// <summary>
 /// Processes a single Lottie file to produce various generated outputs.
@@ -46,7 +45,6 @@ sealed class LottieFileProcessor
 
         // Get an appropriate name for a generated class.
         _className =
-            InstantiatorGeneratorBase.TrySynthesizeClassName(_options.ClassName) ??
             InstantiatorGeneratorBase.TrySynthesizeClassName(System.IO.Path.GetFileNameWithoutExtension(_file)) ??
             InstantiatorGeneratorBase.TrySynthesizeClassName("Lottie");  // If all else fails, just call it Lottie.
     }

--- a/LottieGen/LottieFileProcessor.cs
+++ b/LottieGen/LottieFileProcessor.cs
@@ -2,6 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
 using Microsoft.Toolkit.Uwp.UI.Lottie.LottieData;
 using Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization;
 using Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp;
@@ -9,11 +14,6 @@ using Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen;
 using Microsoft.Toolkit.Uwp.UI.Lottie.UIData.Tools;
 using Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData;
 using Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Tools;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
 
 /// <summary>
 /// Processes a single Lottie file to produce various generated outputs.

--- a/LottieGen/Program.cs
+++ b/LottieGen/Program.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;

--- a/LottieGen/Program.cs
+++ b/LottieGen/Program.cs
@@ -199,11 +199,6 @@ OVERVIEW:
        [Other options]
 
          -Help         Print this help message and exit.
-         -ClassName    Uses the given class name for the generated code. If not 
-                       specified the name is synthesized from the name of the Lottie 
-                       file. The class name will be sanitized as necessary to be valid
-                       for the language and will also be used as the base name of 
-                       the output file(s).
          -DisableTranslationOptimizer  
                        Disables optimization of the translation from Lottie to
                        Windows code. Mainly used to detect bugs in the optimizer.
@@ -225,8 +220,8 @@ EXAMPLES:
 
 
        Keywords can be abbreviated and are case insensitive.
-       Generate Grotz.cs in the C:\temp directory from the Lottie file Bar.json:
+       Generate Bar.cs in the C:\temp directory from the Lottie file Bar.json:
 
-         {0} -i Bar.json -L cs -ClassName Grotz -o C:\temp",
+         {0} -i Bar.json -L cs -o C:\temp",
 System.IO.Path.GetFileNameWithoutExtension(Assembly.GetEntryAssembly().ManifestModule.Name));
 }

--- a/source/WinUIXamlMediaData/LoadedImageSurfaceFromStream.cs
+++ b/source/WinUIXamlMediaData/LoadedImageSurfaceFromStream.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData;
-
 namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinUIXamlMediaData
 {
 #if PUBLIC_WinUIXamlMediaData


### PR DESCRIPTION
The -ClassName option allowed you to override the name generated for a class for a Lottie. However it was rarely used, and it makes no sense when using globs to specify more than one Lottie file. The functionality to control your class name is still available via a workaround: rename your .json file.