### PR TITLE
Fix for #161: Ensure storage is allocated for the root node in codegen.

### DIFF
--- a/source/UIData/CodeGen/InstantiatorGeneratorBase.cs
+++ b/source/UIData/CodeGen/InstantiatorGeneratorBase.cs
@@ -634,10 +634,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
                 // Ensure the root object has storage if it is referenced by anything else in the graph.
                 // This is necessary because the root node is referenced from the instantiator entrypoint
                 // but that isn't counted in the InReference.
-                if (_rootNode.InReferences.Any())
-                {
-                    _rootNode.RequiresStorage = true;
-                }
+                // Because the root object is exposed via IAnimatedVisual::RootVisual this means that
+                // there must always be storage for the root object.
+                _rootNode.RequiresStorage = true;
             }
 
             // Returns the nodes that can be shared between multiple IAnimatedVisuals.
@@ -652,8 +651,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
             {
                 return
                     (from n in _nodes
-                    where n.IsLoadedImageSurface
-                    select _owner._loadedImageSurfaceInfosByNode[n]).OrderBy(n => n.Name);
+                     where n.IsLoadedImageSurface
+                     select _owner._loadedImageSurfaceInfosByNode[n]).OrderBy(n => n.Name);
             }
 
             // Returns the node for the given object.


### PR DESCRIPTION
#161: This issue was producing uncompilable code on some very simpler Lottie files that didn't need references to the root node except through the IAnimatedVisual interface.
