### PR TITLE
Handle AnimatedVisuals where different versions need different parameters.

### DIFF
--- a/source/UIData/CodeGen/CodeBuilder.cs
+++ b/source/UIData/CodeGen/CodeBuilder.cs
@@ -30,6 +30,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
             _lines.Add(new CodeLine { Text = line, IndentCount = _indentCount });
         }
 
+        internal void WriteCommaSeparatedLines(string initialItem, IEnumerable<string> remainingItems)
+        {
+            WriteLine($"{initialItem},");
+            WriteCommaSeparatedLines(remainingItems);
+        }
+
         internal void WriteCommaSeparatedLines(IEnumerable<string> items)
         {
             var itemsToWrite = items.ToArray();

--- a/source/UIData/CodeGen/IAnimatedVisualInfo.cs
+++ b/source/UIData/CodeGen/IAnimatedVisualInfo.cs
@@ -26,11 +26,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
         string ClassName { get; }
 
         /// <summary>
-        /// Gets a value indicating whether the AnimatedVisual has LoadedImageSurface.
-        /// </summary>
-        bool HasLoadedImageSurface { get; }
-
-        /// <summary>
         /// The UAP version required by the IAnimatedVisual.
         /// </summary>
         uint RequiredUapVersion { get; }

--- a/source/UIData/CodeGen/IAnimatedVisualSourceInfo.cs
+++ b/source/UIData/CodeGen/IAnimatedVisualSourceInfo.cs
@@ -61,11 +61,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
         bool UsesStreams { get; }
 
         /// <summary>
-        /// Gets a value indicating whether the composition has LoadedImageSurface.
-        /// </summary>
-        bool HasLoadedImageSurface { get; }
-
-        /// <summary>
         /// Gets the <see cref="IAnimatedVisualInfo"/> objects that describe each IAnimatedVisual
         /// class that can be returned from the generated code.
         /// </summary>

--- a/source/UIData/CodeGen/InstantiatorGeneratorBase.cs
+++ b/source/UIData/CodeGen/InstantiatorGeneratorBase.cs
@@ -296,12 +296,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
         protected IReadOnlyList<Uri> GetAssetsList() => _loadedImageSurfaceInfos.Where(n => n.ImageUri != null).Select(n => n.ImageUri).ToArray();
 
         /// <summary>
-        /// Gets a list of the <see cref="LoadedImageSurfaceInfo"/> representing the LoadedImageSurface of the composition and its properties.
-        /// </summary>
-        /// <returns>List of the <see cref="LoadedImageSurfaceInfo"/> representing the LoadedImageSurface and its properties.</returns>
-        protected IReadOnlyList<LoadedImageSurfaceInfo> GetLoadedImageSurfaceInfos() => _loadedImageSurfaceInfos;
-
-        /// <summary>
         /// Call this to generate the code. Returns a string containing the generated code.
         /// </summary>
         /// <returns>The code.</returns>
@@ -322,7 +316,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
             {
                 bool bytesWritten = false;
 
-                foreach (var loadedImageSurface in GetLoadedImageSurfaceInfos())
+                foreach (var loadedImageSurface in _loadedImageSurfaceInfos)
                 {
                     if (loadedImageSurface.Bytes != null)
                     {
@@ -472,9 +466,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
 
         bool IAnimatedVisualSourceInfo.UsesCompositeEffect => _animatedVisualGenerators.Any(f => f.UsesCompositeEffect);
 
-        bool IAnimatedVisualSourceInfo.HasLoadedImageSurface => GetLoadedImageSurfaceInfos().Any();
-
-        IReadOnlyList<LoadedImageSurfaceInfo> IAnimatedVisualSourceInfo.LoadedImageSurfaceNodes => GetLoadedImageSurfaceInfos();
+        IReadOnlyList<LoadedImageSurfaceInfo> IAnimatedVisualSourceInfo.LoadedImageSurfaceNodes => _loadedImageSurfaceInfos;
 
         static LoadedImageSurfaceInfo LoadedImageSurfaceInfoFromObjectData(ObjectData node)
         {
@@ -2003,8 +1995,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
             IAnimatedVisualSourceInfo IAnimatedVisualInfo.AnimatedVisualSourceInfo => _owner;
 
             string IAnimatedVisualInfo.ClassName => $"AnimatedVisual_UAPv{_requiredUapVersion}";
-
-            bool IAnimatedVisualInfo.HasLoadedImageSurface => GetLoadedImageSurfaceInfos().Any();
 
             IReadOnlyList<LoadedImageSurfaceInfo> IAnimatedVisualInfo.LoadedImageSurfaceNodes => GetLoadedImageSurfaceInfos().ToArray();
 


### PR DESCRIPTION
Handle the case where a v8 AnimatedVisual has images used for masks but the v7 does not (because it doesn't support masks). This was breaking codegen on this rare case.

Includes some refactoring that made it easier for me to figure out what the generators are doing, and some cleanup.