### PR TITLE
Fix bug where combining of strokes could fail during translation.

### DIFF
--- a/source/LottieToWinComp/LottieToWinCompTranslator.cs
+++ b/source/LottieToWinComp/LottieToWinCompTranslator.cs
@@ -1400,6 +1400,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                 if (a.StrokeKind != b.StrokeKind)
                 {
                     _owner._issues.MultipleStrokesIsNotSupported();
+                    return b;
                 }
 
                 switch (a.StrokeKind)


### PR DESCRIPTION
We were correctly recognizing that we couldn't compose strokes of different kinds, but then we tried to compose them anyway which would result in a failed cast.