### PR TITLE
Use the most precise version of "next float".

### DIFF
--- a/source/LottieToWinComp/Float32.cs
+++ b/source/LottieToWinComp/Float32.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         /// Does not handle NaN or Infinity.
         /// </summary>
         /// <returns>The largest value which is less than <paramref name="value"/>.</returns>
-        internal static float Decremented(float value)
+        internal static float PreviousSmallerThan(float value)
         {
             var temp = new Float32(value);
 
@@ -41,7 +41,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         /// Does not handle NaN or Infinity.
         /// </summary>
         /// <returns>The smallest value which is larger than <paramref name="value"/>.</returns>
-        internal static float Incremented(float value)
+        internal static float NextLargerThan(float value)
         {
             var temp = new Float32(value);
 


### PR DESCRIPTION
Windows.UI.Composition key frames need to have distinct progress values. Sometimes during translation we need to place a key frame as close as possible to a previous key frame. Before this change we did that by adding a small constant however that doesn't always give the smallest possible increment (because the increment depends on the exponent of the float, and because the constant we chose was conservative). With this change we actually calculate the next float value, so it is guaranteed to be as close as possible to the previous key frame.