### PR TITLE
Update the LottieGen readme to refer to 6.0.0 and 6.1.0

### DIFF
--- a/LottieGen/README.md
+++ b/LottieGen/README.md
@@ -13,16 +13,20 @@ The latest release version can be [installed from NuGet](https://www.nuget.org/p
 
 A specific version can be installed from NuGet:
 
-    dotnet tool install -g LottieGen --version 5.1.1
+    dotnet tool install -g LottieGen --version 6.0.0
 
 CI builds can be [installed from MyGet](https://dotnet.myget.org/feed/uwpcommunitytoolkit/package/nuget/LottieGen):
 
-    dotnet tool install -g LottieGen --add-source https://dotnet.myget.org/F/uwpcommunitytoolkit/api/v3/index.json --version 5.1.1-build.11
+    dotnet tool install -g LottieGen --add-source https://dotnet.myget.org/F/uwpcommunitytoolkit/api/v3/index.json --version 6.1.0-build.3
 
 Local builds can be installed from your bin\nupkg directory:
 
-    dotnet tool install -g LottieGen --add-source f:\GitHub\Lottie-Windows\bin\nupkg --version 5.1.1-build.11.g31523b44e4
-    
+    dotnet tool install -g LottieGen --add-source f:\GitHub\Lottie-Windows\bin\nupkg --version 6.1.0-build.11.g31523b44e4
+
+Local builds can be run directly:
+
+    dotnet f:\GitHub\Lottie-Windows\LottieGen\bin\AnyCpu\Debug\netcoreapp2.2\lottiegen.dll
+
 ## Updating
     dotnet tool update -g LottieGen
 


### PR DESCRIPTION
6.0.0 is out, and 6.1.0 is what we're working on, so the docs should refer to them.
I also added directions for running lottiegen without installing.