### PR TITLE
Adding a metadata facility to CompositionObject.

### DIFF
--- a/source/LottieToWinComp/LottieToWinCompTranslator.cs
+++ b/source/LottieToWinComp/LottieToWinCompTranslator.cs
@@ -4242,9 +4242,17 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                 _shapeOrVisual = shapeOrVisual;
             }
 
-            public string LongDescription { get => _shapeOrVisual.LongDescription; set => _shapeOrVisual.LongDescription = value; }
+            public string LongDescription
+            {
+                get => ((IDescribable)_shapeOrVisual).LongDescription;
+                set => ((IDescribable)_shapeOrVisual).LongDescription = value;
+            }
 
-            public string ShortDescription { get => _shapeOrVisual.ShortDescription; set => _shapeOrVisual.ShortDescription = value; }
+            public string ShortDescription
+            {
+                get => ((IDescribable)_shapeOrVisual).ShortDescription;
+                set => ((IDescribable)_shapeOrVisual).ShortDescription = value;
+            }
 
             public CompositionObjectType Type => _shapeOrVisual.Type;
 

--- a/source/UIData/CodeGen/InstantiatorGeneratorBase.cs
+++ b/source/UIData/CodeGen/InstantiatorGeneratorBase.cs
@@ -1771,7 +1771,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
                     builder.WriteLine($"{Var} shapes = result{Deref}Shapes;");
                     foreach (var shape in obj.Shapes)
                     {
-                        builder.WriteComment(shape.ShortDescription);
+                        builder.WriteComment(((IDescribable)shape).ShortDescription);
                         builder.WriteLine($"shapes{Deref}{IListAdd}({CallFactoryFromFor(node, shape)});");
                     }
                 }

--- a/source/UIData/Serialization/CompositionObjectDgmlSerializer.cs
+++ b/source/UIData/Serialization/CompositionObjectDgmlSerializer.cs
@@ -207,8 +207,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.Tools
             {
                 GroupNode childGroup;
                 var childObject = child.Object as CompositionObject;
-                var childDescription = (childObject != null && !string.IsNullOrWhiteSpace(childObject.ShortDescription))
-                    ? childObject.ShortDescription
+                var childDescription = (childObject != null && !string.IsNullOrWhiteSpace(ShortDescription(childObject)))
+                    ? ShortDescription(childObject)
                     : string.Empty;
 
                 // Start a new group for the child if:
@@ -246,6 +246,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.Tools
         string GenerateId() => $"id{_idGenerator++}";
 
         string GenerateGroupId() => $"gid{_groupIdGenerator++}";
+
+        static string ShortDescription(IDescribable describable) => describable.ShortDescription;
 
         sealed class ObjectData : Graph.Node<ObjectData>
         {

--- a/source/WinCompData/CompositionAnimation.cs
+++ b/source/WinCompData/CompositionAnimation.cs
@@ -26,8 +26,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData
 
                 Target = other.Target;
 
-                LongDescription = other.LongDescription;
-                ShortDescription = other.ShortDescription;
+                ((IDescribable)this).LongDescription = ((IDescribable)other).LongDescription;
+                ((IDescribable)this).ShortDescription = ((IDescribable)other).ShortDescription;
                 Comment = other.Comment;
             }
         }

--- a/source/WinCompData/CompositionObject.cs
+++ b/source/WinCompData/CompositionObject.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData
         /// <param name="value">The value of the metadata.</param>
         public void SetMetadata(in Guid key, object value)
         {
-            if (_metadata == null)
+            if (_metadata is null)
             {
                 _metadata = new SortedDictionary<Guid, object>();
             }
@@ -63,7 +63,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData
         /// <returns>The metadata, or null.</returns>
         public object TryGetMetadata(in Guid key)
         {
-            if (_metadata != null && _metadata.TryGetValue(key, out var result))
+            if (_metadata is object && _metadata.TryGetValue(key, out var result))
             {
                 return result;
             }


### PR DESCRIPTION
This adds a facility for arbitrary metadata to be added to CompositionObject and uses it for the IDescribable interface.
The metadata facility is being added so that we can smuggle information from names in LottieData through to the optimizer and code generator.
I also made the IDescribable implementation on CompositionObject explicitly implemented so that it doesn't pollute the API surface of CompositionObject. The goal is to have only one extra concept in WinCompData, i.e. classes look just like the real WinComp classes, except with one addition: metadata. IDescribable + metadata would have been 2 concepts.
And the IDescribable storage is now implemented by the metadata store, which should result in space savings at runtime as we now reserve only one pointer (for the metadata) rather than one for the LongDescription and another for the ShortDescription.