### PR TITLE
Remove codegen functionality from LottieViewer.

### DIFF
--- a/LottieViewer/MainPage.xaml
+++ b/LottieViewer/MainPage.xaml
@@ -118,14 +118,6 @@
                     </Button.Flyout>
                     &#xE7BA;
                 </Button>
-                <!--  Save as: e792. Save: e74e  -->
-                <Button Click="SaveFile_Click"
-                        IsEnabled="{x:Bind _stage.Player.IsAnimatedVisualLoaded, Mode=OneWay}"
-                        Style="{StaticResource ControlsButtonStyle}"
-                        ToolTipService.ToolTip="Save Lottie as code">
-                    &#xe74e;
-                </Button>
-
             </StackPanel>
 
         </Grid>


### PR DESCRIPTION
LottieGen has a lot of options for code gen. LottieViewer doesn't have a good way to make those options available. So rather than making LottieViewer more complicated, I'm removing the codegen functionality completely. When you need to codegen, use LottieGen - it's waaaaaay better.