### PR TITLE
Pass Lottie metadata (frame rate, etc) through translator to the code generators.

### DIFF
--- a/LottieGen/LottieFileProcessor.cs
+++ b/LottieGen/LottieFileProcessor.cs
@@ -402,6 +402,7 @@ sealed class LottieFileProcessor
         (string csText, IEnumerable<Uri> assetList) = CSharpInstantiatorGenerator.CreateFactoryCode(
                 _className,
                 _translationResults.Select(tr => ((CompositionObject)tr.RootVisual, tr.MinimumRequiredUapVersion)).ToArray(),
+                _translationResults[0].SourceMetadata,
                 (float)_lottieComposition.Width,
                 (float)_lottieComposition.Height,
                 _lottieComposition.Duration,
@@ -441,6 +442,7 @@ sealed class LottieFileProcessor
         (string cppText, string hText, IEnumerable<Uri> assetList) = CxInstantiatorGenerator.CreateFactoryCode(
                 _className,
                 _translationResults.Select(tr => ((CompositionObject)tr.RootVisual, tr.MinimumRequiredUapVersion)).ToArray(),
+                _translationResults[0].SourceMetadata,
                 (float)_lottieComposition.Width,
                 (float)_lottieComposition.Height,
                 _lottieComposition.Duration,

--- a/LottieViewer/MainPage.xaml.cs
+++ b/LottieViewer/MainPage.xaml.cs
@@ -364,12 +364,6 @@ namespace LottieViewer
             yield return Tuple.Create("Aspect ratio", $"{aspectRatio.Item1.ToString("0.###")}:{aspectRatio.Item2.ToString("0.###")}");
             yield return Tuple.Create("Size", $"{diagnostics.LottieWidth} x {diagnostics.LottieHeight}");
 
-            //yield return Tuple.Create("Version", diagnostics.LottieVersion);
-            //yield return Tuple.Create("Read", MSecs(diagnostics.ReadTime));
-            //yield return Tuple.Create("Parse", MSecs(diagnostics.ParseTime));
-            //yield return Tuple.Create("Validation", MSecs(diagnostics.ValidationTime));
-            //yield return Tuple.Create("Translation", MSecs(diagnostics.TranslationTime));
-            //yield return Tuple.Create("Instantiation", MSecs(diagnostics.InstantiationTime));
             foreach (var marker in diagnostics.Markers)
             {
                 yield return Tuple.Create("Marker", $"{marker.Key}: {marker.Value.ToString("0.0###")}");

--- a/dlls/UIData/UIData.dll.csproj
+++ b/dlls/UIData/UIData.dll.csproj
@@ -10,6 +10,7 @@
   <Import Project="..\..\source\UIData\UIData.projitems" Label="Shared" />
 
   <ItemGroup>
+    <ProjectReference Include="..\GenericData\GenericData.dll.csproj" />
     <ProjectReference Include="..\WinCompData\WinCompData.dll.csproj" />
     <ProjectReference Include="..\WinUIXamlMediaData\WinUIXamlMediaData.dll.csproj" />
   </ItemGroup>

--- a/source/Lottie/LottieVisualDiagnostics.cs
+++ b/source/Lottie/LottieVisualDiagnostics.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Toolkit.Uwp.UI.Lottie.GenericData;
 using Microsoft.Toolkit.Uwp.UI.Lottie.LottieData;
 using Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen;
 using Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData;
@@ -90,6 +91,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
             return CSharpInstantiatorGenerator.CreateFactoryCode(
                 SuggestedClassName,
                 new (CompositionObject, uint)[] { (RootVisual, RequiredUapVersion) },
+                SourceMetadata,
                 (float)LottieComposition.Width,
                 (float)LottieComposition.Height,
                 LottieComposition.Duration,
@@ -108,6 +110,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
             (string cppText, string hText, IEnumerable<Uri> assetList) generatedCode = CxInstantiatorGenerator.CreateFactoryCode(
                 SuggestedClassName,
                 new (CompositionObject, uint)[] { (RootVisual, RequiredUapVersion) },
+                SourceMetadata,
                 (float)LottieComposition.Width,
                 (float)LottieComposition.Height,
                 LottieComposition.Duration,
@@ -122,6 +125,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
 
         // Holds the parsed LottieComposition. Only used if one of the codegen or XML options was selected.
         internal LottieComposition LottieComposition { get; set; }
+
+        internal GenericDataMap SourceMetadata { get; set; }
 
         // Holds the translated Visual. Only used if one of the codegen or XML options was selected.
         internal WinCompData.Visual RootVisual { get; set; }

--- a/source/Lottie/LottieVisualDiagnostics.cs
+++ b/source/Lottie/LottieVisualDiagnostics.cs
@@ -6,8 +6,6 @@ using System;
 using System.Collections.Generic;
 using Microsoft.Toolkit.Uwp.UI.Lottie.GenericData;
 using Microsoft.Toolkit.Uwp.UI.Lottie.LottieData;
-using Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen;
-using Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData;
 
 namespace Microsoft.Toolkit.Uwp.UI.Lottie
 {
@@ -19,25 +17,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
     public sealed class LottieVisualDiagnostics
     {
         public string FileName { get; internal set; } = string.Empty;
-
-        public string SuggestedFileName =>
-            string.IsNullOrWhiteSpace(FileName)
-                ? "MyComposition"
-                : System.IO.Path.GetFileNameWithoutExtension(FileName);
-
-        public string SuggestedClassName
-        {
-            get
-            {
-                string result = null;
-                if (LottieComposition != null)
-                {
-                    result = InstantiatorGeneratorBase.TrySynthesizeClassName(LottieComposition.Name);
-                }
-
-                return result ?? InstantiatorGeneratorBase.TrySynthesizeClassName(SuggestedFileName);
-            }
-        }
 
         public TimeSpan Duration => LottieComposition?.Duration ?? TimeSpan.Zero;
 
@@ -63,63 +42,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
 
         public double LottieHeight => LottieComposition?.Height ?? 0;
 
-        public string LottieDetails => DescribeLottieComposition();
-
-        public string LottieVersion => LottieComposition?.Version.ToString() ?? string.Empty;
-
         /// <summary>
         /// Gets the options that were set on the <see cref="LottieVisualSource"/> when it
         /// produced this diagnostics object.
         /// </summary>
         public LottieVisualOptions Options { get; internal set; }
-
-        public string GenerateLottieXml()
-        {
-            if (LottieComposition == null) { return null; }
-            return LottieData.Serialization.LottieCompositionXmlSerializer.ToXml(LottieComposition).ToString();
-        }
-
-        public string GenerateWinCompXml()
-        {
-            return WinCompData.Tools.CompositionObjectXmlSerializer.ToXml(RootVisual).ToString();
-        }
-
-        public string GenerateCSharpCode()
-        {
-            if (LottieComposition == null) { return null; }
-
-            return CSharpInstantiatorGenerator.CreateFactoryCode(
-                SuggestedClassName,
-                new (CompositionObject, uint)[] { (RootVisual, RequiredUapVersion) },
-                SourceMetadata,
-                (float)LottieComposition.Width,
-                (float)LottieComposition.Height,
-                LottieComposition.Duration,
-                disableFieldOptimization: false).csText;
-        }
-
-        public void GenerateCxCode(string headerFileName, out string cppText, out string hText)
-        {
-            if (LottieComposition == null)
-            {
-                cppText = null;
-                hText = null;
-                return;
-            }
-
-            (string cppText, string hText, IEnumerable<Uri> assetList) generatedCode = CxInstantiatorGenerator.CreateFactoryCode(
-                SuggestedClassName,
-                new (CompositionObject, uint)[] { (RootVisual, RequiredUapVersion) },
-                SourceMetadata,
-                (float)LottieComposition.Width,
-                (float)LottieComposition.Height,
-                LottieComposition.Duration,
-                headerFileName,
-                disableFieldOptimization: false);
-
-            cppText = generatedCode.cppText;
-            hText = generatedCode.hText;
-        }
 
         public KeyValuePair<string, double>[] Markers { get; internal set; } = Array.Empty<KeyValuePair<string, double>>();
 
@@ -152,19 +79,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
                 ValidationTime = ValidationTime,
                 TranslationIssues = TranslationIssues,
             };
-
-        // Creates a string that describes the Lottie.
-        string DescribeLottieComposition()
-        {
-            if (LottieComposition == null) { return null; }
-
-            var stats = new LottieData.Tools.Stats(LottieComposition);
-
-            return $"LottieVisualSource w={LottieComposition.Width} h={LottieComposition.Height} " +
-                $"layers: precomp={stats.PreCompLayerCount} solid={stats.SolidLayerCount} " +
-                $"image={stats.ImageLayerCount} null={stats.NullLayerCount} " +
-                $"shape={stats.ShapeLayerCount} text={stats.TextLayerCount}";
-        }
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
     }
 }

--- a/source/Lottie/LottieVisualSource.cs
+++ b/source/Lottie/LottieVisualSource.cs
@@ -14,6 +14,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading.Tasks;
+using Microsoft.Toolkit.Uwp.UI.Lottie.GenericData;
 using Microsoft.Toolkit.Uwp.UI.Lottie.LottieData;
 using Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization;
 using Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp;
@@ -398,6 +399,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
 
                 // Translating large Lotties can take significant time. Do it on another thread.
                 WinCompData.Visual wincompDataRootVisual = null;
+                GenericDataMap sourceMetadata = null;
                 uint requiredUapVersion = 0;
                 var optimizationEnabled = _owner.Options.HasFlag(LottieVisualOptions.Optimize);
 
@@ -411,6 +413,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
                         addCodegenDescriptions: true);
 
                     wincompDataRootVisual = translationResult.RootVisual;
+                    sourceMetadata = translationResult.SourceMetadata;
                     requiredUapVersion = translationResult.MinimumRequiredUapVersion;
 
                     if (diagnostics != null)
@@ -446,6 +449,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
                     {
                         // Save the root visual so diagnostics can generate XML and codegen.
                         diagnostics.RootVisual = wincompDataRootVisual;
+                        diagnostics.SourceMetadata = sourceMetadata;
                         diagnostics.RequiredUapVersion = requiredUapVersion;
                     }
 

--- a/source/UIData/CodeGen/CSharpInstantiatorGenerator.cs
+++ b/source/UIData/CodeGen/CSharpInstantiatorGenerator.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using Microsoft.Toolkit.Uwp.UI.Lottie.GenericData;
 using Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData;
 using Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Mgcg;
 using Microsoft.Toolkit.Uwp.UI.Lottie.WinUIXamlMediaData;
@@ -24,6 +25,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
             string className,
             Vector2 size,
             IReadOnlyList<(CompositionObject graphRoot, uint requiredUapVersion)> graphs,
+            GenericDataMap sourceMetadata,
             TimeSpan duration,
             bool setCommentProperties,
             bool disableFieldOptimization,
@@ -32,6 +34,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
                   className: className,
                   compositionDeclaredSize: size,
                   graphs: graphs,
+                  sourceMetadata: sourceMetadata,
                   duration: duration,
                   setCommentProperties: setCommentProperties,
                   disableFieldOptimization: disableFieldOptimization,
@@ -48,6 +51,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
         public static (string csText, IEnumerable<Uri> assetList) CreateFactoryCode(
             string className,
             IReadOnlyList<(CompositionObject graphRoot, uint requiredUapVersion)> graphs,
+            GenericDataMap sourceMetadata,
             float width,
             float height,
             TimeSpan duration,
@@ -57,6 +61,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
                                 className: className,
                                 size: new Vector2(width, height),
                                 graphs: graphs,
+                                sourceMetadata: sourceMetadata,
                                 duration: duration,
                                 setCommentProperties: false,
                                 disableFieldOptimization: disableFieldOptimization,

--- a/source/UIData/CodeGen/CxInstantiatorGenerator.cs
+++ b/source/UIData/CodeGen/CxInstantiatorGenerator.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using System.Text;
+using Microsoft.Toolkit.Uwp.UI.Lottie.GenericData;
 using Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData;
 using Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Mgcg;
 using Microsoft.Toolkit.Uwp.UI.Lottie.WinUIXamlMediaData;
@@ -26,6 +27,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
             string className,
             Vector2 size,
             IReadOnlyList<(CompositionObject graphRoot, uint requiredUapVersion)> graphs,
+            GenericDataMap sourceMetadata,
             TimeSpan duration,
             bool setCommentProperties,
             bool disableFieldOptimization,
@@ -35,6 +37,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
                   className: className,
                   compositionDeclaredSize: size,
                   graphs: graphs,
+                  sourceMetadata: sourceMetadata,
                   duration: duration,
                   setCommentProperties: setCommentProperties,
                   disableFieldOptimization: false,
@@ -52,6 +55,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
         public static (string cppText, string hText, IEnumerable<Uri> assetList) CreateFactoryCode(
             string className,
             IReadOnlyList<(CompositionObject graphRoot, uint requiredUapVersion)> graphs,
+            GenericDataMap sourceMetadata,
             float width,
             float height,
             TimeSpan duration,
@@ -62,6 +66,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
                 className: className,
                 size: new Vector2(width, height),
                 graphs: graphs,
+                sourceMetadata: sourceMetadata,
                 duration: duration,
                 disableFieldOptimization: disableFieldOptimization,
                 setCommentProperties: false,

--- a/source/UIData/CodeGen/InstantiatorGeneratorBase.cs
+++ b/source/UIData/CodeGen/InstantiatorGeneratorBase.cs
@@ -541,9 +541,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
 
         void WritePopulateJsonObject(CodeBuilder builder, GenericDataMap jsonData, string objectName, int recursionLevel)
         {
-            foreach ((var key, var value) in jsonData)
+            foreach (var pair in jsonData)
             {
-                var k = _stringifier.String(key);
+                var k = _stringifier.String(pair.Key);
+                var value = pair.Value;
+
                 if (value is null)
                 {
                     builder.WriteLine($"{objectName}{Deref}Add({k}, JsonValue{Deref}CreateNullValue());");

--- a/source/UIData/CodeGen/InstantiatorGeneratorBase.cs
+++ b/source/UIData/CodeGen/InstantiatorGeneratorBase.cs
@@ -427,13 +427,15 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
         }
 
         string String(GenericDataObject value)
-            => value.Type switch
+        {
+            switch (value.Type)
             {
-                GenericDataObjectType.Bool => _stringifier.Bool(((GenericDataBool)value).Value),
-                GenericDataObjectType.Number => _stringifier.Double(((GenericDataNumber)value).Value),
-                GenericDataObjectType.String => _stringifier.String(((GenericDataString)value).Value),
-                _ => throw new InvalidOperationException(),
-            };
+                case GenericDataObjectType.Bool: return _stringifier.Bool(((GenericDataBool)value).Value);
+                case GenericDataObjectType.Number: return _stringifier.Double(((GenericDataNumber)value).Value);
+                case GenericDataObjectType.String: return _stringifier.String(((GenericDataString)value).Value);
+                default: throw new InvalidOperationException();
+            }
+        }
 
         string ScopeResolve => _stringifier.ScopeResolve;
 

--- a/source/UIData/CodeGen/Stringifier.cs
+++ b/source/UIData/CodeGen/Stringifier.cs
@@ -53,6 +53,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
                 ? value.ToString("0", CultureInfo.InvariantCulture)
                 : value.ToString("G9", CultureInfo.InvariantCulture) + "F";
 
+        public virtual string Double(double value) =>
+            Math.Floor(value) == value
+                ? value.ToString("0", CultureInfo.InvariantCulture)
+                : value.ToString("G15", CultureInfo.InvariantCulture);
+
         public virtual string Int32(int value) => value.ToString();
 
         public virtual string Int64(long value) => value.ToString();


### PR DESCRIPTION
Add ability to convert GenericData object to code-genned Windows.Data.Json objects.
   
This change passes the data through but doesn't yet change the output of the code generators. That will come soon when we figure out what clients would like to have (e.g. should it be JSON, or some specialized properties).

