### PR TITLE
Adding a property bindings language parser.

### DIFF
--- a/source/LottieToWinComp/LottieToWinComp.projitems
+++ b/source/LottieToWinComp/LottieToWinComp.projitems
@@ -14,6 +14,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)LottieToMultiVersionWinCompTranslator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)LottieToWinCompTranslator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MultiVersionTranslationResult.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)PropertyBindingsParser.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TranslationContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TranslationIssue.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TranslationIssues.cs" />

--- a/source/LottieToWinComp/LottieToWinCompTranslator.cs
+++ b/source/LottieToWinComp/LottieToWinCompTranslator.cs
@@ -2832,7 +2832,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         }
 
         CompositionColorBrush TranslateSolidColorFill(TranslationContext context, SolidColorFill shapeFill, TrimmedAnimatable<double> opacityPercent)
-            => TranslateSolidColor(context, shapeFill.Color, shapeFill.OpacityPercent, opacityPercent);
+        {
+            // Read property bindings embedded into the name of the fill.
+            // TODO: Currently the bindings are ignored and the parsing is being done just to exercise the parser.
+            var propertyBindings = PropertyBindingsParser.ParseBindings(shapeFill.Name);
+            return TranslateSolidColor(context, shapeFill.Color, shapeFill.OpacityPercent, opacityPercent);
+        }
 
         CompositionLinearGradientBrush TranslateLinearGradientFill(
             TranslationContext context,

--- a/source/LottieToWinComp/PropertyBindingsParser.cs
+++ b/source/LottieToWinComp/PropertyBindingsParser.cs
@@ -1,0 +1,83 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
+{
+    static class PropertyBindingsParser
+    {
+        // Property binding language definition
+        // ====================================
+        // Property bindings are lists of property-name+binding-name pairs.
+        // They are specified using using a regular language (i.e. parseable
+        // by a regular expression) that is designed to look similar to CSS var
+        // functions. Just like CSS, the property bindings are enclosed within
+        // curly braces and multiple property bindings are separated by semicolons.
+        //
+        // <PropertyBindings>    ::= "{" <OptWS> <PropertyBindingList> <OptWS> "}"
+        // <PropertyBindingList> ::= <PropertyBinding> | <PropertyBinding> <OptWS> ";" <OptWS> <PropertyBindingList>
+        // <PropertyBinding>     ::= <PropertyName> <OptWS> ":" <OptWS> "var(" <OptWS> <BindingName> <OptWS> ")"
+        // <PropertyName>        ::= <Identifier>
+        // <BindingName>         ::= <Identifier>
+        // <OptWS>               ::= <Whitespace> <OptWS> | ""
+        // <Identifier>          ::= a word starting with an alpha character.
+        // ------------------------------------
+        // Example: "{ color :var( Foreground);color1:var(Foreground1) ; color3:var(L33t )   }"
+        // ------------------------------------
+        const string PropertyNameSelector = "PropertyName";
+        const string BindingNameSelector = "BindingName";
+
+        const string PropertyBindingRegex =
+
+            // PropertyName  followed by optional whitespace.
+            @"(?<" + PropertyNameSelector + @">\D\w*)\s*" +
+
+            // ':'           followed by optional whitespace.
+            @"\:\s*" +
+
+            // 'var('        followed by optional whitespace.
+            @"var\(\s*" +
+
+            // BindingName   followed by optional whitespace.
+            @"(?<" + BindingNameSelector + @">\D\w*)\s*" +
+
+            // ')'           followed by optional whitespace.
+            @"\)\s*";
+
+        const string PropertyBindingsListRegex =
+
+            // At least one property binding.
+            PropertyBindingRegex +
+
+            // Optional: more property bindings separated by semicolons
+            @"(;\s*" + PropertyBindingRegex + @"\s*)*";
+
+        static readonly Regex s_regex = new Regex(@"{\s*" + PropertyBindingsListRegex + @"}");
+
+        // Parses property bindings from the given string.
+        internal static (string propertyName, string bindingName)[] ParseBindings(string str)
+        {
+            if (string.IsNullOrEmpty(str))
+            {
+                return Array.Empty<(string, string)>();
+            }
+
+            var matches = s_regex.Matches(str);
+            if (matches.Count == 0)
+            {
+                return Array.Empty<(string, string)>();
+            }
+
+            return
+                (from Match match in matches
+                 from pair in match.Groups[PropertyNameSelector].Captures
+                                   .Zip(match.Groups[BindingNameSelector].Captures, (p, b) => (p.Value, b.Value))
+                 select pair).ToArray();
+        }
+    }
+}

--- a/source/LottieToWinComp/PropertyBindingsParser.cs
+++ b/source/LottieToWinComp/PropertyBindingsParser.cs
@@ -14,8 +14,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         // Property binding language definition
         // ====================================
         // Property bindings are lists of property-name+binding-name pairs.
-        // They are specified using using a regular language (i.e. parseable
-        // by a regular expression) that is designed to look similar to CSS var
+        // They are specified using a regular language (i.e. parseable by a
+        // regular expression) that is designed to look similar to CSS var
         // functions. Just like CSS, the property bindings are enclosed within
         // curly braces and multiple property bindings are separated by semicolons.
         //
@@ -29,8 +29,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         // ------------------------------------
         // Example: "{ color :var( Foreground);color1:var(Foreground1) ; color3:var(L33t )   }"
         // ------------------------------------
-        const string PropertyNameSelector = "PropertyName";
-        const string BindingNameSelector = "BindingName";
+        const string PropertyNameSelector = "P";
+        const string BindingNameSelector = "B";
 
         const string PropertyBindingRegex =
 


### PR DESCRIPTION
The parser is designed to allow designers to embed information about how colors should be hooked up to theme colors in the app or OS on which the Lottie runs.
Currently the parser is hooked up to parse property bindings from solid color fills, but it doesn't do anything with the result - this is just to get some coverage on it.
Eventually the property bindings will results in generated code that puts the given color in a CompositionPropertySet property and binds it appropriately so that clients can change the color at runtime.