### PR TITLE
Enable binding of SolidColorFill to property set values.

### DIFF
--- a/source/LottieToWinComp/ExpressionFactory.cs
+++ b/source/LottieToWinComp/ExpressionFactory.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Linq;
 using Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions;
-
+using Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Wui;
 using Sn = System.Numerics;
 
 namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
@@ -21,6 +21,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         internal static readonly Expression RootProgress = Scalar($"{RootName}.{LottieToWinCompTranslator.ProgressPropertyName}");
         internal static readonly Expression MaxTStartTEnd = Max(s_myTStart, s_myTEnd);
         internal static readonly Expression MinTStartTEnd = Min(s_myTStart, s_myTEnd);
+        internal static readonly Expression MyOpacity = Scalar("my.Opacity");
         internal static readonly Expression MyPosition2 = Vector2("my.Position");
         internal static readonly Expression HalfSize2 = Divide(Vector2("my.Size"), Vector2(2, 2));
 
@@ -56,8 +57,22 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             return result;
         }
 
-        // The value of a Color property on the root.
-        internal static Expression RootColorProperty(string propertyName) => Color($"{RootName}.{propertyName}");
+        internal static Expression BoundColor(string bindingName, double opacity)
+            => Vector4AsColorMultipliedByOpacity(RootColor4Property(bindingName), Scalar(opacity));
+
+        internal static Expression BoundColorWithAnimatedOpacity(string bindingName)
+            => Vector4AsColorMultipliedByOpacity(RootColor4Property(bindingName), MyOpacity);
+
+        // The value of a Color property stored as a Vector4 on the root.
+        static Expression RootColor4Property(string propertyName)
+            => Vector4($"{RootName}.{propertyName}");
+
+        static Expression Vector4AsColorMultipliedByOpacity(Expression colorAsVector4, Expression opacity)
+            => ColorRGB(
+                r: X(colorAsVector4),
+                g: Y(colorAsVector4),
+                b: Z(colorAsVector4),
+                a: Multiply(W(colorAsVector4), opacity));
 
         ExpressionFactory()
         {

--- a/source/LottieToWinComp/LottieToWinCompTranslator.cs
+++ b/source/LottieToWinComp/LottieToWinCompTranslator.cs
@@ -2828,7 +2828,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             }
         }
 
-        CompositionColorBrush TranslateSolidColor(TranslationContext context, Animatable<Color> color, Animatable<double> opacityPercentA, TrimmedAnimatable<double> opacityPercentB)
+        CompositionColorBrush TranslateSolidColor(
+            TranslationContext context,
+            Animatable<Color> color,
+            Animatable<double> opacityPercentA,
+            TrimmedAnimatable<double> opacityPercentB)
         {
             return CreateAnimatedColorBrush(
                 context,
@@ -2838,21 +2842,25 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                 opacityPercentB);
         }
 
-        // Parses the given binding string, and return the binding name for the given property, or
-        // null if not found. Returns the first matching binding name.
+        // Parses the given binding string and returns the binding name for the given property, or
+        // null if not found. Returns the first matching binding name (there could be more than
+        // one match).
         // This is used to retrieve property bindings from binding expressions embedded in Lottie
         // object names.
-        static string FindingBindingNameForProperty(string bindingString, string propertyName)
+        static string FindFirstBindingNameForProperty(string bindingString, string propertyName)
             => PropertyBindingsParser.ParseBindings(bindingString)
                 .Where(p => p.propertyName == propertyName)
                 .Select(p => p.bindingName).FirstOrDefault();
 
-        CompositionColorBrush TranslateSolidColorFill(TranslationContext context, SolidColorFill shapeFill, TrimmedAnimatable<double> opacityPercent)
+        CompositionColorBrush TranslateSolidColorFill(
+            TranslationContext context,
+            SolidColorFill shapeFill,
+            TrimmedAnimatable<double> opacityPercent)
         {
             // Read property bindings embedded into the name of the fill.
             if (_translatePropertyBindings)
             {
-                var bindingName = FindingBindingNameForProperty(shapeFill.Name, "Color");
+                var bindingName = FindFirstBindingNameForProperty(shapeFill.Name, "Color");
                 if (bindingName is string)
                 {
                     // The fill is bound to a property name.

--- a/source/UIData/Tools/Optimizer.cs
+++ b/source/UIData/Tools/Optimizer.cs
@@ -346,6 +346,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.Tools
         {
             target.LongDescription = source.LongDescription;
             target.ShortDescription = source.ShortDescription;
+            target.Name = source.Name;
         }
 
         void InitializeCompositionObject<T>(T source, T target)
@@ -506,6 +507,16 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.Tools
             foreach (var prop in obj.Vector2Properties)
             {
                 result.InsertVector2(prop.Key, prop.Value);
+            }
+
+            foreach (var prop in obj.Vector3Properties)
+            {
+                result.InsertVector3(prop.Key, prop.Value);
+            }
+
+            foreach (var prop in obj.Vector4Properties)
+            {
+                result.InsertVector4(prop.Key, prop.Value);
             }
 
             StartAnimationsAndFreeze(obj, result);

--- a/source/UIDataCodeGen/CodeGen/InstantiatorGeneratorBase.cs
+++ b/source/UIDataCodeGen/CodeGen/InstantiatorGeneratorBase.cs
@@ -1421,6 +1421,16 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
                     {
                         builder.WriteLine($"propertySet{Deref}InsertVector2({String(prop.Key)}, {Vector2(prop.Value)});");
                     }
+
+                    foreach (var prop in propertySet.Vector3Properties)
+                    {
+                        builder.WriteLine($"propertySet{Deref}InsertVector3({String(prop.Key)}, {Vector3(prop.Value)});");
+                    }
+
+                    foreach (var prop in propertySet.Vector4Properties)
+                    {
+                        builder.WriteLine($"propertySet{Deref}InsertVector4({String(prop.Key)}, {Vector4(prop.Value)});");
+                    }
                 }
             }
 

--- a/source/UIDataCodeGen/CodeGen/NodeNamer.cs
+++ b/source/UIDataCodeGen/CodeGen/NodeNamer.cs
@@ -208,7 +208,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
                         else
                         {
                             // The color is bound to a property set.
-                            result = "BoundColorBrush";
+                            var objectName = ((IDescribable)brush).Name;
+
+                            result = string.IsNullOrWhiteSpace(objectName)
+                                ? "BoundColorBrush"
+                                : $"{objectName}ColorBrush";
                         }
                     }
                     else

--- a/source/WinCompData/CompositionObject.cs
+++ b/source/WinCompData/CompositionObject.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData
         // Keys used to identify the short description and long description metadata.
         static readonly Guid s_shortDescriptionMetadataKey = new Guid("AF01D303-5572-4540-A4AC-E48F1394E1D1");
         static readonly Guid s_longDescriptionMetadataKey = new Guid("63514254-2B3E-4794-B01D-9F67D5946A7E");
+        static readonly Guid s_nameMetadataKey = new Guid("6EB18A31-FA33-43B9-8EE1-57B489DC3404");
 
         readonly ListOfNeverNull<Animator> _animators = new ListOfNeverNull<Animator>();
 
@@ -93,6 +94,15 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData
         {
             get => (string)TryGetMetadata(in s_shortDescriptionMetadataKey);
             set => SetMetadata(in s_shortDescriptionMetadataKey, value);
+        }
+
+        /// <summary>
+        /// Gets or sets a name for the object. This may be used for variable names in generated code.
+        /// </summary>
+        string IDescribable.Name
+        {
+            get => (string)TryGetMetadata(in s_nameMetadataKey);
+            set => SetMetadata(in s_nameMetadataKey, value);
         }
 
         public CompositionPropertySet Properties { get; }

--- a/source/WinCompData/CompositionPath.cs
+++ b/source/WinCompData/CompositionPath.cs
@@ -21,9 +21,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData
         public Wg.IGeometrySource2D Source { get; }
 
         /// <inheritdoc/>
-        public string LongDescription { get; set; }
+        string IDescribable.LongDescription { get; set; }
 
         /// <inheritdoc/>
-        public string ShortDescription { get; set; }
+        string IDescribable.ShortDescription { get; set; }
+
+        /// <inheritdoc/>
+        string IDescribable.Name { get; set; }
     }
 }

--- a/source/WinCompData/CompositionPropertySet.cs
+++ b/source/WinCompData/CompositionPropertySet.cs
@@ -22,6 +22,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData
         PropertyBag<Color> _colorProperties;
         PropertyBag<float> _scalarProperties;
         PropertyBag<Vector2> _vector2Properties;
+        PropertyBag<Vector3> _vector3Properties;
+        PropertyBag<Vector4> _vector4Properties;
 
         internal CompositionPropertySet(CompositionObject owner)
         {
@@ -36,17 +38,29 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData
 
         public void InsertVector2(string propertyName, Vector2 value) => Insert(propertyName, in value, ref _vector2Properties);
 
+        public void InsertVector3(string propertyName, Vector3 value) => Insert(propertyName, in value, ref _vector3Properties);
+
+        public void InsertVector4(string propertyName, Vector4 value) => Insert(propertyName, in value, ref _vector4Properties);
+
         public CompositionGetValueStatus TryGetColor(string propertyName, out Color value) => TryGet(propertyName, ref _colorProperties, out value);
 
         public CompositionGetValueStatus TryGetScalar(string propertyName, out float value) => TryGet(propertyName, ref _scalarProperties, out value);
 
         public CompositionGetValueStatus TryGetVector2(string propertyName, out Vector2 value) => TryGet(propertyName, ref _vector2Properties, out value);
 
+        public CompositionGetValueStatus TryGetVector3(string propertyName, out Vector3 value) => TryGet(propertyName, ref _vector3Properties, out value);
+
+        public CompositionGetValueStatus TryGetVector4(string propertyName, out Vector4 value) => TryGet(propertyName, ref _vector4Properties, out value);
+
         public IEnumerable<KeyValuePair<string, Color>> ColorProperties => _colorProperties.Entries;
 
         public IEnumerable<KeyValuePair<string, float>> ScalarProperties => _scalarProperties.Entries;
 
         public IEnumerable<KeyValuePair<string, Vector2>> Vector2Properties => _vector2Properties.Entries;
+
+        public IEnumerable<KeyValuePair<string, Vector3>> Vector3Properties => _vector3Properties.Entries;
+
+        public IEnumerable<KeyValuePair<string, Vector4>> Vector4Properties => _vector4Properties.Entries;
 
         public IEnumerable<string> PropertyNames => _names ?? Enumerable.Empty<string>();
 
@@ -81,9 +95,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData
 
         CompositionGetValueStatus TryGet<T>(string propertyName, ref PropertyBag<T> bag, out T value)
         {
-            // There's nothing in this property set.
-            if (_names is null)
+            if (_names is null || !_names.Contains(propertyName))
             {
+                // The name isn't in this property set.
                 value = default(T);
                 return CompositionGetValueStatus.NotFound;
             }

--- a/source/WinCompData/Expressions/ColorRGB.cs
+++ b/source/WinCompData/Expressions/ColorRGB.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
+{
+    /// <summary>
+    /// Constructs a color from RGBA values.
+    /// </summary>
+#if PUBLIC_WinCompData
+    public
+#endif
+    sealed class ColorRGB : Expression
+    {
+        public ColorRGB(Expression r, Expression g, Expression b, Expression a)
+        {
+            R = r;
+            G = g;
+            B = b;
+            A = a;
+        }
+
+        public Expression R { get; }
+
+        public Expression G { get; }
+
+        public Expression B { get; }
+
+        public Expression A { get; }
+
+        /// <inheritdoc/>
+        protected override Expression Simplify() => this;
+
+        /// <inheritdoc/>
+        protected override string CreateExpressionString() => $"ColorRGB({A.Simplified},{R.Simplified},{G.Simplified},{B.Simplified})";
+
+        internal override bool IsAtomic => true;
+
+        /// <inheritdoc/>
+        public override ExpressionType InferredType => new ExpressionType(TypeConstraint.Color);
+    }
+}

--- a/source/WinCompData/Expressions/ColorRGB.cs
+++ b/source/WinCompData/Expressions/ColorRGB.cs
@@ -32,7 +32,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
         protected override Expression Simplify() => this;
 
         /// <inheritdoc/>
-        protected override string CreateExpressionString() => $"ColorRGB({A.Simplified},{R.Simplified},{G.Simplified},{B.Simplified})";
+        protected override string CreateExpressionString()
+            => $"ColorRGB({A.Simplified},{R.Simplified},{G.Simplified},{B.Simplified})";
 
         internal override bool IsAtomic => true;
 

--- a/source/WinCompData/Expressions/Expression.cs
+++ b/source/WinCompData/Expressions/Expression.cs
@@ -20,6 +20,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
 
         public virtual ExpressionType InferredType { get; } = new ExpressionType(TypeConstraint.NoType);
 
+        public static ScalarSubchannel X(Expression value) => new ScalarSubchannel(value, "X");
+
+        public static ScalarSubchannel Y(Expression value) => new ScalarSubchannel(value, "Y");
+
+        public static ScalarSubchannel Z(Expression value) => new ScalarSubchannel(value, "Z");
+
+        public static ScalarSubchannel W(Expression value) => new ScalarSubchannel(value, "W");
+
         public static Number Scalar(double value) => new Number(value);
 
         public static Divide Divide(Expression x, Expression y) => new Divide(x, y);
@@ -27,6 +35,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
         public static Vector2 Constant(Sn.Vector2 value) => new Vector2(Scalar(value.X), Scalar(value.Y));
 
         public static TypeAssert Color(string name) => Name(name, TypeConstraint.Color);
+
+        public static ColorRGB ColorRGB(Expression r, Expression g, Expression b, Expression a) => new ColorRGB(r, g, b, a);
 
         public static TypeAssert Scalar(string name) => Name(name, TypeConstraint.Scalar);
 
@@ -38,6 +48,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
 
         public static TypeAssert Vector2(string name) => Name(name, TypeConstraint.Vector2);
 
+        public static TypeAssert Vector4(string name) => Name(name, TypeConstraint.Vector4);
+
         public static Vector2 Vector2(Expression x, Expression y) => new Vector2(x, y);
 
         public static Vector2 Vector2(double x, double y) => new Vector2(Scalar(x), Scalar(y));
@@ -47,6 +59,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
         public static Vector3 Vector3(Expression x, Expression y, Expression z) => new Vector3(x, y, z);
 
         public static Vector3 Vector3(Expression x, Expression y) => new Vector3(x, y, Scalar(0));
+
+        public static Vector4 Vector4(Expression x, Expression y, Expression z, Expression w) => new Vector4(x, y, z, w);
 
         protected static Squared Squared(Expression expression) => new Squared(expression);
 
@@ -139,7 +153,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
             }
             else if (expression is Vector2 vector2Expression)
             {
-                return IsZero(vector2Expression.X) && IsZero(vector2Expression.Y);
+                return IsZero(vector2Expression);
             }
             else
             {
@@ -157,7 +171,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
             }
             else if (expression is Vector2 vector2Expression)
             {
-                return IsOne(vector2Expression.X) && IsOne(vector2Expression.Y);
+                return IsOne(vector2Expression);
             }
             else
             {

--- a/source/WinCompData/Expressions/LessThan.cs
+++ b/source/WinCompData/Expressions/LessThan.cs
@@ -37,7 +37,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
         }
 
         /// <inheritdoc/>
-        protected override string CreateExpressionString() => $"{Parenthesize(Left.Simplified)} < {Parenthesize(Right.Simplified)}";
+        protected override string CreateExpressionString()
+            => $"{Parenthesize(Left.Simplified)} < {Parenthesize(Right.Simplified)}";
 
         /// <inheritdoc/>
         public override ExpressionType InferredType =>

--- a/source/WinCompData/Expressions/Max.cs
+++ b/source/WinCompData/Expressions/Max.cs
@@ -39,7 +39,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
         }
 
         /// <inheritdoc/>
-        protected override string CreateExpressionString() => $"Max({Parenthesize(Left.Simplified)}, {Parenthesize(Right.Simplified)})";
+        protected override string CreateExpressionString()
+            => $"Max({Parenthesize(Left.Simplified)}, {Parenthesize(Right.Simplified)})";
 
         /// <inheritdoc/>
         public override ExpressionType InferredType =>

--- a/source/WinCompData/Expressions/Min.cs
+++ b/source/WinCompData/Expressions/Min.cs
@@ -39,7 +39,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
         }
 
         /// <inheritdoc/>
-        protected override string CreateExpressionString() => $"Min({Parenthesize(Left.Simplified)}, {Parenthesize(Right.Simplified)})";
+        protected override string CreateExpressionString()
+            => $"Min({Parenthesize(Left.Simplified)}, {Parenthesize(Right.Simplified)})";
 
         /// <inheritdoc/>
         public override ExpressionType InferredType =>

--- a/source/WinCompData/Expressions/ScalarSubchannel.cs
+++ b/source/WinCompData/Expressions/ScalarSubchannel.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
+{
+#if PUBLIC_WinCompData
+    public
+#endif
+    sealed class ScalarSubchannel : Expression
+    {
+        internal ScalarSubchannel(Expression value, string channelName)
+        {
+            Value = value;
+            ChannelName = channelName;
+        }
+
+        public Expression Value { get; }
+
+        public string ChannelName { get; }
+
+        /// <inheritdoc/>
+        protected override Expression Simplify() => this;
+
+        /// <inheritdoc/>
+        protected override string CreateExpressionString() => $"{Value}.{ChannelName}";
+
+        internal override bool IsAtomic => true;
+
+        /// <inheritdoc/>
+        public override ExpressionType InferredType => new ExpressionType(TypeConstraint.Scalar);
+    }
+}

--- a/source/WinCompData/Expressions/Vector2.cs
+++ b/source/WinCompData/Expressions/Vector2.cs
@@ -9,23 +9,26 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
 #endif
     sealed class Vector2 : Expression
     {
-        public Expression X { get; }
-
-        public Expression Y { get; }
+        readonly Expression _x;
+        readonly Expression _y;
 
         internal Vector2(Expression x, Expression y)
         {
-            X = x;
-            Y = y;
+            _x = x;
+            _y = y;
         }
 
-        public static Vector2 operator *(Vector2 left, double right) => new Vector2(Multiply(left.X, Scalar(right)), Multiply(left.Y, Scalar(right)));
+        public static Vector2 operator *(Vector2 left, double right) => new Vector2(Multiply(left._x, Scalar(right)), Multiply(left._y, Scalar(right)));
 
         /// <inheritdoc/>
         protected override Expression Simplify() => this;
 
         /// <inheritdoc/>
-        protected override string CreateExpressionString() => $"Vector2({Parenthesize(X)},{Parenthesize(Y)})";
+        protected override string CreateExpressionString() => $"Vector2({Parenthesize(_x)},{Parenthesize(_y)})";
+
+        internal static bool IsZero(Vector2 value) => IsZero(value._x) && IsZero(value._y);
+
+        internal static bool IsOne(Vector2 value) => IsOne(value._x) && IsOne(value._y);
 
         internal override bool IsAtomic => true;
 

--- a/source/WinCompData/Expressions/Vector2.cs
+++ b/source/WinCompData/Expressions/Vector2.cs
@@ -18,13 +18,15 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
             _y = y;
         }
 
-        public static Vector2 operator *(Vector2 left, double right) => new Vector2(Multiply(left._x, Scalar(right)), Multiply(left._y, Scalar(right)));
+        public static Vector2 operator *(Vector2 left, double right)
+            => new Vector2(Multiply(left._x, Scalar(right)), Multiply(left._y, Scalar(right)));
 
         /// <inheritdoc/>
         protected override Expression Simplify() => this;
 
         /// <inheritdoc/>
-        protected override string CreateExpressionString() => $"Vector2({Parenthesize(_x)},{Parenthesize(_y)})";
+        protected override string CreateExpressionString()
+            => $"Vector2({Parenthesize(_x)},{Parenthesize(_y)})";
 
         internal static bool IsZero(Vector2 value) => IsZero(value._x) && IsZero(value._y);
 

--- a/source/WinCompData/Expressions/Vector3.cs
+++ b/source/WinCompData/Expressions/Vector3.cs
@@ -24,7 +24,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
         protected override Expression Simplify() => this;
 
         /// <inheritdoc/>
-        protected override string CreateExpressionString() => $"Vector3({Parenthesize(_x)},{Parenthesize(_y)},{Parenthesize(_z)})";
+        protected override string CreateExpressionString()
+            => $"Vector3({Parenthesize(_x)},{Parenthesize(_y)},{Parenthesize(_z)})";
 
         internal override bool IsAtomic => true;
 

--- a/source/WinCompData/Expressions/Vector4.cs
+++ b/source/WinCompData/Expressions/Vector4.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -7,28 +7,30 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
 #if PUBLIC_WinCompData
     public
 #endif
-    sealed class Vector3 : Expression
+    sealed class Vector4 : Expression
     {
         readonly Expression _x;
         readonly Expression _y;
         readonly Expression _z;
+        readonly Expression _w;
 
-        internal Vector3(Expression x, Expression y, Expression z)
+        internal Vector4(Expression x, Expression y, Expression z, Expression w)
         {
             _x = x;
             _y = y;
             _z = z;
+            _w = w;
         }
 
         /// <inheritdoc/>
         protected override Expression Simplify() => this;
 
         /// <inheritdoc/>
-        protected override string CreateExpressionString() => $"Vector3({Parenthesize(_x)},{Parenthesize(_y)},{Parenthesize(_z)})";
+        protected override string CreateExpressionString() => $"Vector4({Parenthesize(_x)},{Parenthesize(_y)},{Parenthesize(_z)},{Parenthesize(_w)})";
 
         internal override bool IsAtomic => true;
 
         /// <inheritdoc/>
-        public override ExpressionType InferredType => new ExpressionType(TypeConstraint.Vector3);
+        public override ExpressionType InferredType => new ExpressionType(TypeConstraint.Vector4);
     }
 }

--- a/source/WinCompData/Expressions/Vector4.cs
+++ b/source/WinCompData/Expressions/Vector4.cs
@@ -26,7 +26,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
         protected override Expression Simplify() => this;
 
         /// <inheritdoc/>
-        protected override string CreateExpressionString() => $"Vector4({Parenthesize(_x)},{Parenthesize(_y)},{Parenthesize(_z)},{Parenthesize(_w)})";
+        protected override string CreateExpressionString()
+            => $"Vector4({Parenthesize(_x)},{Parenthesize(_y)},{Parenthesize(_z)},{Parenthesize(_w)})";
 
         internal override bool IsAtomic => true;
 

--- a/source/WinCompData/IDescribable.cs
+++ b/source/WinCompData/IDescribable.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData
     interface IDescribable
     {
         /// <summary>
-        /// Gets or sets a long desription of the object, suitable for
+        /// Gets or sets a long description of the object, suitable for
         /// use in a multi-line comment.
         /// </summary>
         string LongDescription { get; set; }
@@ -24,5 +24,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData
         /// use in a single line comment.
         /// </summary>
         string ShortDescription { get; set; }
+
+        /// <summary>
+        /// Gets or sets a name that is suitable for use as a variable name
+        /// in code.
+        /// </summary>
+        string Name { get; set; }
     }
 }

--- a/source/WinCompData/Mgcg/CanvasGeometry.cs
+++ b/source/WinCompData/Mgcg/CanvasGeometry.cs
@@ -71,17 +71,18 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Mgcg
             {
                 SourceGeometry = this,
                 TransformMatrix = transformMatrix,
-                LongDescription = LongDescription,
-                ShortDescription = ShortDescription,
             };
 
         public abstract GeometryType Type { get; }
 
         /// <inheritdoc/>
-        public string LongDescription { get; set; }
+        string IDescribable.LongDescription { get; set; }
 
         /// <inheritdoc/>
-        public string ShortDescription { get; set; }
+        string IDescribable.ShortDescription { get; set; }
+
+        /// <inheritdoc/>
+        string IDescribable.Name { get; set; }
 
         /// <summary>
         /// The type of a <see cref="CanvasGeometry"/>.

--- a/source/WinCompData/Serialization/CompositionObjectXmlSerializer.cs
+++ b/source/WinCompData/Serialization/CompositionObjectXmlSerializer.cs
@@ -720,6 +720,22 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Tools
                         yield return item;
                     }
                 }
+
+                foreach (var prop in obj.Vector3Properties)
+                {
+                    foreach (var item in FromAnimatableVector3(prop.Key, animators, prop.Value))
+                    {
+                        yield return item;
+                    }
+                }
+
+                foreach (var prop in obj.Vector4Properties)
+                {
+                    foreach (var item in FromAnimatableVector4(prop.Key, animators, prop.Value))
+                    {
+                        yield return item;
+                    }
+                }
             }
         }
 
@@ -879,6 +895,23 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Tools
             }
         }
 
+        IEnumerable<XObject> FromAnimatableVector4(string name, IEnumerable<CompositionObject.Animator> animators, Vector4? initialValue)
+        {
+            var animation = animators.Where(a => a.AnimatedProperty == name).FirstOrDefault()?.Animation;
+
+            if (animation != null)
+            {
+                yield return FromAnimation(name, animation, initialValue);
+            }
+            else
+            {
+                if (initialValue.HasValue)
+                {
+                    yield return FromVector4(name, initialValue.Value);
+                }
+            }
+        }
+
         XElement FromColor(string name, Color value)
         {
             return new XElement(name, new XAttribute("ColorValue", value));
@@ -897,14 +930,25 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Tools
             => FromVector2(name, obj.HasValue ? obj.Value : defaultIfNull);
 
         XElement FromVector2(string name, Vector2 obj)
-        {
-            return new XElement(name, new XAttribute(nameof(obj.X), obj.X), new XAttribute(nameof(obj.Y), obj.Y));
-        }
+            => new XElement(
+                name,
+                new XAttribute(nameof(obj.X), obj.X),
+                new XAttribute(nameof(obj.Y), obj.Y));
 
         XElement FromVector3(string name, Vector3 obj)
-        {
-            return new XElement(name, new XAttribute(nameof(obj.X), obj.X), new XAttribute(nameof(obj.Y), obj.Y), new XAttribute(nameof(obj.Z), obj.Z));
-        }
+            => new XElement(
+                name,
+                new XAttribute(nameof(obj.X), obj.X),
+                new XAttribute(nameof(obj.Y), obj.Y),
+                new XAttribute(nameof(obj.Z), obj.Z));
+
+        XElement FromVector4(string name, Vector4 obj)
+            => new XElement(
+                name,
+                new XAttribute(nameof(obj.X), obj.X),
+                new XAttribute(nameof(obj.Y), obj.Y),
+                new XAttribute(nameof(obj.Z), obj.Z),
+                new XAttribute(nameof(obj.W), obj.W));
 
         XElement FromSpriteVisual(SpriteVisual obj)
         {

--- a/source/WinCompData/WinCompData.projitems
+++ b/source/WinCompData/WinCompData.projitems
@@ -49,6 +49,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)ExpressionAnimation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Expressions\BinaryExpression.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Expressions\Boolean.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Expressions\ScalarSubchannel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Expressions\ColorRGB.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Expressions\Cubed.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Expressions\CubicBezierFunction2.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Expressions\Divide.cs" />
@@ -70,6 +72,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Expressions\UntypedExpression.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Expressions\Vector2.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Expressions\Vector3.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Expressions\Vector4.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ICompositionSurface.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IContainShapes.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IDescribable.cs" />

--- a/source/WinUIXamlMediaData/LoadedImageSurface.cs
+++ b/source/WinUIXamlMediaData/LoadedImageSurface.cs
@@ -18,10 +18,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinUIXamlMediaData
         }
 
         /// <inheritdoc/>
-        public string LongDescription { get; set; }
+        string IDescribable.LongDescription { get; set; }
 
         /// <inheritdoc/>
-        public string ShortDescription { get; set; }
+        string IDescribable.ShortDescription { get; set; }
+
+        /// <inheritdoc/>
+        string IDescribable.Name { get; set; }
 
         public abstract LoadedImageSurfaceType Type { get; }
 


### PR DESCRIPTION
Add support for Vector3 and Vector4 in CompositionPropertySet.
Fix bug in CompositionPropertySet.TryGet* logic.
Add IDescribable.Name so that brushes that are bound to property set values can have names that match the property set name.
Add support for scalar subchannel accessors in animation expressions.
Add support for ColorRGB constructor in animation expressions.
Add support for Vector4 in animation expressions.