### PR TITLE
Vector4 didn't support simplification. Now it does.

### DIFF
--- a/source/WinCompData/Expressions/Expression.cs
+++ b/source/WinCompData/Expressions/Expression.cs
@@ -107,26 +107,16 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
         internal virtual bool IsAtomic => false;
 
         /// <inheritdoc/>
-        public sealed override string ToString()
-        {
-            // Expressions are immutable, so it's always safe to return a cached string representation.
-            return _expressionStringCache != null
-                ? _expressionStringCache
-                : _expressionStringCache = Simplified.CreateExpressionString();
-        }
+        // Expressions are immutable, so it's always safe to return a cached version.
+        public sealed override string ToString() =>
+            _expressionStringCache ?? (_expressionStringCache = Simplified.CreateExpressionString());
 
         /// <summary>
         /// Gets a simplified form of the expression. May be the same as this.
         /// </summary>
-        public Expression Simplified
-        {
-            get
-            {
-                return _simplifiedExpressionCache != null
-                    ? _simplifiedExpressionCache
-                    : _simplifiedExpressionCache = Simplify();
-            }
-        }
+        // Expressions are immutable, so it's always safe to return a cached version.
+        public Expression Simplified =>
+            _simplifiedExpressionCache ?? (_simplifiedExpressionCache = Simplify());
 
         /// <summary>
         /// Returns an equivalent expression, simplified if possible.
@@ -145,38 +135,46 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
 
         protected static bool IsZero(Expression expression)
         {
-            if (expression is Number numberExpression)
+            switch (expression)
             {
-                // Cast to a float for purposes of determining if it is equal to 1 because
-                // Composition will do this internally.
-                return (float)numberExpression.Value == 0;
+                case Number number:
+                    // Cast to a float for purposes of determining if it is equal to 0 because
+                    // Composition will do this internally.
+                    return (float)number.Value == 0;
+
+                case Vector2 vector:
+                    return Expressions.Vector2.IsZero(vector);
+
+                case Vector3 vector:
+                    return Expressions.Vector3.IsZero(vector);
+
+                case Vector4 vector:
+                    return Expressions.Vector4.IsZero(vector);
             }
-            else if (expression is Vector2 vector2Expression)
-            {
-                return Expressions.Vector2.IsZero(vector2Expression);
-            }
-            else
-            {
-                return false;
-            }
+
+            return false;
         }
 
         protected static bool IsOne(Expression expression)
         {
-            if (expression is Number numberExpression)
+            switch (expression)
             {
-                // Cast to a float for purposes of determining if it is equal to 1 because
-                // Composition will do this internally.
-                return (float)numberExpression.Value == 1;
+                case Number number:
+                    // Cast to a float for purposes of determining if it is equal to 1 because
+                    // Composition will do this internally.
+                    return (float)number.Value == 1;
+
+                case Vector2 vector:
+                    return Expressions.Vector2.IsOne(vector);
+
+                case Vector3 vector:
+                    return Expressions.Vector3.IsOne(vector);
+
+                case Vector4 vector:
+                    return Expressions.Vector4.IsOne(vector);
             }
-            else if (expression is Vector2 vector2Expression)
-            {
-                return Expressions.Vector2.IsOne(vector2Expression);
-            }
-            else
-            {
-                return false;
-            }
+
+            return false;
         }
     }
 }

--- a/source/WinCompData/Expressions/ScalarSubchannel.cs
+++ b/source/WinCompData/Expressions/ScalarSubchannel.cs
@@ -20,11 +20,66 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
         public string ChannelName { get; }
 
         /// <inheritdoc/>
-        protected override Expression Simplify() => this;
+        protected override Expression Simplify()
+        {
+            switch (Value)
+            {
+                case Vector4 vector:
+                    switch (ChannelName)
+                    {
+                        case "X":
+                        case "x":
+                            return vector.X;
+                        case "Y":
+                        case "y":
+                            return vector.Y;
+                        case "Z":
+                        case "z":
+                            return vector.Z;
+                        case "W":
+                        case "w":
+                            return vector.W;
+                    }
+
+                    break;
+
+                case Vector3 vector:
+                    switch (ChannelName)
+                    {
+                        case "X":
+                        case "x":
+                            return vector.X;
+                        case "Y":
+                        case "y":
+                            return vector.Y;
+                        case "Z":
+                        case "z":
+                            return vector.Z;
+                    }
+
+                    break;
+
+                case Vector2 vector:
+                    switch (ChannelName)
+                    {
+                        case "X":
+                        case "x":
+                            return vector.X;
+                        case "Y":
+                        case "y":
+                            return vector.Y;
+                    }
+
+                    break;
+            }
+
+            return this;
+        }
 
         /// <inheritdoc/>
         protected override string CreateExpressionString() => $"{Value}.{ChannelName}";
 
+        /// <inheritdoc/>
         internal override bool IsAtomic => true;
 
         /// <inheritdoc/>

--- a/source/WinCompData/Expressions/ScalarSubchannel.cs
+++ b/source/WinCompData/Expressions/ScalarSubchannel.cs
@@ -22,21 +22,19 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
         /// <inheritdoc/>
         protected override Expression Simplify()
         {
+            var channelNameLower = ChannelName?.ToLowerInvariant() ?? string.Empty;
+
             switch (Value)
             {
                 case Vector4 vector:
-                    switch (ChannelName)
+                    switch (channelNameLower)
                     {
-                        case "X":
                         case "x":
                             return vector.X;
-                        case "Y":
                         case "y":
                             return vector.Y;
-                        case "Z":
                         case "z":
                             return vector.Z;
-                        case "W":
                         case "w":
                             return vector.W;
                     }
@@ -44,15 +42,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
                     break;
 
                 case Vector3 vector:
-                    switch (ChannelName)
+                    switch (channelNameLower)
                     {
-                        case "X":
                         case "x":
                             return vector.X;
-                        case "Y":
                         case "y":
                             return vector.Y;
-                        case "Z":
                         case "z":
                             return vector.Z;
                     }
@@ -60,12 +55,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
                     break;
 
                 case Vector2 vector:
-                    switch (ChannelName)
+                    switch (channelNameLower)
                     {
-                        case "X":
                         case "x":
                             return vector.X;
-                        case "Y":
                         case "y":
                             return vector.Y;
                     }

--- a/source/WinCompData/Expressions/Vector2.cs
+++ b/source/WinCompData/Expressions/Vector2.cs
@@ -9,28 +9,37 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
 #endif
     sealed class Vector2 : Expression
     {
-        readonly Expression _x;
-        readonly Expression _y;
-
         internal Vector2(Expression x, Expression y)
         {
-            _x = x;
-            _y = y;
+            X = x;
+            Y = y;
         }
 
+        public new Expression X { get; }
+
+        public new Expression Y { get; }
+
         public static Vector2 operator *(Vector2 left, double right)
-            => new Vector2(Multiply(left._x, Scalar(right)), Multiply(left._y, Scalar(right)));
+            => new Vector2(Multiply(left.X, Scalar(right)), Multiply(left.Y, Scalar(right)));
 
         /// <inheritdoc/>
-        protected override Expression Simplify() => this;
+        protected override Expression Simplify()
+        {
+            var x = X.Simplified;
+            var y = Y.Simplified;
+
+            return x == X && y == Y
+                ? this
+                : new Vector2(x, y);
+        }
 
         /// <inheritdoc/>
         protected override string CreateExpressionString()
-            => $"Vector2({Parenthesize(_x)},{Parenthesize(_y)})";
+            => $"Vector2({Parenthesize(X)},{Parenthesize(Y)})";
 
-        internal static bool IsZero(Vector2 value) => IsZero(value._x) && IsZero(value._y);
+        internal static bool IsZero(Vector2 value) => IsZero(value.X) && IsZero(value.Y);
 
-        internal static bool IsOne(Vector2 value) => IsOne(value._x) && IsOne(value._y);
+        internal static bool IsOne(Vector2 value) => IsOne(value.X) && IsOne(value.Y);
 
         internal override bool IsAtomic => true;
 

--- a/source/WinCompData/Expressions/Vector3.cs
+++ b/source/WinCompData/Expressions/Vector3.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
             var x = X.Simplified;
             var y = Y.Simplified;
             var z = Z.Simplified;
+
             return x == X && y == Y && z == Z
                 ? this
                 : new Vector3(x, y, z);

--- a/source/WinCompData/Expressions/Vector3.cs
+++ b/source/WinCompData/Expressions/Vector3.cs
@@ -9,23 +9,37 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
 #endif
     sealed class Vector3 : Expression
     {
-        readonly Expression _x;
-        readonly Expression _y;
-        readonly Expression _z;
-
         internal Vector3(Expression x, Expression y, Expression z)
         {
-            _x = x;
-            _y = y;
-            _z = z;
+            X = x;
+            Y = y;
+            Z = z;
+        }
+
+        public new Expression X { get; }
+
+        public new Expression Y { get; }
+
+        public new Expression Z { get; }
+
+        /// <inheritdoc/>
+        protected override Expression Simplify()
+        {
+            var x = X.Simplified;
+            var y = Y.Simplified;
+            var z = Z.Simplified;
+            return x == X && y == Y && z == Z
+                ? this
+                : new Vector3(x, y, z);
         }
 
         /// <inheritdoc/>
-        protected override Expression Simplify() => this;
-
-        /// <inheritdoc/>
         protected override string CreateExpressionString()
-            => $"Vector3({Parenthesize(_x)},{Parenthesize(_y)},{Parenthesize(_z)})";
+            => $"Vector3({Parenthesize(X)},{Parenthesize(Y)},{Parenthesize(Z)})";
+
+        internal static bool IsZero(Vector3 value) => IsZero(value.X) && IsZero(value.Y) && IsZero(value.Z);
+
+        internal static bool IsOne(Vector3 value) => IsOne(value.X) && IsOne(value.Y) && IsOne(value.Z);
 
         internal override bool IsAtomic => true;
 

--- a/source/WinCompData/Expressions/Vector4.cs
+++ b/source/WinCompData/Expressions/Vector4.cs
@@ -9,25 +9,42 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
 #endif
     sealed class Vector4 : Expression
     {
-        readonly Expression _x;
-        readonly Expression _y;
-        readonly Expression _z;
-        readonly Expression _w;
-
         internal Vector4(Expression x, Expression y, Expression z, Expression w)
         {
-            _x = x;
-            _y = y;
-            _z = z;
-            _w = w;
+            X = x;
+            Y = y;
+            Z = z;
+            W = w;
+        }
+
+        public new Expression X { get; }
+
+        public new Expression Y { get; }
+
+        public new Expression Z { get; }
+
+        public new Expression W { get; }
+
+        /// <inheritdoc/>
+        protected override Expression Simplify()
+        {
+            var x = X.Simplified;
+            var y = Y.Simplified;
+            var z = Z.Simplified;
+            var w = W.Simplified;
+
+            return x == X && y == Y && z == Z && w == W
+                ? this
+                : new Vector4(x, y, z, w);
         }
 
         /// <inheritdoc/>
-        protected override Expression Simplify() => this;
-
-        /// <inheritdoc/>
         protected override string CreateExpressionString()
-            => $"Vector4({Parenthesize(_x)},{Parenthesize(_y)},{Parenthesize(_z)},{Parenthesize(_w)})";
+            => $"Vector4({Parenthesize(X)},{Parenthesize(Y)},{Parenthesize(Z)},{Parenthesize(W)})";
+
+        internal static bool IsZero(Vector4 value) => IsZero(value.X) && IsZero(value.Y) && IsZero(value.Z) && IsZero(value.W);
+
+        internal static bool IsOne(Vector4 value) => IsOne(value.X) && IsOne(value.Y) && IsOne(value.Z) && IsOne(value.W);
 
         internal override bool IsAtomic => true;
 


### PR DESCRIPTION
This includes some cleanup to make Vector expression code more consistent, and takes advantage of C# 7 switching on types.