### PR TITLE
More consistent naming for factories.

### DIFF
--- a/source/UIDataCodeGen/CodeGen/NodeNamer.cs
+++ b/source/UIDataCodeGen/CodeGen/NodeNamer.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
                         baseName = DescribeCompositionObject(node, (CompositionObject)node.Object);
                         break;
                     case Graph.NodeType.CompositionPath:
-                        baseName = "CompositionPath";
+                        baseName = "Path";
                         break;
                     case Graph.NodeType.CanvasGeometry:
                         baseName = "Geometry";


### PR DESCRIPTION
In all cases except "CompositionPath" the factory names in the generated code do not have the "Composition" prefix. This is because "Composition" doesn't add anything useful to the meaning, so it's just noise. But we never did that for CompositionPath. Now we do.