### PR TITLE
Make expressions equatable.

### DIFF
--- a/source/WinCompData/Expressions/Expression.cs
+++ b/source/WinCompData/Expressions/Expression.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using Sn = System.Numerics;
 
 namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
@@ -9,7 +10,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
 #if PUBLIC_WinCompData
     public
 #endif
-    abstract class Expression
+    abstract class Expression : IEquatable<Expression>
     {
         private protected Expression()
         {
@@ -83,5 +84,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
         /// </summary>
         /// <returns>The expression as a string suitable for use in the Windows.UI.Composition animation APIs.</returns>
         protected abstract string CreateExpressionText();
+
+        public bool Equals(Expression other) => !(other is null) && other.ToText() == ToText();
+
+        public override sealed bool Equals(object obj) => (obj is Expression other) && Equals(other);
+
+        public override sealed int GetHashCode() => ToText().GetHashCode();
     }
 }

--- a/source/WinCompData/Expressions/ExpressionType.cs
+++ b/source/WinCompData/Expressions/ExpressionType.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-
 namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
 {
     /// <summary>

--- a/source/WinCompData/Expressions/Expression_.cs
+++ b/source/WinCompData/Expressions/Expression_.cs
@@ -2,12 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+
 namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
 {
 #if PUBLIC_WinCompData
     public
 #endif
-    abstract class Expression_<T> : Expression
+    abstract class Expression_<T> : Expression, IEquatable<T>
         where T : Expression_<T>
     {
         string _expressionTextCache;
@@ -30,5 +32,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
             => _expressionTextCache ?? (_expressionTextCache = Simplified.CreateExpressionText());
 
         protected virtual T Simplify() => (T)this;
+
+        public bool Equals(T other) => !(other is null) && other.ToText() == ToText();
     }
 }


### PR DESCRIPTION
This is needed for an unpcoming change which uses KeyFrame<Expressions.Color>. KeyFrame<T> requires that T is IEquatable (to support animation trimming).

Expressions are considered equivalent if their simplified text is exactly the same. It does not guarantee that the expression evaluates to the same value, but it does guarantee that if the expressions claim to be equal, they will evaluate to the same value.