### PR TITLE
Strong type of Lottie Opacity.

### DIFF
--- a/source/LottieData/Color.cs
+++ b/source/LottieData/Color.cs
@@ -50,8 +50,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
         /// Return the color with the given opacity multiplied into the alpha channel.
         /// </summary>
         /// <returns>The color with the given opacity multiplied into the alpha channel.</returns>
-        public Color MultipliedByOpacity(double opacity)
-            => opacity == 1 ? this : new Color(opacity * A, R, G, B);
+        public Color MultipliedByOpacity(Opacity opacity)
+            => opacity.IsOpaque ? this : new Color(opacity.Value * A, R, G, B);
 
         /// <inheritdoc/>
         public override bool Equals(object obj) => obj is Color && Equals((Color)obj);

--- a/source/LottieData/ExtensionMethods.cs
+++ b/source/LottieData/ExtensionMethods.cs
@@ -100,5 +100,21 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 
             return result;
         }
+
+        public static Opacity Max<TSource>(this ReadOnlySpan<TSource> source, Func<TSource, Opacity> selector)
+        {
+            var result = Opacity.Transparent;
+
+            foreach (var item in source)
+            {
+                var candidate = selector(item);
+                if (candidate > result)
+                {
+                    result = candidate;
+                }
+            }
+
+            return result;
+        }
     }
 }

--- a/source/LottieData/LinearGradientFill.cs
+++ b/source/LottieData/LinearGradientFill.cs
@@ -12,11 +12,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
         public LinearGradientFill(
             in ShapeLayerContentArgs args,
             PathFillType fillType,
-            Animatable<double> opacityPercent,
+            Animatable<Opacity> opacity,
             IAnimatableVector3 startPoint,
             IAnimatableVector3 endPoint,
             Animatable<Sequence<GradientStop>> gradientStops)
-            : base(in args, fillType, opacityPercent)
+            : base(in args, fillType, opacity)
         {
             StartPoint = startPoint;
             EndPoint = endPoint;

--- a/source/LottieData/LinearGradientStroke.cs
+++ b/source/LottieData/LinearGradientStroke.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
     {
         public LinearGradientStroke(
             in ShapeLayerContentArgs args,
-            Animatable<double> opacityPercent,
+            Animatable<Opacity> opacity,
             Animatable<double> strokeWidth,
             LineCapType capType,
             LineJoinType joinType,
@@ -19,7 +19,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
             IAnimatableVector3 startPoint,
             IAnimatableVector3 endPoint,
             Animatable<Sequence<GradientStop>> gradientStops)
-            : base(in args, opacityPercent, strokeWidth, capType, joinType, miterLimit)
+            : base(in args, opacity, strokeWidth, capType, joinType, miterLimit)
         {
             StartPoint = startPoint;
             EndPoint = endPoint;

--- a/source/LottieData/LottieData.projitems
+++ b/source/LottieData/LottieData.projitems
@@ -46,6 +46,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)\Mask.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\MergePaths.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\NullLayer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Opacity.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\OpacityGradientStop.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Optimization\GradientStopOptimizer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Optimization\Optimizer.cs" />

--- a/source/LottieData/Mask.cs
+++ b/source/LottieData/Mask.cs
@@ -16,14 +16,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
             bool inverted,
             string name,
             Animatable<Sequence<BezierSegment>> points,
-            Animatable<double> opacityPercent,
+            Animatable<Opacity> opacity,
             MaskMode mode
         )
         {
             Inverted = inverted;
             Name = name;
             Points = points;
-            OpacityPercent = opacityPercent;
+            Opacity = opacity;
             Mode = mode;
         }
 
@@ -33,7 +33,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 
         public Animatable<Sequence<BezierSegment>> Points { get; }
 
-        public Animatable<double> OpacityPercent { get; }
+        public Animatable<Opacity> Opacity { get; }
 
         public MaskMode Mode { get; }
 

--- a/source/LottieData/Opacity.cs
+++ b/source/LottieData/Opacity.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
+{
+    /// <summary>
+    /// A percentage value.
+    /// </summary>
+#if PUBLIC_LottieData
+    public
+#endif
+    struct Opacity : IEquatable<Opacity>
+    {
+        Opacity(double value)
+        {
+            Value = value;
+        }
+
+        public bool IsOpaque => Value == 1;
+
+        public bool IsTransparent => Value == 0;
+
+        public static Opacity Opaque { get; } = new Opacity(1);
+
+        public double Percent => Value * 100;
+
+        public static Opacity Transparent { get; } = new Opacity(0);
+
+        public double Value { get; }
+
+        public static Opacity FromFloat(double value) => new Opacity(value);
+
+        public static Opacity operator *(Opacity left, Opacity right) => new Opacity(left.Value * right.Value);
+
+        public static Opacity operator *(Opacity opacity, double scale) => new Opacity(opacity.Value * scale);
+
+        public static bool operator >(Opacity left, Opacity right) => left.Value > right.Value;
+
+        public static bool operator <(Opacity left, Opacity right) => left.Value < right.Value;
+
+        public static bool operator ==(Opacity left, Opacity right) => left.Value == right.Value;
+
+        public static bool operator !=(Opacity left, Opacity right) => left.Value != right.Value;
+
+        public bool Equals(Opacity other) => other.Value == Value;
+
+        public override bool Equals(object obj) => obj is Opacity other ? other.Equals(this) : false;
+
+        public override int GetHashCode() => Value.GetHashCode();
+
+        public override string ToString() => $"{Percent}%";
+    }
+}

--- a/source/LottieData/OpacityGradientStop.cs
+++ b/source/LottieData/OpacityGradientStop.cs
@@ -9,18 +9,18 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 #endif
     sealed class OpacityGradientStop : GradientStop
     {
-        public OpacityGradientStop(double offset, double opacityPercent)
+        public OpacityGradientStop(double offset, Opacity opacity)
             : base(offset)
         {
-            OpacityPercent = opacityPercent;
+            Opacity = opacity;
         }
 
-        public double OpacityPercent { get; }
+        public Opacity Opacity { get; }
 
         /// <inheritdoc/>
         public override GradientStopKind Kind => GradientStopKind.Opacity;
 
         /// <inheritdoc/>
-        public override string ToString() => $"{OpacityPercent}%@{Offset}";
+        public override string ToString() => $"{Opacity.Value * 100}%@{Offset}";
     }
 }

--- a/source/LottieData/OpacityGradientStop.cs
+++ b/source/LottieData/OpacityGradientStop.cs
@@ -21,6 +21,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
         public override GradientStopKind Kind => GradientStopKind.Opacity;
 
         /// <inheritdoc/>
-        public override string ToString() => $"{Opacity.Value * 100}%@{Offset}";
+        public override string ToString() => $"{Opacity.Percent}%@{Offset}";
     }
 }

--- a/source/LottieData/RadialGradientFill.cs
+++ b/source/LottieData/RadialGradientFill.cs
@@ -12,13 +12,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
         public RadialGradientFill(
             in ShapeLayerContentArgs args,
             PathFillType fillType,
-            Animatable<double> opacityPercent,
+            Animatable<Opacity> opacity,
             IAnimatableVector3 startPoint,
             IAnimatableVector3 endPoint,
             Animatable<Sequence<GradientStop>> gradientStops,
             Animatable<double> highlightLength,
             Animatable<double> highlightDegrees)
-            : base(in args, fillType, opacityPercent)
+            : base(in args, fillType, opacity)
         {
             StartPoint = startPoint;
             EndPoint = endPoint;

--- a/source/LottieData/RadialGradientStroke.cs
+++ b/source/LottieData/RadialGradientStroke.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
     {
         public RadialGradientStroke(
             in ShapeLayerContentArgs args,
-            Animatable<double> opacityPercent,
+            Animatable<Opacity> opacity,
             Animatable<double> strokeWidth,
             LineCapType capType,
             LineJoinType joinType,
@@ -21,7 +21,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
             Animatable<Sequence<GradientStop>> gradientStops,
             Animatable<double> highlightLength,
             Animatable<double> highlightDegrees)
-            : base(in args, opacityPercent, strokeWidth, capType, joinType, miterLimit)
+            : base(in args, opacity, strokeWidth, capType, joinType, miterLimit)
         {
             StartPoint = startPoint;
             EndPoint = endPoint;

--- a/source/LottieData/RepeaterTransform.cs
+++ b/source/LottieData/RepeaterTransform.cs
@@ -15,23 +15,23 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
             IAnimatableVector3 position,
             IAnimatableVector3 scalePercent,
             Animatable<double> rotationDegrees,
-            Animatable<double> opacityPercent,
-            Animatable<double> startOpacityPercent,
-            Animatable<double> endOpacityPercent)
-            : base(in args, anchor, position, scalePercent, rotationDegrees, opacityPercent)
+            Animatable<Opacity> opacity,
+            Animatable<Opacity> startOpacity,
+            Animatable<Opacity> endOpacity)
+            : base(in args, anchor, position, scalePercent, rotationDegrees, opacity)
         {
-            StartOpacityPercent = startOpacityPercent;
-            EndOpacityPercent = endOpacityPercent;
+            StartOpacity = startOpacity;
+            EndOpacity = endOpacity;
         }
 
         /// <summary>
         /// Gets the opacity of the original shaped. Only used by <see cref="Repeater"/>.
         /// </summary>
-        public Animatable<double> StartOpacityPercent { get; }
+        public Animatable<Opacity> StartOpacity { get; }
 
         /// <summary>
         /// Gets the opacity of the last copy of the original shape. Only used by <see cref="Repeater"/>.
         /// </summary>
-        public Animatable<double> EndOpacityPercent { get; }
+        public Animatable<Opacity> EndOpacity { get; }
     }
 }

--- a/source/LottieData/Serialization/LottieCompositionXmlSerializer.cs
+++ b/source/LottieData/Serialization/LottieCompositionXmlSerializer.cs
@@ -390,7 +390,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
                 yield return new XAttribute(nameof(mask.Inverted), mask.Inverted);
                 yield return new XAttribute(nameof(mask.Name), mask.Name);
                 yield return FromAnimatable(nameof(mask.Points), mask.Points);
-                yield return FromAnimatable(nameof(mask.OpacityPercent), mask.OpacityPercent);
+                yield return FromAnimatable(nameof(mask.Opacity), mask.Opacity);
                 yield return new XAttribute(nameof(mask.Mode), mask.Mode);
             }
         }
@@ -423,7 +423,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
                 }
 
                 yield return FromAnimatable(nameof(content.Color), content.Color);
-                yield return FromAnimatable(nameof(content.OpacityPercent), content.OpacityPercent);
+                yield return FromAnimatable(nameof(content.Opacity), content.Opacity);
                 yield return FromAnimatable(nameof(content.StrokeWidth), content.StrokeWidth);
             }
         }
@@ -463,7 +463,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
                 }
 
                 yield return FromAnimatable("Color", content.Color);
-                yield return FromAnimatable("OpacityPercent", content.OpacityPercent);
+                yield return FromAnimatable("OpacityPercent", content.Opacity);
             }
         }
 
@@ -506,7 +506,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
                 yield return FromAnimatable(nameof(content.ScalePercent), content.ScalePercent);
                 yield return FromAnimatable(nameof(content.Position), content.Position);
                 yield return FromAnimatable(nameof(content.Anchor), content.Anchor);
-                yield return FromAnimatable(nameof(content.OpacityPercent), content.OpacityPercent);
+                yield return FromAnimatable(nameof(content.Opacity), content.Opacity);
                 yield return FromAnimatable(nameof(content.RotationDegrees), content.RotationDegrees);
             }
         }

--- a/source/LottieData/Serialization/LottieCompositionXmlSerializer.cs
+++ b/source/LottieData/Serialization/LottieCompositionXmlSerializer.cs
@@ -463,7 +463,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
                 }
 
                 yield return FromAnimatable("Color", content.Color);
-                yield return FromAnimatable("OpacityPercent", content.Opacity);
+                yield return FromAnimatable("Opacity", content.Opacity);
             }
         }
 

--- a/source/LottieData/Serialization/LottieCompositionYamlSerializer.cs
+++ b/source/LottieData/Serialization/LottieCompositionYamlSerializer.cs
@@ -328,7 +328,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
                 { "Name", mask.Name },
                 { "Inverted", mask.Inverted },
                 { "Mode", Scalar(mask.Mode) },
-                { "OpacityPercent", FromAnimatable(mask.OpacityPercent) },
+                { "OpacityPercent", FromAnimatable(mask.Opacity, FromOpacityPercent) },
                 { "Points", FromAnimatable(mask.Points, p => FromSequence(p, FromBezierSegment)) },
             };
             return result;
@@ -345,7 +345,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
         {
             var result = superclassContent;
             result.Add("Color", FromAnimatable(content.Color, FromColor));
-            result.Add("OpacityPercent", FromAnimatable(content.OpacityPercent));
+            result.Add("OpacityPercent", FromAnimatable(content.Opacity, FromOpacityPercent));
             result.Add("Thickness", FromAnimatable(content.StrokeWidth));
             return result;
         }
@@ -366,14 +366,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
         {
             var result = superclassContent;
             result.Add("Color", FromAnimatable(content.Color, FromColor));
-            result.Add("OpacityPercent", FromAnimatable(content.OpacityPercent));
+            result.Add("OpacityPercent", FromAnimatable(content.Opacity, FromOpacityPercent));
             return result;
         }
 
         YamlObject FromLinearGradientFill(LinearGradientFill content, YamlMap superclassContent)
         {
             var result = superclassContent;
-            result.Add("OpacityPercent", FromAnimatable(content.OpacityPercent));
+            result.Add("OpacityPercent", FromAnimatable(content.Opacity, FromOpacityPercent));
             result.Add("GradientStops", FromAnimatable(content.GradientStops, p => FromSequence(p, FromGradientStop)));
             return result;
         }
@@ -381,7 +381,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
         YamlObject FromRadialGradientFill(RadialGradientFill content, YamlMap superclassContent)
         {
             var result = superclassContent;
-            result.Add("OpacityPercent", FromAnimatable(content.OpacityPercent));
+            result.Add("OpacityPercent", FromAnimatable(content.Opacity, FromOpacityPercent));
             result.Add("GradientStops", FromAnimatable(content.GradientStops, p => FromSequence(p, FromGradientStop)));
             return result;
         }
@@ -392,7 +392,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
             result.Add("ScalePercent", FromAnimatable(content.ScalePercent));
             result.Add("Position", FromAnimatable(content.Position));
             result.Add("Anchor", FromAnimatable(content.Anchor));
-            result.Add("OpacityPercent", FromAnimatable(content.OpacityPercent));
+            result.Add("OpacityPercent", FromAnimatable(content.Opacity, FromOpacityPercent));
             result.Add("RotationDegrees", FromAnimatable(content.RotationDegrees));
             return result;
         }
@@ -439,6 +439,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
         static YamlObject FromDouble(double value) => (YamlScalar)value;
 
         static YamlObject FromColor(Color value) => (YamlScalar)value?.ToString();
+
+        static YamlObject FromOpacityPercent(Opacity value) => (YamlScalar)value.Percent;
 
         static YamlObject FromVector3(Vector3 value)
         {
@@ -500,7 +502,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
         {
             var result = new YamlMap
             {
-                { "OpacityPercent", value.OpacityPercent },
+                { "OpacityPercent", value.Opacity.Percent },
                 { "Offset", value.Offset },
             };
             return result;

--- a/source/LottieData/ShapeFill.cs
+++ b/source/LottieData/ShapeFill.cs
@@ -12,14 +12,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
         public ShapeFill(
             in ShapeLayerContentArgs args,
             PathFillType fillType,
-            Animatable<double> opacityPercent)
+            Animatable<Opacity> opacity)
             : base(in args)
         {
-            OpacityPercent = opacityPercent;
+            Opacity = opacity;
             FillType = fillType;
         }
 
-        public Animatable<double> OpacityPercent { get; }
+        public Animatable<Opacity> Opacity { get; }
 
         public abstract ShapeFillKind FillKind { get; }
 

--- a/source/LottieData/ShapeStroke.cs
+++ b/source/LottieData/ShapeStroke.cs
@@ -11,21 +11,21 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
     {
         public ShapeStroke(
             in ShapeLayerContentArgs args,
-            Animatable<double> opacityPercent,
+            Animatable<Opacity> opacity,
             Animatable<double> strokeWidth,
             LineCapType capType,
             LineJoinType joinType,
             double miterLimit)
             : base(in args)
         {
-            OpacityPercent = opacityPercent;
+            Opacity = opacity;
             StrokeWidth = strokeWidth;
             CapType = capType;
             JoinType = joinType;
             MiterLimit = miterLimit;
         }
 
-        public Animatable<double> OpacityPercent { get; }
+        public Animatable<Opacity> Opacity { get; }
 
         public Animatable<double> StrokeWidth { get; }
 

--- a/source/LottieData/SolidColorFill.cs
+++ b/source/LottieData/SolidColorFill.cs
@@ -12,9 +12,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
         public SolidColorFill(
             in ShapeLayerContentArgs args,
             PathFillType fillType,
-            Animatable<double> opacityPercent,
+            Animatable<Opacity> opacity,
             Animatable<Color> color)
-            : base(in args, fillType, opacityPercent)
+            : base(in args, fillType, opacity)
         {
             Color = color;
         }

--- a/source/LottieData/SolidColorStroke.cs
+++ b/source/LottieData/SolidColorStroke.cs
@@ -20,12 +20,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
             Animatable<double> dashOffset,
             IEnumerable<double> dashPattern,
             Animatable<Color> color,
-            Animatable<double> opacityPercent,
+            Animatable<Opacity> opacity,
             Animatable<double> strokeWidth,
             LineCapType capType,
             LineJoinType joinType,
             double miterLimit)
-            : base(in args, opacityPercent, strokeWidth, capType, joinType, miterLimit)
+            : base(in args, opacity, strokeWidth, capType, joinType, miterLimit)
         {
             DashOffset = dashOffset;
             _dashPattern = dashPattern.ToArray();

--- a/source/LottieData/Transform.cs
+++ b/source/LottieData/Transform.cs
@@ -15,14 +15,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
             IAnimatableVector3 position,
             IAnimatableVector3 scalePercent,
             Animatable<double> rotationDegrees,
-            Animatable<double> opacityPercent)
+            Animatable<Opacity> opacity)
             : base(in args)
         {
             Anchor = anchor;
             Position = position;
             ScalePercent = scalePercent;
             RotationDegrees = rotationDegrees;
-            OpacityPercent = opacityPercent;
+            Opacity = opacity;
         }
 
         /// <summary>
@@ -39,9 +39,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 
         public Animatable<double> RotationDegrees { get; }
 
-        public Animatable<double> OpacityPercent { get; }
+        public Animatable<Opacity> Opacity { get; }
 
-        public bool IsAnimated => Anchor.IsAnimated || Position.IsAnimated || ScalePercent.IsAnimated || RotationDegrees.IsAnimated || OpacityPercent.IsAnimated;
+        public bool IsAnimated => Anchor.IsAnimated || Position.IsAnimated || ScalePercent.IsAnimated || RotationDegrees.IsAnimated || Opacity.IsAnimated;
 
         /// <inheritdoc/>
         public override ShapeContentType ContentType => ShapeContentType.Transform;

--- a/source/LottieReader/Serialization/LottieCompositionReader.cs
+++ b/source/LottieReader/Serialization/LottieCompositionReader.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
     sealed class LottieCompositionReader
     {
         static readonly AnimatableFloatParser s_animatableFloatParser = new AnimatableFloatParser();
+        static readonly AnimatableOpacityParser s_animatableOpacityParser = new AnimatableOpacityParser();
         static readonly AnimatableVector2Parser s_animatableVector2Parser = new AnimatableVector2Parser();
         static readonly AnimatableVector3Parser s_animatableVector3Parser = new AnimatableVector3Parser();
         static readonly AnimatableGeometryParser s_animatableGeometryParser = new AnimatableGeometryParser();
@@ -812,7 +813,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
                 var inverted = obj.GetNamedBoolean("inv");
                 var name = ReadName(obj);
                 var animatedGeometry = ReadAnimatableGeometry(obj.GetNamedObject("pt"));
-                var opacityPercent = ReadAnimatableFloat(obj.GetNamedObject("o"));
+                var opacity = ReadOpacityFromO(obj);
                 var mode = Mask.MaskMode.None;
                 var maskMode = obj.GetNamedString("mode");
                 switch (maskMode)
@@ -848,7 +849,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
                     inverted,
                     name,
                     animatedGeometry,
-                    opacityPercent,
+                    opacity,
                     mode
                 );
             }
@@ -983,8 +984,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
             IgnoreFieldThatIsNotYetSupported(obj, "fillEnabled");
             IgnoreFieldThatIsNotYetSupported(obj, "hd");
 
-            var color = ReadColor(obj);
-            var opacityPercent = ReadOpacityPercent(obj);
+            var color = ReadColorFromC(obj);
+            var opacity = ReadOpacityFromO(obj);
             var strokeWidth = ReadAnimatableFloat(obj.GetNamedObject("w"));
             var capType = LcToLineCapType(obj.GetNamedNumber("lc"));
             var joinType = LjToLineJoinType(obj.GetNamedNumber("lj"));
@@ -1019,7 +1020,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
                 offset ?? s_animatable_0,
                 dashPattern,
                 color,
-                opacityPercent,
+                opacity,
                 strokeWidth,
                 capType,
                 joinType,
@@ -1047,7 +1048,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
             IgnoreFieldThatIsNotYetSupported(obj, "t");
             IgnoreFieldThatIsNotYetSupported(obj, "1");
 
-            var opacityPercent = ReadOpacityPercent(obj);
+            var opacity = ReadOpacityFromO(obj);
             var strokeWidth = ReadAnimatableFloat(obj.GetNamedObject("w"));
             var capType = LcToLineCapType(obj.GetNamedNumber("lc"));
             var joinType = LjToLineJoinType(obj.GetNamedNumber("lj"));
@@ -1059,7 +1060,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
             AssertAllFieldsRead(obj);
             return new LinearGradientStroke(
                 in shapeLayerContentArgs,
-                opacityPercent,
+                opacity,
                 strokeWidth,
                 capType,
                 joinType,
@@ -1092,7 +1093,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
                 highlightDegrees = ReadAnimatableFloat(highlightAngleObject);
             }
 
-            var opacityPercent = ReadOpacityPercent(obj);
+            var opacity = ReadOpacityFromO(obj);
             var strokeWidth = ReadAnimatableFloat(obj.GetNamedObject("w"));
             var capType = LcToLineCapType(obj.GetNamedNumber("lc"));
             var joinType = LjToLineJoinType(obj.GetNamedNumber("lj"));
@@ -1104,7 +1105,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
             AssertAllFieldsRead(obj);
             return new RadialGradientStroke(
                 in shapeLayerContentArgs,
-                opacityPercent: opacityPercent,
+                opacity: opacity,
                 strokeWidth: strokeWidth,
                 capType: capType,
                 joinType: joinType,
@@ -1125,11 +1126,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
             IgnoreFieldThatIsNotYetSupported(obj, "hd");
 
             var fillType = ReadFillType(obj);
-            var opacityPercent = ReadOpacityPercent(obj);
-            var color = ReadColor(obj);
+            var opacity = ReadOpacityFromO(obj);
+            var color = ReadColorFromC(obj);
 
             AssertAllFieldsRead(obj);
-            return new SolidColorFill(in shapeLayerContentArgs, fillType, opacityPercent, color);
+            return new SolidColorFill(in shapeLayerContentArgs, fillType, opacity, color);
         }
 
         // gf
@@ -1153,7 +1154,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
             IgnoreFieldThatIsNotYetSupported(obj, "1");
 
             var fillType = ReadFillType(obj);
-            var opacityPercent = ReadOpacityPercent(obj);
+            var opacity = ReadOpacityFromO(obj);
             var startPoint = ReadAnimatableVector3(obj.GetNamedObject("s"));
             var endPoint = ReadAnimatableVector3(obj.GetNamedObject("e"));
             ReadAnimatableGradientStops(obj.GetNamedObject("g"), out var gradientStops);
@@ -1176,7 +1177,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
             return new RadialGradientFill(
                 in shapeLayerContentArgs,
                 fillType: fillType,
-                opacityPercent: opacityPercent,
+                opacity: opacity,
                 startPoint: startPoint,
                 endPoint: endPoint,
                 gradientStops: gradientStops,
@@ -1190,7 +1191,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
             IgnoreFieldThatIsNotYetSupported(obj, "hd");
 
             var fillType = ReadFillType(obj);
-            var opacityPercent = ReadOpacityPercent(obj);
+            var opacity = ReadOpacityFromO(obj);
             var startPoint = ReadAnimatableVector3(obj.GetNamedObject("s"));
             var endPoint = ReadAnimatableVector3(obj.GetNamedObject("e"));
             ReadAnimatableGradientStops(obj.GetNamedObject("g"), out var gradientStops);
@@ -1199,7 +1200,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
             return new LinearGradientFill(
                 in shapeLayerContentArgs,
                 fillType: fillType,
-                opacityPercent: opacityPercent,
+                opacity: opacity,
                 startPoint: startPoint,
                 endPoint: endPoint,
                 gradientStops: gradientStops);
@@ -1386,21 +1387,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
             return isWindingFill ? ShapeFill.PathFillType.Winding : ShapeFill.PathFillType.EvenOdd;
         }
 
-        Animatable<double> ReadOpacityPercent(JObject obj)
-        {
-            var jsonOpacity = obj.GetNamedObject("o", null);
-            return ReadOpacityPercentFromObject(jsonOpacity);
-        }
-
-        Animatable<double> ReadOpacityPercentFromObject(JObject obj)
-        {
-            var result = obj != null
-                ? ReadAnimatableFloat(obj)
-                : new Animatable<double>(100, null);
-            return result;
-        }
-
-        Animatable<Color> ReadColor(JObject obj) =>
+        Animatable<Color> ReadColorFromC(JObject obj) =>
             ReadAnimatableColor(obj.GetNamedObject("c", null));
 
         Animatable<Color> ReadAnimatableColor(JObject obj)
@@ -1423,8 +1410,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
         // except they have an extra couple properties.
         RepeaterTransform ReadRepeaterTransform(JObject obj, in ShapeLayerContent.ShapeLayerContentArgs shapeLayerContentArgs)
         {
-            var startOpacityPercent = ReadOpacityPercentFromObject(obj.GetNamedObject("so", null));
-            var endOpacityPercent = ReadOpacityPercentFromObject(obj.GetNamedObject("eo", null));
+            var startOpacity = ReadOpacityFromObject(obj.GetNamedObject("so", null));
+            var endOpacity = ReadOpacityFromObject(obj.GetNamedObject("eo", null));
             var transform = ReadTransform(obj, in shapeLayerContentArgs);
             return new RepeaterTransform(
                 in shapeLayerContentArgs,
@@ -1432,9 +1419,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
                 transform.Position,
                 transform.ScalePercent,
                 transform.RotationDegrees,
-                transform.OpacityPercent,
-                startOpacityPercent,
-                endOpacityPercent);
+                transform.Opacity,
+                startOpacity,
+                endOpacity);
         }
 
         Transform ReadTransform(JObject obj, in ShapeLayerContent.ShapeLayerContentArgs shapeLayerContentArgs)
@@ -1467,9 +1454,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
                         ? ReadAnimatableFloat(rotationJson)
                         : new Animatable<double>(0, null);
 
-            var opacityPercent = ReadOpacityPercent(obj);
+            var opacity = ReadOpacityFromO(obj);
 
-            return new Transform(in shapeLayerContentArgs, anchor, position, scalePercent, rotation, opacityPercent);
+            return new Transform(in shapeLayerContentArgs, anchor, position, scalePercent, rotation, opacity);
         }
 
         static bool? ReadBool(JObject obj, string name)
@@ -1598,8 +1585,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
             if (numberOfColorStops.HasValue)
             {
                 // There may be opacity stops. Read them.
-                var animatableOpacityPercentStopsParser = new AnimatableOpacityPercentStopsParser(numberOfColorStops.Value);
-                animatableOpacityPercentStopsParser.ParseJson(
+                var animatableOpacityStopsParser = new AnimatableOpacityStopsParser(numberOfColorStops.Value);
+                animatableOpacityStopsParser.ParseJson(
                     this,
                     obj.GetNamedObject("k"),
                     out var opacityKeyFrames,
@@ -1680,6 +1667,30 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
             return keyFrames.Any()
                 ? new Animatable<double>(keyFrames, propertyIndex)
                 : new Animatable<double>(initialValue, propertyIndex);
+        }
+
+        Animatable<Opacity> ReadOpacityFromO(JObject obj)
+        {
+            var jsonOpacity = obj.GetNamedObject("o", null);
+            return ReadOpacityFromObject(jsonOpacity);
+        }
+
+        Animatable<Opacity> ReadOpacityFromObject(JObject obj)
+        {
+            var result = obj != null
+                ? ReadAnimatableOpacity(obj)
+                : new Animatable<Opacity>(Opacity.Opaque, null);
+            return result;
+        }
+
+        Animatable<Opacity> ReadAnimatableOpacity(JObject obj)
+        {
+            s_animatableOpacityParser.ParseJson(this, obj, out IEnumerable<KeyFrame<Opacity>> keyFrames, out Opacity initialValue);
+            var propertyIndex = ReadInt(obj, "ix");
+
+            return keyFrames.Any()
+                ? new Animatable<Opacity>(keyFrames, propertyIndex)
+                : new Animatable<Opacity>(initialValue, propertyIndex);
         }
 
         static Vector3 ReadVector3FromJsonArray(JArray array)
@@ -1981,12 +1992,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
             }
         }
 
-        sealed class AnimatableOpacityPercentStopsParser : AnimatableParser<Sequence<GradientStop>>
+        sealed class AnimatableOpacityStopsParser : AnimatableParser<Sequence<GradientStop>>
         {
             // The number of color stops. The opacity stops follow this number of color stops.
             readonly int _colorStopCount;
 
-            internal AnimatableOpacityPercentStopsParser(int colorStopCount)
+            internal AnimatableOpacityStopsParser(int colorStopCount)
             {
                 _colorStopCount = colorStopCount;
             }
@@ -2014,7 +2025,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
                                 opacity /= 255;
                             }
 
-                            gradientStops[i / 2] = new OpacityGradientStop(offset, opacityPercent: opacity * 100);
+                            gradientStops[i / 2] = new OpacityGradientStop(offset, opacity: Opacity.FromFloat(opacity));
                             break;
                     }
                 }
@@ -2026,6 +2037,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
         sealed class AnimatableFloatParser : AnimatableParser<double>
         {
             protected override double ReadValue(JToken obj) => ReadFloat(obj);
+        }
+
+        sealed class AnimatableOpacityParser : AnimatableParser<Opacity>
+        {
+            protected override Opacity ReadValue(JToken obj) => Opacity.FromFloat(ReadFloat(obj) / 100.0);
         }
 
         abstract class AnimatableParser<T>


### PR DESCRIPTION
Opacity is special because it's expressed in Lottie as a percent, which is inconvenient for multiplication with alpha.
Giving an Opacity a strong type allows us to abstract the percent details, and also make the translator clearer because it's obvious where a value is being used for opacity.