### PR TITLE
Add a type to represent rotation.

### DIFF
--- a/source/LottieData/LottieData.projitems
+++ b/source/LottieData/LottieData.projitems
@@ -59,6 +59,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)\Repeater.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\RepeaterTransform.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\RoundedCorner.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Rotation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Sequence.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Serialization\LottieCompositionXmlSerializer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Serialization\LottieCompositionYamlSerializer.cs" />

--- a/source/LottieData/LottieData.projitems
+++ b/source/LottieData/LottieData.projitems
@@ -58,8 +58,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)\Rectangle.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Repeater.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\RepeaterTransform.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\RoundedCorner.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Rotation.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\RoundedCorner.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Sequence.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Serialization\LottieCompositionXmlSerializer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Serialization\LottieCompositionYamlSerializer.cs" />

--- a/source/LottieData/Opacity.cs
+++ b/source/LottieData/Opacity.cs
@@ -7,7 +7,7 @@ using System;
 namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 {
     /// <summary>
-    /// A percentage value.
+    /// An opacity value. 0 is transparent, 1 is opaque.
     /// </summary>
 #if PUBLIC_LottieData
     public

--- a/source/LottieData/RepeaterTransform.cs
+++ b/source/LottieData/RepeaterTransform.cs
@@ -14,11 +14,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
             IAnimatableVector3 anchor,
             IAnimatableVector3 position,
             IAnimatableVector3 scalePercent,
-            Animatable<double> rotationDegrees,
+            Animatable<Rotation> rotation,
             Animatable<Opacity> opacity,
             Animatable<Opacity> startOpacity,
             Animatable<Opacity> endOpacity)
-            : base(in args, anchor, position, scalePercent, rotationDegrees, opacity)
+            : base(in args, anchor, position, scalePercent, rotation, opacity)
         {
             StartOpacity = startOpacity;
             EndOpacity = endOpacity;

--- a/source/LottieData/Rotation.cs
+++ b/source/LottieData/Rotation.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
+{
+    /// <summary>
+    /// A rotation value.
+    /// </summary>
+#if PUBLIC_LottieData
+    public
+#endif
+    struct Rotation : IEquatable<Rotation>
+    {
+        Rotation(double degrees)
+        {
+            Degrees = degrees;
+        }
+
+        public double Degrees { get; }
+
+        public double Radians => Math.PI * Degrees / 180.0;
+
+        public static Rotation None => new Rotation(0);
+
+        public static Rotation FromDegrees(double value) => new Rotation(value);
+
+        public bool Equals(Rotation other) => other.Degrees == Degrees;
+
+        public override bool Equals(object obj) => obj is Rotation other ? other.Equals(this) : false;
+
+        public override int GetHashCode() => Degrees.GetHashCode();
+
+        public override string ToString() => $"{Degrees}°";
+    }
+}

--- a/source/LottieData/Rotation.cs
+++ b/source/LottieData/Rotation.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 #if PUBLIC_LottieData
     public
 #endif
-    struct Rotation : IEquatable<Rotation>
+    readonly struct Rotation : IEquatable<Rotation>
     {
         Rotation(double degrees)
         {
@@ -29,7 +29,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 
         public bool Equals(Rotation other) => other.Degrees == Degrees;
 
-        public override bool Equals(object obj) => obj is Rotation other ? other.Equals(this) : false;
+        public override bool Equals(object obj) => obj is Rotation other && Equals(other);
 
         public override int GetHashCode() => Degrees.GetHashCode();
 

--- a/source/LottieData/Serialization/LottieCompositionXmlSerializer.cs
+++ b/source/LottieData/Serialization/LottieCompositionXmlSerializer.cs
@@ -507,7 +507,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
                 yield return FromAnimatable(nameof(content.Position), content.Position);
                 yield return FromAnimatable(nameof(content.Anchor), content.Anchor);
                 yield return FromAnimatable(nameof(content.Opacity), content.Opacity);
-                yield return FromAnimatable(nameof(content.RotationDegrees), content.RotationDegrees);
+                yield return FromAnimatable(nameof(content.Rotation), content.Rotation);
             }
         }
 
@@ -644,7 +644,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
 
                 yield return FromAnimatable(nameof(content.StartPercent), content.StartPercent);
                 yield return FromAnimatable(nameof(content.EndPercent), content.EndPercent);
-                yield return FromAnimatable(nameof(content.OffsetDegrees), content.OffsetDegrees);
+                yield return FromAnimatable(nameof(content.Offset), content.Offset);
             }
         }
 

--- a/source/LottieData/Serialization/LottieCompositionYamlSerializer.cs
+++ b/source/LottieData/Serialization/LottieCompositionYamlSerializer.cs
@@ -400,7 +400,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
             result.Add("Position", FromAnimatable(content.Position));
             result.Add("Anchor", FromAnimatable(content.Anchor));
             result.Add("OpacityPercent", FromAnimatable(content.Opacity, FromOpacityPercent));
-            result.Add("RotationDegrees", FromAnimatable(content.RotationDegrees));
+            result.Add("RotationDegrees", FromAnimatable(content.Rotation, FromRotation));
             return result;
         }
 
@@ -448,6 +448,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
         static YamlObject FromColor(Color value) => (YamlScalar)value?.ToString();
 
         static YamlObject FromOpacityPercent(Opacity value) => (YamlScalar)value.Percent;
+
+        static YamlObject FromRotation(Rotation value) => (YamlScalar)value.Degrees;
 
         static YamlObject FromVector3(Vector3 value)
         {
@@ -577,7 +579,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
             var result = superclassContent;
             result.Add("StartPercent", FromAnimatable(content.StartPercent));
             result.Add("EndPercent", FromAnimatable(content.EndPercent));
-            result.Add("OffsetDegrees", FromAnimatable(content.OffsetDegrees));
+            result.Add("Offset", FromAnimatable(content.Offset, FromRotation));
             return result;
         }
 

--- a/source/LottieData/Transform.cs
+++ b/source/LottieData/Transform.cs
@@ -14,14 +14,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
             IAnimatableVector3 anchor,
             IAnimatableVector3 position,
             IAnimatableVector3 scalePercent,
-            Animatable<double> rotationDegrees,
+            Animatable<Rotation> rotation,
             Animatable<Opacity> opacity)
             : base(in args)
         {
             Anchor = anchor;
             Position = position;
             ScalePercent = scalePercent;
-            RotationDegrees = rotationDegrees;
+            Rotation = rotation;
             Opacity = opacity;
         }
 
@@ -37,11 +37,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 
         public IAnimatableVector3 ScalePercent { get; }
 
-        public Animatable<double> RotationDegrees { get; }
+        public Animatable<Rotation> Rotation { get; }
 
         public Animatable<Opacity> Opacity { get; }
 
-        public bool IsAnimated => Anchor.IsAnimated || Position.IsAnimated || ScalePercent.IsAnimated || RotationDegrees.IsAnimated || Opacity.IsAnimated;
+        public bool IsAnimated => Anchor.IsAnimated || Position.IsAnimated || ScalePercent.IsAnimated || Rotation.IsAnimated || Opacity.IsAnimated;
 
         /// <inheritdoc/>
         public override ShapeContentType ContentType => ShapeContentType.Transform;

--- a/source/LottieData/TrimPath.cs
+++ b/source/LottieData/TrimPath.cs
@@ -14,20 +14,20 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
             TrimType trimPathType,
             Animatable<double> startPercent,
             Animatable<double> endPercent,
-            Animatable<double> offsetDegrees)
+            Animatable<Rotation> offset)
             : base(in args)
         {
             TrimPathType = trimPathType;
             StartPercent = startPercent;
             EndPercent = endPercent;
-            OffsetDegrees = offsetDegrees;
+            Offset = offset;
         }
 
         public Animatable<double> StartPercent { get; }
 
         public Animatable<double> EndPercent { get; }
 
-        public Animatable<double> OffsetDegrees { get; }
+        public Animatable<Rotation> Offset { get; }
 
         public TrimType TrimPathType { get; }
 

--- a/source/LottieToWinComp/LottieToWinCompTranslator.cs
+++ b/source/LottieToWinComp/LottieToWinCompTranslator.cs
@@ -1441,10 +1441,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                     return a;
                 }
 
-                if (!a.StartPercent.IsAnimated && !a.StartPercent.IsAnimated && !a.OffsetDegrees.IsAnimated)
+                if (!a.StartPercent.IsAnimated && !a.StartPercent.IsAnimated && !a.Offset.IsAnimated)
                 {
                     // a is not animated.
-                    if (!b.StartPercent.IsAnimated && !b.StartPercent.IsAnimated && !b.OffsetDegrees.IsAnimated)
+                    if (!b.StartPercent.IsAnimated && !b.StartPercent.IsAnimated && !b.Offset.IsAnimated)
                     {
                         // Both are not animated.
                         if (a.StartPercent.InitialValue == b.EndPercent.InitialValue)
@@ -1457,12 +1457,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                             // b trims out everything. a is unnecessary.
                             return b;
                         }
-                        else if (a.StartPercent.InitialValue == 0 && a.EndPercent.InitialValue == 100 && a.OffsetDegrees.InitialValue == 0)
+                        else if (a.StartPercent.InitialValue == 0 && a.EndPercent.InitialValue == 100 && a.Offset.InitialValue.Degrees == 0)
                         {
                             // a is trimming nothing. a is unnecessary.
                             return b;
                         }
-                        else if (b.StartPercent.InitialValue == 0 && b.EndPercent.InitialValue == 100 && b.OffsetDegrees.InitialValue == 0)
+                        else if (b.StartPercent.InitialValue == 0 && b.EndPercent.InitialValue == 100 && b.Offset.InitialValue.Degrees == 0)
                         {
                             // b is trimming nothing. b is unnecessary.
                             return a;
@@ -1968,7 +1968,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             var anchor = Vector2(transform.Anchor.InitialValue);
             var position = Vector2(transform.Position.InitialValue);
             var scale = Vector2(transform.ScalePercent.InitialValue / 100.0);
-            var rotation = (float)DegreesToRadians(transform.RotationDegrees.InitialValue);
+            var rotation = (float)transform.Rotation.InitialValue.Radians;
 
             // Calculate the matrix that is equivalent to the properties.
             var combinedMatrix =
@@ -1978,8 +1978,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 
             return combinedMatrix;
         }
-
-        static double DegreesToRadians(double angle) => Math.PI * angle / 180.0;
 
         CanvasGeometry CreateWin2dPathGeometryFromShape(
             TranslationContext context,
@@ -2268,7 +2266,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             // TODO - this only works correctly if Size and TrimOffset are not animated. A complete solution requires
             //        adding another property.
             var isPartialTrimPath = shapeContext.TrimPath != null &&
-                (shapeContext.TrimPath.StartPercent.IsAnimated || shapeContext.TrimPath.EndPercent.IsAnimated || shapeContext.TrimPath.OffsetDegrees.IsAnimated ||
+                (shapeContext.TrimPath.StartPercent.IsAnimated || shapeContext.TrimPath.EndPercent.IsAnimated || shapeContext.TrimPath.Offset.IsAnimated ||
                 shapeContext.TrimPath.StartPercent.InitialValue != 0 || shapeContext.TrimPath.EndPercent.InitialValue != 100);
 
             if (size.IsAnimated && isPartialTrimPath)
@@ -2473,7 +2471,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 
             var startPercent = context.TrimAnimatable(trimPath.StartPercent);
             var endPercent = context.TrimAnimatable(trimPath.EndPercent);
-            var trimPathOffsetDegrees = context.TrimAnimatable(trimPath.OffsetDegrees);
+            var trimPathOffset = context.TrimAnimatable(trimPath.Offset);
 
             if (!startPercent.IsAnimated && !endPercent.IsAnimated)
             {
@@ -2557,12 +2555,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                 }
             }
 
-            if (trimOffsetDegrees != 0 && !trimPathOffsetDegrees.IsAnimated)
+            if (trimOffsetDegrees != 0 && !trimPathOffset.IsAnimated)
             {
                 // Rectangle shapes are treated specially here to account for Lottie rectangle 0,0 being
                 // top right and WinComp rectangle 0,0 being top left. As long as the TrimOffset isn't
                 // being animated we can simply add an offset to the trim path.
-                geometry.TrimOffset = (float)((trimPathOffsetDegrees.InitialValue + trimOffsetDegrees) / 360);
+                geometry.TrimOffset = (float)((trimPathOffset.InitialValue.Degrees + trimOffsetDegrees) / 360);
             }
             else
             {
@@ -2572,13 +2570,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                     _issues.AnimatedTrimOffsetWithStaticTrimOffsetIsNotSupported();
                 }
 
-                if (trimPathOffsetDegrees.IsAnimated)
+                if (trimPathOffset.IsAnimated)
                 {
-                    ApplyScaledScalarKeyFrameAnimation(context, trimPathOffsetDegrees, 1 / 360.0, geometry, nameof(geometry.TrimOffset), "TrimOffset", null);
+                    ApplyScaledRotationKeyFrameAnimation(context, trimPathOffset, 1 / 360.0, geometry, nameof(geometry.TrimOffset), "TrimOffset", null);
                 }
                 else
                 {
-                    geometry.TrimOffset = Float(trimPathOffsetDegrees.InitialValue / 360);
+                    geometry.TrimOffset = Float(trimPathOffset.InitialValue.Degrees / 360);
                 }
             }
         }
@@ -3383,7 +3381,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                 context,
                 transform.Anchor,
                 transform.Position,
-                context.TrimAnimatable(transform.RotationDegrees),
+                context.TrimAnimatable(transform.Rotation),
                 context.TrimAnimatable(transform.ScalePercent),
                 container);
 
@@ -3395,7 +3393,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             TranslationContext context,
             IAnimatableVector3 anchor,
             IAnimatableVector3 position,
-            in TrimmedAnimatable<double> rotationDegrees,
+            in TrimmedAnimatable<Rotation> rotation,
             in TrimmedAnimatable<Vector3> scalePercent,
             ContainerShapeOrVisual container)
         {
@@ -3411,13 +3409,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             //    as just an offset)
             //
             // The current implementation doesn't take all cases into consideration yet.
-            if (rotationDegrees.IsAnimated)
+            if (rotation.IsAnimated)
             {
-                ApplyScalarKeyFrameAnimation(context, rotationDegrees, container, nameof(container.RotationAngleInDegrees), "Rotation");
+                ApplyRotationKeyFrameAnimation(context, rotation, container, nameof(container.RotationAngleInDegrees), "Rotation");
             }
             else
             {
-                container.RotationAngleInDegrees = FloatDefaultIsZero(rotationDegrees.InitialValue);
+                container.RotationAngleInDegrees = FloatDefaultIsZero(rotation.InitialValue.Degrees);
             }
 
 #if !NoScaling
@@ -3649,6 +3647,15 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             controller.StartAnimation("Progress", bindingAnimation);
         }
 
+        void ApplyRotationKeyFrameAnimation(
+            TranslationContext context,
+            in TrimmedAnimatable<Rotation> value,
+            CompositionObject targetObject,
+            string targetPropertyName,
+            string longDescription = null,
+            string shortDescription = null)
+            => ApplyScaledRotationKeyFrameAnimation(context, value, 1, targetObject, targetPropertyName, longDescription, shortDescription);
+
         void ApplyScalarKeyFrameAnimation(
             TranslationContext context,
             in TrimmedAnimatable<double> value,
@@ -3675,6 +3682,28 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             string longDescription = null,
             string shortDescription = null)
             => ApplyScaledOpacityKeyFrameAnimation(context, value, 1, targetObject, targetPropertyName, longDescription, shortDescription);
+
+        void ApplyScaledRotationKeyFrameAnimation(
+            TranslationContext context,
+            in TrimmedAnimatable<Rotation> value,
+            double scale,
+            CompositionObject targetObject,
+            string targetPropertyName,
+            string longDescription,
+            string shortDescription)
+        {
+            Debug.Assert(value.IsAnimated, "Precondition");
+            GenericCreateCompositionKeyFrameAnimation(
+                context,
+                value,
+                _c.CreateScalarKeyFrameAnimation,
+                (ca, progress, val, easing) => ca.InsertKeyFrame(progress, (float)(val.Degrees * scale), easing),
+                null,
+                targetObject,
+                targetPropertyName,
+                longDescription,
+                shortDescription);
+        }
 
         void ApplyScaledOpacityKeyFrameAnimation(
             TranslationContext context,


### PR DESCRIPTION
Previously we just used a double and you had to know that it was represented in degrees. Now the type directly represents 2d rotation and has properties to express the rotation in degrees and in radians.

This change also fixed up a few places I noticed where the Opacity type was still talking about OpacityPercent.