### PR TITLE
Add ability to get the type for a given CompositionPropertySet property name.

### DIFF
--- a/source/Lottie/Instantiator.cs
+++ b/source/Lottie/Instantiator.cs
@@ -485,29 +485,48 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
 
             result = CacheAndInitializeCompositionObject(obj, result);
 
-            foreach (var prop in obj.ColorProperties)
+            foreach (var (name, type) in obj.Names)
             {
-                result.InsertColor(prop.Key, Color(prop.Value));
-            }
+                switch (type)
+                {
+                    case Wd.MetaData.PropertySetValueType.Color:
+                        {
+                            obj.TryGetColor(name, out var value);
+                            result.InsertColor(name, Color(value));
+                            break;
+                        }
 
-            foreach (var prop in obj.ScalarProperties)
-            {
-                result.InsertScalar(prop.Key, prop.Value);
-            }
+                    case Wd.MetaData.PropertySetValueType.Scalar:
+                        {
+                            obj.TryGetScalar(name, out var value);
+                            result.InsertScalar(name, value);
+                            break;
+                        }
 
-            foreach (var prop in obj.Vector2Properties)
-            {
-                result.InsertVector2(prop.Key, prop.Value);
-            }
+                    case Wd.MetaData.PropertySetValueType.Vector2:
+                        {
+                            obj.TryGetVector2(name, out var value);
+                            result.InsertVector2(name, value);
+                            break;
+                        }
 
-            foreach (var prop in obj.Vector3Properties)
-            {
-                result.InsertVector3(prop.Key, prop.Value);
-            }
+                    case Wd.MetaData.PropertySetValueType.Vector3:
+                        {
+                            obj.TryGetVector3(name, out var value);
+                            result.InsertVector3(name, value);
+                            break;
+                        }
 
-            foreach (var prop in obj.Vector4Properties)
-            {
-                result.InsertVector4(prop.Key, prop.Value);
+                    case Wd.MetaData.PropertySetValueType.Vector4:
+                        {
+                            obj.TryGetVector4(name, out var value);
+                            result.InsertVector4(name, value);
+                            break;
+                        }
+
+                    default:
+                        throw new InvalidOperationException();
+                }
             }
 
             StartAnimations(obj, result);

--- a/source/UIData/Tools/Canonicalizer.cs
+++ b/source/UIData/Tools/Canonicalizer.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.Tools
                     from item in items
                     let obj = item.Object
                     where (_ignoreCommentProperties || obj.Comment == null)
-                       && obj.Properties.IsEmpty
+                       && obj.Properties.Names.Count == 0
                        && obj.Animators.Count == 0
                     select (item.Node, obj);
             }
@@ -312,7 +312,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.Tools
                     from item in nodes
                     let obj = item.Object
                     where (_ignoreCommentProperties || obj.Comment == null)
-                       && obj.Properties.IsEmpty
+                       && obj.Properties.Names.Count == 0
                     select (item.Node, obj);
 
                 var grouping =
@@ -346,7 +346,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.Tools
                     from b in gradientBrushes
                     let nonAnimatedStops = from s in b.Object.ColorStops
                                            where (_ignoreCommentProperties || s.Comment == null)
-                                              && s.Properties.IsEmpty && !s.Animators.Any()
+                                              && s.Properties.Names.Count == 0 && !s.Animators.Any()
                                            group s by (s.Color, s.Offset) into g
                                            from s2 in g.Zip(PositiveInts, (x, y) => (Stop: x, Index: y))
                                            select s2
@@ -373,7 +373,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.Tools
                     from item in nodes
                     let obj = item.Object
                     where (_ignoreCommentProperties || obj.Comment == null)
-                       && obj.Properties.IsEmpty
+                       && obj.Properties.Names.Count == 0
                     select (item.Node, obj);
 
                 var grouping =

--- a/source/UIData/Tools/Optimizer.cs
+++ b/source/UIData/Tools/Optimizer.cs
@@ -495,29 +495,48 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.Tools
 
             result = CacheAndInitializeCompositionObject(obj, result);
 
-            foreach (var prop in obj.ColorProperties)
+            foreach (var (name, type) in obj.Names)
             {
-                result.InsertColor(prop.Key, prop.Value);
-            }
+                switch (type)
+                {
+                    case WinCompData.MetaData.PropertySetValueType.Color:
+                        {
+                            obj.TryGetColor(name, out var value);
+                            result.InsertColor(name, value);
+                            break;
+                        }
 
-            foreach (var prop in obj.ScalarProperties)
-            {
-                result.InsertScalar(prop.Key, prop.Value);
-            }
+                    case WinCompData.MetaData.PropertySetValueType.Scalar:
+                        {
+                            obj.TryGetScalar(name, out var value);
+                            result.InsertScalar(name, value);
+                            break;
+                        }
 
-            foreach (var prop in obj.Vector2Properties)
-            {
-                result.InsertVector2(prop.Key, prop.Value);
-            }
+                    case WinCompData.MetaData.PropertySetValueType.Vector2:
+                        {
+                            obj.TryGetVector2(name, out var value);
+                            result.InsertVector2(name, value);
+                            break;
+                        }
 
-            foreach (var prop in obj.Vector3Properties)
-            {
-                result.InsertVector3(prop.Key, prop.Value);
-            }
+                    case WinCompData.MetaData.PropertySetValueType.Vector3:
+                        {
+                            obj.TryGetVector3(name, out var value);
+                            result.InsertVector3(name, value);
+                            break;
+                        }
 
-            foreach (var prop in obj.Vector4Properties)
-            {
-                result.InsertVector4(prop.Key, prop.Value);
+                    case WinCompData.MetaData.PropertySetValueType.Vector4:
+                        {
+                            obj.TryGetVector4(name, out var value);
+                            result.InsertVector4(name, value);
+                            break;
+                        }
+
+                    default:
+                        throw new InvalidOperationException();
+                }
             }
 
             StartAnimationsAndFreeze(obj, result);

--- a/source/UIData/Tools/Stats.cs
+++ b/source/UIData/Tools/Stats.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.Tools
                         break;
                     case CompositionObjectType.CompositionPropertySet:
                         {
-                            var propertyCount = ((CompositionPropertySet)n.Object).PropertyNames.Count();
+                            var propertyCount = ((CompositionPropertySet)n.Object).Names.Count();
                             if (propertyCount > 0)
                             {
                                 PropertySetCount++;

--- a/source/UIData/Tools/TreeReducer.cs
+++ b/source/UIData/Tools/TreeReducer.cs
@@ -232,7 +232,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.Tools
             var elidableContainers = containerShapes.Where(n =>
             {
                 var container = (CompositionContainerShape)n.Object;
-                if (!container.Properties.IsEmpty ||
+                if (container.Properties.Names.Count > 0 ||
                     container.Animators.Count > 0 ||
                     container.CenterPoint != null ||
                     container.Offset != null ||
@@ -244,7 +244,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.Tools
 
                 foreach (var child in container.Shapes)
                 {
-                    if (!child.Properties.IsEmpty ||
+                    if (child.Properties.Names.Count > 0 ||
                         child.Animators.Count > 0 ||
                         child.CenterPoint != null ||
                         child.Offset != null ||
@@ -286,7 +286,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.Tools
                     container.Scale != null ||
                     container.TransformMatrix != null ||
                     container.Animators.Count > 0 ||
-                    !container.Properties.IsEmpty)
+                    container.Properties.Names.Count > 0)
                 {
                     return false;
                 }
@@ -366,7 +366,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.Tools
                     container.Size == null &&
                     container.TransformMatrix == null &&
                     container.Animators.Count == 0 &&
-                    container.Properties.IsEmpty;
+                    container.Properties.Names.Count == 0;
             }).ToArray();
 
             // Pull the children of the container into the parent of the container. Remove the unnecessary containers.

--- a/source/UIDataCodeGen/CodeGen/InstantiatorGeneratorBase.cs
+++ b/source/UIDataCodeGen/CodeGen/InstantiatorGeneratorBase.cs
@@ -778,15 +778,15 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
             nodes.OrderBy(n => n.Name, AlphanumericStringComparer.Instance);
 
         static string PropertySetValueType(PropertySetValueType value)
-    => value switch
-    {
-        WinCompData.MetaData.PropertySetValueType.Color => "Color",
-        WinCompData.MetaData.PropertySetValueType.Scalar => "Scalar",
-        WinCompData.MetaData.PropertySetValueType.Vector2 => "Vector2",
-        WinCompData.MetaData.PropertySetValueType.Vector3 => "Vector3",
-        WinCompData.MetaData.PropertySetValueType.Vector4 => "Vector4",
-        _ => throw new InvalidOperationException(),
-    };
+            => value switch
+            {
+                WinCompData.MetaData.PropertySetValueType.Color => "Color",
+                WinCompData.MetaData.PropertySetValueType.Scalar => "Scalar",
+                WinCompData.MetaData.PropertySetValueType.Vector2 => "Vector2",
+                WinCompData.MetaData.PropertySetValueType.Vector3 => "Vector3",
+                WinCompData.MetaData.PropertySetValueType.Vector4 => "Vector4",
+                _ => throw new InvalidOperationException(),
+            };
 
         string PropertySetValueInitializer(CompositionPropertySet propertySet, string propertyName, WinCompData.MetaData.PropertySetValueType propertyType)
             => propertyType switch

--- a/source/WinCompData/CompositionPropertySet.cs
+++ b/source/WinCompData/CompositionPropertySet.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Numerics;
 using Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.MetaData;
 using Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Wui;
@@ -77,6 +78,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData
 
         void Insert<T>(string propertyName, in T value, PropertySetValueType type, ref PropertyBag<T> bag)
         {
+            Debug.Assert(type != PropertySetValueType.None, "Precondition");
+
             // Ensure the names set exists.
             if (_names == s_empty)
             {

--- a/source/WinCompData/CompositionPropertySet.cs
+++ b/source/WinCompData/CompositionPropertySet.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Numerics;
 using Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.MetaData;
 using Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Wui;

--- a/source/WinCompData/CompositionPropertySet.cs
+++ b/source/WinCompData/CompositionPropertySet.cs
@@ -6,19 +6,24 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.MetaData;
 using Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Wui;
 
 namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData
 {
     // CompositionPropertySet was introduced in version 2. Boolean types
     // were added in version 3.
-    [MetaData.UapVersion(2)]
+    [UapVersion(2)]
 #if PUBLIC_WinCompData
     public
 #endif
     sealed class CompositionPropertySet : CompositionObject
     {
-        HashSet<string> _names;
+        static readonly SortedDictionary<string, PropertySetValueType> s_empty = new SortedDictionary<string, PropertySetValueType>();
+
+        // Initialized to an empty sentinel value, then replaced with a new object
+        // when the first value is added.
+        SortedDictionary<string, PropertySetValueType> _names = s_empty;
         PropertyBag<Color> _colorProperties;
         PropertyBag<float> _scalarProperties;
         PropertyBag<Vector2> _vector2Properties;
@@ -32,70 +37,76 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData
 
         public CompositionObject Owner { get; }
 
-        public void InsertColor(string propertyName, Color value) => Insert(propertyName, in value, ref _colorProperties);
+        public void InsertColor(string propertyName, Color value)
+            => Insert(propertyName, in value, PropertySetValueType.Color, ref _colorProperties);
 
-        public void InsertScalar(string propertyName, float value) => Insert(propertyName, in value, ref _scalarProperties);
+        public void InsertScalar(string propertyName, float value)
+            => Insert(propertyName, in value, PropertySetValueType.Scalar, ref _scalarProperties);
 
-        public void InsertVector2(string propertyName, Vector2 value) => Insert(propertyName, in value, ref _vector2Properties);
+        public void InsertVector2(string propertyName, Vector2 value)
+            => Insert(propertyName, in value, PropertySetValueType.Vector2, ref _vector2Properties);
 
-        public void InsertVector3(string propertyName, Vector3 value) => Insert(propertyName, in value, ref _vector3Properties);
+        public void InsertVector3(string propertyName, Vector3 value)
+            => Insert(propertyName, in value, PropertySetValueType.Vector3, ref _vector3Properties);
 
-        public void InsertVector4(string propertyName, Vector4 value) => Insert(propertyName, in value, ref _vector4Properties);
+        public void InsertVector4(string propertyName, Vector4 value)
+            => Insert(propertyName, in value, PropertySetValueType.Vector4, ref _vector4Properties);
 
-        public CompositionGetValueStatus TryGetColor(string propertyName, out Color value) => TryGet(propertyName, ref _colorProperties, out value);
+        public CompositionGetValueStatus TryGetColor(string propertyName, out Color value)
+            => TryGet(propertyName, PropertySetValueType.Color, ref _colorProperties, out value);
 
-        public CompositionGetValueStatus TryGetScalar(string propertyName, out float value) => TryGet(propertyName, ref _scalarProperties, out value);
+        public CompositionGetValueStatus TryGetScalar(string propertyName, out float value)
+            => TryGet(propertyName, PropertySetValueType.Scalar, ref _scalarProperties, out value);
 
-        public CompositionGetValueStatus TryGetVector2(string propertyName, out Vector2 value) => TryGet(propertyName, ref _vector2Properties, out value);
+        public CompositionGetValueStatus TryGetVector2(string propertyName, out Vector2 value)
+            => TryGet(propertyName, PropertySetValueType.Vector2, ref _vector2Properties, out value);
 
-        public CompositionGetValueStatus TryGetVector3(string propertyName, out Vector3 value) => TryGet(propertyName, ref _vector3Properties, out value);
+        public CompositionGetValueStatus TryGetVector3(string propertyName, out Vector3 value)
+            => TryGet(propertyName, PropertySetValueType.Vector3, ref _vector3Properties, out value);
 
-        public CompositionGetValueStatus TryGetVector4(string propertyName, out Vector4 value) => TryGet(propertyName, ref _vector4Properties, out value);
+        public CompositionGetValueStatus TryGetVector4(string propertyName, out Vector4 value)
+            => TryGet(propertyName, PropertySetValueType.Vector4, ref _vector4Properties, out value);
 
-        public IEnumerable<KeyValuePair<string, Color>> ColorProperties => _colorProperties.Entries;
-
-        public IEnumerable<KeyValuePair<string, float>> ScalarProperties => _scalarProperties.Entries;
-
-        public IEnumerable<KeyValuePair<string, Vector2>> Vector2Properties => _vector2Properties.Entries;
-
-        public IEnumerable<KeyValuePair<string, Vector3>> Vector3Properties => _vector3Properties.Entries;
-
-        public IEnumerable<KeyValuePair<string, Vector4>> Vector4Properties => _vector4Properties.Entries;
-
-        public IEnumerable<string> PropertyNames => _names ?? Enumerable.Empty<string>();
-
-        public bool IsEmpty => !(_names?.Count > 0);
+        /// <summary>
+        /// Returns the names and types of the values that have been added to this <see cref="CompositionPropertySet"/>.
+        /// The results are ordered by name.
+        /// </summary>
+        public IReadOnlyDictionary<string, PropertySetValueType> Names => _names;
 
         /// <inheritdoc/>
         public override CompositionObjectType Type => CompositionObjectType.CompositionPropertySet;
 
-        void Insert<T>(string propertyName, in T value, ref PropertyBag<T> bag)
+        void Insert<T>(string propertyName, in T value, PropertySetValueType type, ref PropertyBag<T> bag)
         {
             // Ensure the names set exists.
-            if (_names is null)
+            if (_names == s_empty)
             {
                 // CompositionPropertySet ignores the case of property names.
-                _names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                _names = new SortedDictionary<string, PropertySetValueType>(StringComparer.OrdinalIgnoreCase);
             }
 
             // Try to add the name to the set of names.
-            if (!_names.Add(propertyName))
+            if (_names.TryGetValue(propertyName, out var existingPropertyType))
             {
                 // The name already existed. That's ok as long the name is associated
                 // with the correct type.
-                if (!bag.ContainsKey(propertyName))
+                if (existingPropertyType != type)
                 {
                     throw new ArgumentException();
                 }
+            }
+            else
+            {
+                _names.Add(propertyName, type);
             }
 
             // Set the value.
             bag.SetValue(propertyName, in value);
         }
 
-        CompositionGetValueStatus TryGet<T>(string propertyName, ref PropertyBag<T> bag, out T value)
+        CompositionGetValueStatus TryGet<T>(string propertyName, PropertySetValueType type, ref PropertyBag<T> bag, out T value)
         {
-            if (_names is null || !_names.Contains(propertyName))
+            if (!_names.TryGetValue(propertyName, out var existingPropertyType))
             {
                 // The name isn't in this property set.
                 value = default(T);
@@ -103,9 +114,19 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData
             }
 
             // The name is in the property set - does it refer to the right type?
-            return bag.TryGetValue(propertyName, out value)
-                ? CompositionGetValueStatus.Succeeded
-                : CompositionGetValueStatus.TypeMismatch;
+            if (existingPropertyType != type)
+            {
+                // The name is in the property set, but not for this type.
+                value = default(T);
+                return CompositionGetValueStatus.TypeMismatch;
+            }
+
+            if (!bag.TryGetValue(propertyName, out value))
+            {
+                throw new InvalidOperationException();
+            }
+
+            return CompositionGetValueStatus.Succeeded;
         }
 
         struct PropertyBag<T>
@@ -138,11 +159,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData
 
                 return _dictionary.TryGetValue(propertyName, out value);
             }
-
-            internal IEnumerable<string> Names => _dictionary?.Keys ?? Enumerable.Empty<string>();
-
-            internal IEnumerable<KeyValuePair<string, T>> Entries
-                => _dictionary ?? Enumerable.Empty<KeyValuePair<string, T>>();
         }
     }
 }

--- a/source/WinCompData/MetaData/PropertySetValueType.cs
+++ b/source/WinCompData/MetaData/PropertySetValueType.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.MetaData
+{
+#if PUBLIC_WinCompData
+    public
+#endif
+    enum PropertySetValueType
+    {
+        None = 0,
+        Color,
+        Scalar,
+        Vector2,
+        Vector3,
+        Vector4,
+    }
+}

--- a/source/WinCompData/Serialization/CompositionObjectXmlSerializer.cs
+++ b/source/WinCompData/Serialization/CompositionObjectXmlSerializer.cs
@@ -565,12 +565,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Tools
 
             // Find the animations that are targetting properties in the property set.
             var propertySetAnimators =
-                from pn in obj.Properties.PropertyNames
+                from pn in obj.Properties.Names
                 from an in obj.Animators
-                where an.AnimatedProperty == pn
+                where an.AnimatedProperty == pn.Key
                 select an;
 
-            if (!obj.Properties.IsEmpty)
+            if (obj.Properties.Names.Count > 0)
             {
                 yield return FromCompositionPropertySet(obj.Properties, propertySetAnimators);
             }
@@ -698,43 +698,67 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Tools
             return new XElement("PropertySet", GetContents());
             IEnumerable<XObject> GetContents()
             {
-                foreach (var prop in obj.ColorProperties)
+                foreach (var (name, type) in obj.Names)
                 {
-                    foreach (var item in FromAnimatableColor(prop.Key, animators, prop.Value))
+                    switch (type)
                     {
-                        yield return item;
-                    }
-                }
+                        case MetaData.PropertySetValueType.Color:
+                            {
+                                obj.TryGetColor(name, out var value);
+                                foreach (var item in FromAnimatableColor(name, animators, value))
+                                {
+                                    yield return item;
+                                }
 
-                foreach (var prop in obj.ScalarProperties)
-                {
-                    foreach (var item in FromAnimatableScalar(prop.Key, animators, prop.Value))
-                    {
-                        yield return item;
-                    }
-                }
+                                break;
+                            }
 
-                foreach (var prop in obj.Vector2Properties)
-                {
-                    foreach (var item in FromAnimatableVector2(prop.Key, animators, prop.Value))
-                    {
-                        yield return item;
-                    }
-                }
+                        case MetaData.PropertySetValueType.Scalar:
+                            {
+                                obj.TryGetScalar(name, out var value);
+                                foreach (var item in FromAnimatableScalar(name, animators, value))
+                                {
+                                    yield return item;
+                                }
 
-                foreach (var prop in obj.Vector3Properties)
-                {
-                    foreach (var item in FromAnimatableVector3(prop.Key, animators, prop.Value))
-                    {
-                        yield return item;
-                    }
-                }
+                                break;
+                            }
 
-                foreach (var prop in obj.Vector4Properties)
-                {
-                    foreach (var item in FromAnimatableVector4(prop.Key, animators, prop.Value))
-                    {
-                        yield return item;
+                        case MetaData.PropertySetValueType.Vector2:
+                            {
+                                obj.TryGetVector2(name, out var value);
+                                foreach (var item in FromAnimatableVector2(name, animators, value))
+                                {
+                                    yield return item;
+                                }
+
+                                break;
+                            }
+
+                        case MetaData.PropertySetValueType.Vector3:
+                            {
+                                obj.TryGetVector3(name, out var value);
+                                foreach (var item in FromAnimatableVector3(name, animators, value))
+                                {
+                                    yield return item;
+                                }
+
+                                break;
+                            }
+
+                        case MetaData.PropertySetValueType.Vector4:
+                            {
+                                obj.TryGetVector4(name, out var value);
+                                foreach (var item in FromAnimatableVector4(name, animators, value))
+                                {
+                                    yield return item;
+                                }
+
+                                break;
+                            }
+
+                        default:
+                            throw new InvalidOperationException();
                     }
                 }
             }

--- a/source/WinCompData/WinCompData.projitems
+++ b/source/WinCompData/WinCompData.projitems
@@ -66,6 +66,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)KeyFrameAnimation_.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)KeyFrameType.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)LinearEasingFunction.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)MetaData\PropertySetValueType.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MetaData\UapVersionAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Mgc\CanvasComposite.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Mgce\CompositeEffect.cs" />


### PR DESCRIPTION
This also gets rid of the CompositionPropertySet.IsEmpty property in order to reduce the number of non-standard (i.e. not in Windows.UI.Composition) apis on the class.

This change is in preparation for some new features coming to property binding.