### PR TITLE
Added Lottie-Windows package description and tags

### DIFF
--- a/Lottie-Windows/Lottie-Windows.csproj
+++ b/Lottie-Windows/Lottie-Windows.csproj
@@ -6,8 +6,12 @@
     <OutputType>winmdobj</OutputType>
     <IsPackable>True</IsPackable>
     
+    <Description>This library provides the LottieVisualSource which is consumed by the Microsoft.UI.Xaml.Controls.AnimatedVisualPlayer to render Lottie JSON files.</Description>
+    <PackageTags>UWP Toolkit Windows Animations Lottie XAML</PackageTags>
+
     <RootNamespace>Microsoft.Toolkit.Uwp.UI.Lottie</RootNamespace>
     <AssemblyName>Microsoft.Toolkit.Uwp.UI.Lottie</AssemblyName>
+    
 
     <!-- Enable the latest C# language features -->
     <LangVersion>latest</LangVersion>


### PR DESCRIPTION
## Summary

Changes have been made to the Lottie Windows csproj to include additional metadata for the generated NuGet package including a description (taken from the [README](https://github.com/windows-toolkit/Lottie-Windows/tree/master/Lottie-Windows)) and package tags.

This change is related to #253 