### PR TITLE
Fixing spacing in all mentions of "After Effects".

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Lottie-Windows
 
-Lottie-Windows is a library for rendering [Adobe AfterEffects](https://www.adobe.com/products/aftereffects.html) animations natively in your application. This project adds Windows to the [Lottie](http://airbnb.io/lottie/) family of tools also targeting [Android](https://github.com/airbnb/lottie-android), [iOS](https://github.com/airbnb/lottie-ios), and [Web](https://github.com/airbnb/lottie-web).
+Lottie-Windows is a library for rendering [Adobe After Effects](https://www.adobe.com/products/aftereffects.html) animations natively in your application. This project adds Windows to the [Lottie](http://airbnb.io/lottie/) family of tools also targeting [Android](https://github.com/airbnb/lottie-android), [iOS](https://github.com/airbnb/lottie-ios), and [Web](https://github.com/airbnb/lottie-web).
 
 Lottie simplifies the design-to-code workflow for bringing engaging, interactive vector animations to your Windows applications, with significant improvements in terms of performance, quality, and engineering efficiency over traditional approaches such as gifs, manually coded animations, etc. Lottie-Windows uses the [Windows.UI.Composition APIs](https://docs.microsoft.com/windows/uwp/composition/visual-layer) to provide smooth 60fps animations and resolution-independent vector graphics.
 

--- a/samples/LottieSamples/Scenarios/JsonPage.xaml
+++ b/samples/LottieSamples/Scenarios/JsonPage.xaml
@@ -16,7 +16,7 @@
                     <Paragraph>
                         <Span>To render our first Lottie animation, we use</Span>
                         <Span FontFamily="Consolas">Assets/LottieLogo1.json</Span>
-                        which was generated from Adobe AfterEffects using
+                        which was generated from Adobe After Effects using
                         <Hyperlink NavigateUri="http://aescripts.com/bodymovin/">Bodymovin</Hyperlink>.
                         You'll need to
                         <Span FontWeight="SemiBold">include</Span>:

--- a/samples/LottieSamples/Scenarios/ModifyPage.xaml
+++ b/samples/LottieSamples/Scenarios/ModifyPage.xaml
@@ -38,7 +38,7 @@
                 <winui:AnimatedVisualPlayer x:Name="Modified_Player">
                     <!--
                         Codegen Source that has been generated from the modified LottieLogo1_Modified.json to dynamically
-                        update color values defined in the AfterEffects file.
+                        update color values defined in the After Effects file.
                     -->
                     <animatedvisuals:LottieLogo1_Modified x:Name="Modified_Source_LottieLogo1" />
                 </winui:AnimatedVisualPlayer>

--- a/samples/LottieSamples/Scenarios/SegmentPage.xaml
+++ b/samples/LottieSamples/Scenarios/SegmentPage.xaml
@@ -15,7 +15,7 @@
                 <RichTextBlock>
                     <Paragraph>
                         We build upon the previous scenarios to create an animated icon with interactive behaviors.
-                        The Lottie animation, as created in AfterEffects, contains the following segments on its timeline:
+                        The Lottie animation, as created in After Effects, contains the following segments on its timeline:
                         <LineBreak />
                     </Paragraph>
                 </RichTextBlock>

--- a/source/LottieData/Optimization/GradientStopOptimizer.cs
+++ b/source/LottieData/Optimization/GradientStopOptimizer.cs
@@ -273,7 +273,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Optimization
 
         // Returns a bool for each stop, set to true if the stop is redundant.
         // This is particularly useful for eliminating the default "midpoint" stop
-        // that AfterEffects creates between any 2 stops that the user adds.
+        // that After Effects creates between any 2 stops that the user adds.
         static bool[] FindRedundantColorStops(ColorGradientStop[] stops)
         {
             var result = new bool[stops.Length];


### PR DESCRIPTION
At one point we were in a habit of calling it "AfterEffects", which is wrong.