### PR TITLE
Improve handling of grouped animated paths.

### DIFF
--- a/source/Issues/LT0027.md
+++ b/source/Issues/LT0027.md
@@ -7,7 +7,7 @@ A Lottie file contains a shape layer or group that contains shapes that cannot b
 merged by Lottie-Windows.
 
 ## Remarks
-Currently Lottie-Windows is only able to combine multiple shapes if they are all non-animated paths.
+Currently Lottie-Windows is only able to combine multiple shapes if they are all paths.
 
 If support for this feature is important for your scenario please provide feedback
 by raising it as an issue [here](https://github.com/windows-toolkit/Lottie-Windows/issues).

--- a/source/Issues/LT0036.md
+++ b/source/Issues/LT0036.md
@@ -1,0 +1,17 @@
+﻿[comment]: # (name:CombiningMultipleAnimatedPathsIsNotSupported)
+[comment]: # (text:Combining multiple animated paths is not supported.)
+
+# Lottie-Windows Warning LT0036
+
+A Lottie file contains a shape layer or group that contains multiple paths with animations.
+
+## Remarks
+Currently Lottie-Windows is only able to combine multiple paths if they are all non-animated.
+
+If support for this feature is important for your scenario please provide feedback
+by raising it as an issue [here](https://github.com/windows-toolkit/Lottie-Windows/issues).
+
+## Resources
+
+* [Lottie-Windows repository](https://aka.ms/lottie)
+* [Questions and feedback via Github](https://github.com/windows-toolkit/Lottie-Windows/issues)

--- a/source/LottieData/Path.cs
+++ b/source/LottieData/Path.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 
         /// <summary>
         /// Returns a path with the same properties except with the given
-        /// <paramref name="geometryData"/> in palse of <see cref="Data"/>.
+        /// <paramref name="geometryData"/> in place of <see cref="Data"/>.
         /// </summary>
         /// <param name="geometryData">The geometry to use in place of <see cref="Data"/>.</param>
         /// <returns>The cloned path.</returns>

--- a/source/LottieData/Path.cs
+++ b/source/LottieData/Path.cs
@@ -28,5 +28,22 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 
         /// <inheritdoc/>
         public override LottieObjectType ObjectType => LottieObjectType.Shape;
+
+        /// <summary>
+        /// Returns a path with the same properties except with the given
+        /// <paramref name="geometryData"/> in palse of <see cref="Data"/>.
+        /// </summary>
+        /// <param name="geometryData">The geometry to use in place of <see cref="Data"/>.</param>
+        /// <returns>The cloned path.</returns>
+        public Path CloneWithNewGeometry(Animatable<Sequence<BezierSegment>> geometryData)
+            => new Path(
+                    new ShapeLayerContent.ShapeLayerContentArgs
+                    {
+                        BlendMode = BlendMode,
+                        MatchName = MatchName,
+                        Name = Name,
+                    },
+                    Direction,
+                    geometryData);
     }
 }

--- a/source/LottieToWinComp/TranslationContext.cs
+++ b/source/LottieToWinComp/TranslationContext.cs
@@ -80,6 +80,23 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             return result;
         }
 
+        internal Path OptimizePath(Path path)
+        {
+            var optimizedPathData = TrimAnimatable(path.Data);
+
+            return new Path(
+                new ShapeLayerContent.ShapeLayerContentArgs
+                {
+                    BlendMode = path.BlendMode,
+                    MatchName = path.MatchName,
+                    Name = path.Name,
+                },
+                path.Direction,
+                optimizedPathData.IsAnimated
+                    ? new Animatable<Sequence<BezierSegment>>(optimizedPathData.KeyFrames.ToArray(), path.Data.PropertyIndex)
+                    : new Animatable<Sequence<BezierSegment>>(optimizedPathData.InitialValue, path.Data.PropertyIndex));
+        }
+
         internal TrimmedAnimatable<Vector3> TrimAnimatable(IAnimatableVector3 animatable)
         {
             return TrimAnimatable<Vector3>((AnimatableVector3)animatable);

--- a/source/LottieToWinComp/TranslationContext.cs
+++ b/source/LottieToWinComp/TranslationContext.cs
@@ -82,16 +82,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 
         internal Path OptimizePath(Path path)
         {
+            // Optimize the path data. This may result in a previously animated path
+            // becoming non-animated.
             var optimizedPathData = TrimAnimatable(path.Data);
 
-            return new Path(
-                new ShapeLayerContent.ShapeLayerContentArgs
-                {
-                    BlendMode = path.BlendMode,
-                    MatchName = path.MatchName,
-                    Name = path.Name,
-                },
-                path.Direction,
+            return path.CloneWithNewGeometry(
                 optimizedPathData.IsAnimated
                     ? new Animatable<Sequence<BezierSegment>>(optimizedPathData.KeyFrames.ToArray(), path.Data.PropertyIndex)
                     : new Animatable<Sequence<BezierSegment>>(optimizedPathData.InitialValue, path.Data.PropertyIndex));

--- a/source/LottieToWinComp/TranslationIssues.cs
+++ b/source/LottieToWinComp/TranslationIssues.cs
@@ -108,6 +108,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 
         internal void ThemePropertyValuesAreInconsistent(string themePropertyName, string chosenValue, string requestedValue) => Report("LT0035", $"Theme property \"{themePropertyName}\" has more than one value. Using {chosenValue} in place of {requestedValue}.");
 
+        internal void CombiningMultipleAnimatedPathsIsNotSupported() => Report("LT0036", "Combining multiple animated paths is not supported.");
+
         void Report(string code, string description)
         {
             _issues.Add((code, description));


### PR DESCRIPTION
This change will allow some (not very common) cases of grouped animated paths where the animation can be optimized away.
In the cases it can't handle, it now raises an issue to make it clear that there is a problem.