### PR TITLE
We were ignoring the "closed" property on paths.

### DIFF
--- a/source/LottieData/BezierSegment.cs
+++ b/source/LottieData/BezierSegment.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 {
     /// <summary>
-    /// A segment defined as a cubic bezier curve from <see cref="ControlPoint0"/> to <see cref="ControlPoint3"/>.
+    /// A segment defined as a cubic Bezier curve from <see cref="ControlPoint0"/> to <see cref="ControlPoint3"/>.
     /// </summary>
 #if PUBLIC_LottieData
     public
@@ -133,7 +133,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
                 return false;
             }
 
-            // The points are on the same line. The cubic bezier is a line if
+            // The points are on the same line. The cubic Bezier is a line if
             // p1 and p2 are between p0..p3.
             if (!IsBetween(ControlPoint0.X, ControlPoint1.X, ControlPoint2.X, ControlPoint3.X))
             {

--- a/source/LottieData/LottieData.projitems
+++ b/source/LottieData/LottieData.projitems
@@ -51,6 +51,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)\Optimization\GradientStopOptimizer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Optimization\Optimizer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Path.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\PathGeometry.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Polystar.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\PreCompLayer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\RadialGradientFill.cs" />

--- a/source/LottieData/Mask.cs
+++ b/source/LottieData/Mask.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
         public Mask(
             bool inverted,
             string name,
-            Animatable<Sequence<BezierSegment>> points,
+            Animatable<PathGeometry> points,
             Animatable<Opacity> opacity,
             MaskMode mode
         )
@@ -31,7 +31,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 
         public string Name { get; }
 
-        public Animatable<Sequence<BezierSegment>> Points { get; }
+        public Animatable<PathGeometry> Points { get; }
 
         public Animatable<Opacity> Opacity { get; }
 

--- a/source/LottieData/Optimization/Optimizer.cs
+++ b/source/LottieData/Optimization/Optimizer.cs
@@ -106,8 +106,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Optimization
             return new Animatable<PathGeometry>(hacked[0].Value, hacked, optimized.PropertyIndex);
         }
 
-        // Returns a KeyFrame<PathGeometry> that contains only the first bezier segment of the given
-        // KeyFrame<PathGeometry>
+        // Returns a KeyFrame<PathGeometry> that contains only the first Bezier segment of the given
+        // KeyFrame<PathGeometry>.
         static KeyFrame<PathGeometry> HackPathGeometry(KeyFrame<PathGeometry> value)
             => new KeyFrame<PathGeometry>(
                 value.Frame,

--- a/source/LottieData/Optimization/Optimizer.cs
+++ b/source/LottieData/Optimization/Optimizer.cs
@@ -21,22 +21,22 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Optimization
 #endif
     sealed class Optimizer
     {
-        static readonly AnimatableComparer<Sequence<BezierSegment>> PathGeometryComparer = new AnimatableComparer<Sequence<BezierSegment>>();
-        readonly Dictionary<Animatable<Sequence<BezierSegment>>, Animatable<Sequence<BezierSegment>>> _animatablePathGeometriesCache;
+        static readonly AnimatableComparer<PathGeometry> PathGeometryComparer = new AnimatableComparer<PathGeometry>();
+        readonly Dictionary<Animatable<PathGeometry>, Animatable<PathGeometry>> _animatablePathGeometriesCache;
 
         public Optimizer()
         {
-            _animatablePathGeometriesCache = new Dictionary<Animatable<Sequence<BezierSegment>>, Animatable<Sequence<BezierSegment>>>(PathGeometryComparer);
+            _animatablePathGeometriesCache = new Dictionary<Animatable<PathGeometry>, Animatable<PathGeometry>>(PathGeometryComparer);
         }
 
-        public Animatable<Sequence<BezierSegment>> GetOptimized(Animatable<Sequence<BezierSegment>> value)
+        public Animatable<PathGeometry> GetOptimized(Animatable<PathGeometry> value)
         {
             var optimized = GetOptimized(value, _animatablePathGeometriesCache);
 
             // If the geometries have different numbers of segments they can't be animated. However
             // in one specific case we can fix that.
-            var geometries = value.KeyFrames.SelectToArray(kf => kf.Value.Items.ToArray());
-            var distinctSegmentCounts = geometries.Select(g => g.Length).Distinct().Count();
+            var geometries = value.KeyFrames.SelectToArray(kf => kf.Value);
+            var distinctSegmentCounts = geometries.Select(g => g.BezierSegments.Items.Length).Distinct().Count();
 
             if (distinctSegmentCounts != 2)
             {
@@ -50,7 +50,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Optimization
             //  * If there are 2 segments, the second segment draws back over the first.
             foreach (var g in geometries)
             {
-                foreach (var segment in g)
+                var segments = g.BezierSegments;
+
+                foreach (var segment in segments)
                 {
                     if (!segment.IsALine)
                     {
@@ -58,31 +60,31 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Optimization
                     }
                 }
 
-                switch (g.Length)
+                switch (segments.Items.Length)
                 {
                     default:
                         return optimized;
                     case 1:
-                        if (!g[0].IsALine)
+                        if (!segments.Items[0].IsALine)
                         {
                             return optimized;
                         }
 
                         break;
                     case 2:
-                        if (!g[0].IsALine || !g[1].IsALine)
+                        if (!segments.Items[0].IsALine || !segments.Items[1].IsALine)
                         {
                             return optimized;
                         }
 
                         // Start of line 0
-                        var a = g[0].ControlPoint0;
+                        var a = segments.Items[0].ControlPoint0;
 
                         // End of line 0
-                        var b = g[0].ControlPoint3;
+                        var b = segments.Items[0].ControlPoint3;
 
                         // End of line 1
-                        var c = g[1].ControlPoint3;
+                        var c = segments.Items[1].ControlPoint3;
 
                         if (!BezierSegment.ArePointsColinear(0, a, b, c))
                         {
@@ -101,13 +103,18 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Optimization
 
             // Create a new Animatable<PathGeometry> which has only one segment in each keyframe.
             var hacked = optimized.KeyFrames.SelectToSpan(pg => HackPathGeometry(pg));
-            return new Animatable<Sequence<BezierSegment>>(hacked[0].Value, hacked, optimized.PropertyIndex);
+            return new Animatable<PathGeometry>(hacked[0].Value, hacked, optimized.PropertyIndex);
         }
 
-        static KeyFrame<Sequence<BezierSegment>> HackPathGeometry(KeyFrame<Sequence<BezierSegment>> value)
-        {
-            return new KeyFrame<Sequence<BezierSegment>>(value.Frame, new Sequence<BezierSegment>(new[] { value.Value.Items[0] }), Vector3.Zero, Vector3.Zero, value.Easing);
-        }
+        // Returns a KeyFrame<PathGeometry> that contains only the first bezier segment of the given
+        // KeyFrame<PathGeometry>
+        static KeyFrame<PathGeometry> HackPathGeometry(KeyFrame<PathGeometry> value)
+            => new KeyFrame<PathGeometry>(
+                value.Frame,
+                new PathGeometry(new Sequence<BezierSegment>(new[] { value.Value.BezierSegments.Items[0] }), isClosed: false),
+                Vector3.Zero,
+                Vector3.Zero,
+                value.Easing);
 
         // True iff b is between and c.
         static bool IsBetween(Vector2 a, Vector2 b, Vector2 c)

--- a/source/LottieData/Path.cs
+++ b/source/LottieData/Path.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
         public Path(
             in ShapeLayerContentArgs args,
             bool direction,
-            Animatable<Sequence<BezierSegment>> geometryData)
+            Animatable<PathGeometry> geometryData)
             : base(in args)
         {
             Direction = direction;
@@ -21,7 +21,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 
         public bool Direction { get; }
 
-        public Animatable<Sequence<BezierSegment>> Data { get; }
+        public Animatable<PathGeometry> Data { get; }
 
         /// <inheritdoc/>
         public override ShapeContentType ContentType => ShapeContentType.Path;
@@ -35,7 +35,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
         /// </summary>
         /// <param name="geometryData">The geometry to use in place of <see cref="Data"/>.</param>
         /// <returns>The cloned path.</returns>
-        public Path CloneWithNewGeometry(Animatable<Sequence<BezierSegment>> geometryData)
+        public Path CloneWithNewGeometry(Animatable<PathGeometry> geometryData)
             => new Path(
                     new ShapeLayerContent.ShapeLayerContentArgs
                     {

--- a/source/LottieData/PathGeometry.cs
+++ b/source/LottieData/PathGeometry.cs
@@ -8,7 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 {
     /// <summary>
-    /// A sequence of <see cref="BezierSegment"/> that describes the shape of a path.
+    /// A sequence of <see cref="BezierSegment"/>s that describes the shape of a path.
     /// </summary>
 #if PUBLIC_LottieData
     public

--- a/source/LottieData/PathGeometry.cs
+++ b/source/LottieData/PathGeometry.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
+{
+    /// <summary>
+    /// A sequence of <see cref="BezierSegment"/> that describes the shape of a path.
+    /// </summary>
+#if PUBLIC_LottieData
+    public
+#endif
+    sealed class PathGeometry : IEquatable<PathGeometry>
+    {
+        public PathGeometry(Sequence<BezierSegment> bezierSegments, bool isClosed)
+        {
+            BezierSegments = bezierSegments;
+            IsClosed = isClosed;
+        }
+
+        /// <summary>
+        /// Indicates whether the path is closed. A closed path will use mitering to join
+        /// the final segment end back to the start, synthesizing a segment if necessary,
+        /// whereas an open path will never synthesize an extra segment and will use end caps.
+        /// </summary>
+        public bool IsClosed { get; }
+
+        /// <summary>
+        /// The segments that describe the path.
+        /// </summary>
+        public Sequence<BezierSegment> BezierSegments { get; }
+
+        /// <summary>
+        /// An empty <see cref="PathGeometry"/>.
+        /// </summary>
+        public static PathGeometry Empty { get; } = new PathGeometry(Sequence<BezierSegment>.Empty, false);
+
+        public bool Equals([AllowNull] PathGeometry other) =>
+            other != null && other.IsClosed == IsClosed && other.BezierSegments.Equals(BezierSegments);
+    }
+}

--- a/source/LottieData/PathGeometry.cs
+++ b/source/LottieData/PathGeometry.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
         /// </summary>
         public static PathGeometry Empty { get; } = new PathGeometry(Sequence<BezierSegment>.Empty, false);
 
-        public bool Equals([AllowNull] PathGeometry other) =>
+        public bool Equals(PathGeometry other) =>
             other != null && other.IsClosed == IsClosed && other.BezierSegments.Equals(BezierSegments);
     }
 }

--- a/source/LottieData/Serialization/LottieCompositionXmlSerializer.cs
+++ b/source/LottieData/Serialization/LottieCompositionXmlSerializer.cs
@@ -557,7 +557,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
                 var cp2 = v3kf.SpatialControlPoint2;
                 if (cp1 != Vector3.Zero || cp2 != Vector3.Zero)
                 {
-                    // Spatial bezier
+                    // Spatial Bezier
                     return $"SpatialBezier:{keyFrame.Value},{cp1},{cp2}@{keyFrame.Frame}({keyFrame.Easing.Type})";
                 }
             }

--- a/source/LottieData/Serialization/LottieCompositionYamlSerializer.cs
+++ b/source/LottieData/Serialization/LottieCompositionYamlSerializer.cs
@@ -563,7 +563,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
                 var cp2 = v3kf.SpatialControlPoint2;
                 if (cp1 != Vector3.Zero || cp2 != Vector3.Zero)
                 {
-                    // Spatial bezier
+                    // Spatial Bezier
                     result.Add(nameof(v3kf.SpatialControlPoint1), FromVector3(cp1));
                     result.Add(nameof(v3kf.SpatialControlPoint2), FromVector3(cp2));
                 }

--- a/source/LottieData/Serialization/LottieCompositionYamlSerializer.cs
+++ b/source/LottieData/Serialization/LottieCompositionYamlSerializer.cs
@@ -379,7 +379,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
                 { nameof(mask.Inverted), mask.Inverted },
                 { nameof(mask.Mode), Scalar(mask.Mode) },
                 { nameof(mask.Opacity), FromAnimatable(mask.Opacity) },
-                { nameof(mask.Points), FromAnimatable(mask.Points, p => FromSequence(p, FromBezierSegment)) },
+                { nameof(mask.Points), FromAnimatable(mask.Points, p => FromPathGeometry(p)) },
             };
 
         YamlObject FromShapeGroup(ShapeGroup content, YamlMap superclassContent)
@@ -576,7 +576,18 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
         {
             var result = superclassContent;
             result.Add(nameof(content.Direction), content.Direction);
-            result.Add(nameof(content.Data), FromAnimatable(content.Data, p => FromSequence(p, FromBezierSegment)));
+            result.Add(nameof(content.Data), FromAnimatable(content.Data, p => FromPathGeometry(p)));
+            return result;
+        }
+
+        YamlObject FromPathGeometry(PathGeometry content)
+        {
+            var result = new YamlMap()
+            {
+                { nameof(content.IsClosed), content.IsClosed },
+                { nameof(content.BezierSegments), FromSequence(content.BezierSegments, FromBezierSegment) },
+            };
+
             return result;
         }
 

--- a/source/LottieReader/Serialization/Animatables.cs
+++ b/source/LottieReader/Serialization/Animatables.cs
@@ -7,8 +7,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
 
-using PathGeometry = Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Sequence<Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.BezierSegment>;
-
 namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
 {
 #pragma warning disable SA1205 // Partial elements should declare access
@@ -21,7 +19,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
         static readonly Animatable<double> s_animatableDoubleZero = CreateNonAnimatedAnimatable(0.0);
         static readonly Animatable<Color> s_animatableColorBlack = CreateNonAnimatedAnimatable(Color.Black);
         static readonly Animatable<Opacity> s_animatableOpacityOpaque = CreateNonAnimatedAnimatable(Opacity.Opaque);
-        static readonly Animatable<PathGeometry> s_animatableGeometryEmpty = CreateNonAnimatedAnimatable(Sequence<BezierSegment>.Empty);
+        static readonly Animatable<PathGeometry> s_animatableGeometryEmpty = CreateNonAnimatedAnimatable(PathGeometry.Empty);
         static readonly Animatable<Rotation> s_animatableRotationNone = CreateNonAnimatedAnimatable(Rotation.None);
         static readonly Animatable<Sequence<GradientStop>> s_animatableGradientStopsSingle = CreateNonAnimatedAnimatable(s_defaultGradientStops);
         static readonly Animatable<Trim> s_animatableTrimNone = CreateNonAnimatedAnimatable(Trim.None);

--- a/source/LottieReader/Serialization/LottieCompositionReader.cs
+++ b/source/LottieReader/Serialization/LottieCompositionReader.cs
@@ -334,7 +334,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
                 // The vertices for the figure.
                 var verticesAsVector2 = ReadArrayOfVector2(vertices.Value);
 
-                // The control points that define the cubic beziers between the vertices.
+                // The control points that define the cubic Beziers between the vertices.
                 var inTangentsAsVector2 = ReadArrayOfVector2(inTangents.Value);
                 var outTangentsAsVector2 = ReadArrayOfVector2(outTangents.Value);
 

--- a/source/LottieReader/Serialization/LottieCompositionReader.cs
+++ b/source/LottieReader/Serialization/LottieCompositionReader.cs
@@ -10,8 +10,6 @@ using System.Text;
 using System.Text.Json;
 using Microsoft.Toolkit.Uwp.UI.Lottie.GenericData;
 
-using PathGeometry = Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Sequence<Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.BezierSegment>;
-
 namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
 {
     // See: https://github.com/airbnb/lottie-web/tree/master/docs/json for the (usually out-of-date) schema.
@@ -370,7 +368,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
                 }
             }
 
-            return new PathGeometry(beziers);
+            return new PathGeometry(new Sequence<BezierSegment>(beziers), isClosed);
         }
 
         static Vector2[] ReadArrayOfVector2(in LottieJsonArrayElement array)

--- a/source/LottieToWinComp/CanvasGeometryCombiner.cs
+++ b/source/LottieToWinComp/CanvasGeometryCombiner.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 
             void Win2D.ICanvasPathReceiver.AddQuadraticBezier(System.Numerics.Vector2 controlPoint, System.Numerics.Vector2 endPoint)
             {
-                // Should never be called because we never add quadratic beziers.
+                // Should never be called because we never add quadratic Beziers.
                 throw new InvalidOperationException();
             }
 

--- a/source/LottieToWinComp/CubicBezierFunction2.cs
+++ b/source/LottieToWinComp/CubicBezierFunction2.cs
@@ -9,7 +9,7 @@ using SnVector2 = System.Numerics.Vector2;
 namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 {
     /// <summary>
-    /// A cubic bezier function with type Vector2.
+    /// A cubic Bezier function with type Vector2.
     /// </summary>
     sealed class CubicBezierFunction2 : Vector2
     {
@@ -39,7 +39,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         public static CubicBezierFunction2 ZeroBezier { get; } = Create(SnVector2.Zero, SnVector2.Zero, SnVector2.Zero, SnVector2.Zero, 0);
 
         /// <summary>
-        /// Gets a value indicating whether the cubic bezier is equivalent to a line drawn from point 0 to point 3.
+        /// Gets a value indicating whether the cubic Bezier is equivalent to a line drawn from point 0 to point 3.
         /// </summary>
         public bool IsEquivalentToLinear
         {
@@ -50,7 +50,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                     return false;
                 }
 
-                // The points are on the same line. The cubic bezier is a line if
+                // The points are on the same line. The cubic Bezier is a line if
                 // p1 and p2 are between p0..p3.
                 if (!IsBetween(_p0.X, _p1.X, _p2.X, _p3.X))
                 {

--- a/source/LottieToWinComp/LottieToWinCompTranslator.cs
+++ b/source/LottieToWinComp/LottieToWinCompTranslator.cs
@@ -80,8 +80,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         readonly uint _targetUapVersion;
 
         // Factory used for creating properties that map from the Progress value of the animated visual
-        // to another value. These are used to create properties that are required by cubic bezier
-        // expressions used for spatial beziers.
+        // to another value. These are used to create properties that are required by cubic Bezier
+        // expressions used for spatial Beziers.
         readonly ProgressMapFactory _progressMapFactory = new ProgressMapFactory();
 
         // Property set used for property bindings for themed Lotties.
@@ -207,7 +207,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             }
         }
 
-        // Adds the progress remapping variables and animations that are needed for spatial beziers.
+        // Adds the progress remapping variables and animations that are needed for spatial Beziers.
         void AddRemappedProgressAnimations()
         {
             foreach (var (name, scale, offset, ranges) in _progressMapFactory.GetVariables())
@@ -2040,7 +2040,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                         var cp2 = Sn.Vector2.Transform(Vector2(segment.ControlPoint2), transformMatrix);
                         var cp3 = Sn.Vector2.Transform(Vector2(segment.ControlPoint3), transformMatrix);
 
-                        // Add a line rather than a cubic bezier if the segment is a straight line.
+                        // Add a line rather than a cubic Bezier if the segment is a straight line.
                         if (optimizeLines && segment.IsALine)
                         {
                             // Ignore 0-length lines.
@@ -2057,9 +2057,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 
                     // Closed tells D2D to synthesize a final segment. In many cases Closed
                     // will have no effect because After Effects will have included the final
-                    // segment however it can make a difference, for example if the figure is
-                    // closed then mitering will be applied where the start and end meet, whereas
-                    // if it is open an end cap will be used instead.
+                    // segment however it can make a difference because it determines whether
+                    // mitering or end caps will be used to join the end back to the start.
                     builder.EndFigure(figure.IsClosed ? CanvasFigureLoop.Closed : CanvasFigureLoop.Open);
                 }
 
@@ -2411,7 +2410,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                 var trimmedRadius = context.TrimAnimatable(shapeContext.RoundedCorner.Radius);
                 if (trimmedRadius.IsAnimated || trimmedRadius.InitialValue != 0)
                 {
-                    // TODO - can rounded corners be implemented by composing cubic beziers?
+                    // TODO - can rounded corners be implemented by composing cubic Beziers?
                     _issues.PathWithRoundedCornersIsNotSupported();
                 }
             }
@@ -3613,7 +3612,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                     }
                     else
                     {
-                        // TODO - when we support spatial bezier CubicBezierFunction3, we can enable this. For now this
+                        // TODO - when we support spatial Bezier CubicBezierFunction3, we can enable this. For now this
                         //        may result in a CubicBezierFunction2 being applied to the Vector3 Offset property.
                         //ApplyVector3KeyFrameAnimation(context, (AnimatableVector3)position, container, "Offset");
                         offsetExpression = _c.CreateExpressionAnimation(container.IsShape
@@ -4008,7 +4007,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                         val,
                         fillType,
 
-                        // Turn off the optimization that replaces cubic beziers with
+                        // Turn off the optimization that replaces cubic Beziers with
                         // segments because it may result in different numbers of
                         // control points in each path in the keyframes.
                         optimizeLines: false),
@@ -4176,7 +4175,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                                 Expr.Scalar("dummy"));
                             break;
                         case Easing.EasingType.Hold:
-                            // Holds should never have interesting cubic beziers, so replace with one that is definitely colinear.
+                            // Holds should never have interesting cubic Beziers, so replace with one that is definitely colinear.
                             cb = CubicBezierFunction2.ZeroBezier;
                             break;
                         default:
@@ -4185,8 +4184,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 
                     if (cb.IsEquivalentToLinear || adjustedProgress == 0)
                     {
-                        // The cubic bezier function is equivalent to a line, or its value starts at the start of the animation, so no need
-                        // for an expression to do spatial beziers on it. Just use a regular key frame.
+                        // The cubic Bezier function is equivalent to a line, or its value starts at the start of the animation, so no need
+                        // for an expression to do spatial Beziers on it. Just use a regular key frame.
                         if (previousKeyFrameWasExpression)
                         {
                             // Ensure the previous expression doesn't continue being evaluated during the current keyframe.
@@ -4202,7 +4201,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                     }
                     else
                     {
-                        // Expression key frame needed for a spatial bezier.
+                        // Expression key frame needed for a spatial Bezier.
 
                         // Make the progress value just before the requested progress value
                         // so that there is room to add a key frame just after this to hold
@@ -4218,7 +4217,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                             previousProgress = Float32.NextLargerThan((float)previousProgress);
                         }
 
-                        // Re-create the cubic bezier using the real variable name (it was created previously just to
+                        // Re-create the cubic Bezier using the real variable name (it was created previously just to
                         // see if it was linear).
                         cb = CubicBezierFunction2.Create(
                             cp0,
@@ -4227,7 +4226,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                             cp3,
                             RootScalar(_progressMapFactory.GetVariableForProgressMapping((float)previousProgress, (float)adjustedProgress, keyFrame.Easing, scale, offset)));
 
-                        // Insert the cubic bezier expression. The easing has to be a StepThenHold because otherwise
+                        // Insert the cubic Bezier expression. The easing has to be a StepThenHold because otherwise
                         // the value will be interpolated between the result of the expression, and the previous
                         // key frame value. The StepThenHold will make it just evaluate the expression.
                         insertExpressionKeyFrame(

--- a/source/LottieToWinComp/ProgressMapFactory.cs
+++ b/source/LottieToWinComp/ProgressMapFactory.cs
@@ -9,7 +9,7 @@ using Microsoft.Toolkit.Uwp.UI.Lottie.LottieData;
 
 namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 {
-    // Creates progress mapping variables and animations. This is used by spatial bezier
+    // Creates progress mapping variables and animations. This is used by spatial Bezier
     // animations to remap the Progress value of the animation to a smaller range so
     // that there is a value that progresses linearly from 0 to 1 between 2 key frames.
     sealed class ProgressMapFactory

--- a/source/LottieToWinComp/TranslationContext.cs
+++ b/source/LottieToWinComp/TranslationContext.cs
@@ -88,8 +88,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 
             return path.CloneWithNewGeometry(
                 optimizedPathData.IsAnimated
-                    ? new Animatable<Sequence<BezierSegment>>(optimizedPathData.KeyFrames.ToArray(), path.Data.PropertyIndex)
-                    : new Animatable<Sequence<BezierSegment>>(optimizedPathData.InitialValue, path.Data.PropertyIndex));
+                    ? new Animatable<PathGeometry>(optimizedPathData.KeyFrames.ToArray(), path.Data.PropertyIndex)
+                    : new Animatable<PathGeometry>(optimizedPathData.InitialValue, path.Data.PropertyIndex));
         }
 
         internal TrimmedAnimatable<Vector3> TrimAnimatable(IAnimatableVector3 animatable)


### PR DESCRIPTION
In most cases, a closed path is simply one that ends where it starts, so we just left all our paths open and relied on After Effects to complete the path.
But that was wrong in some cases - specifically the closing of the path determines whether a miter or an end cap is used where the end meets the start.