### PR TITLE
PathGeometry didn't implement GetHashCode so it wasn't being canonicalized.

### DIFF
--- a/source/LottieData/PathGeometry.cs
+++ b/source/LottieData/PathGeometry.cs
@@ -40,5 +40,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 
         public bool Equals(PathGeometry other) =>
             other != null && other.IsClosed == IsClosed && other.BezierSegments.Equals(BezierSegments);
+
+        public override bool Equals(object obj) => Equals(obj as PathGeometry);
+
+        public override int GetHashCode() => BezierSegments.GetHashCode();
     }
 }

--- a/source/UIDataCodeGen/CodeGen/NodeNamer.cs
+++ b/source/UIDataCodeGen/CodeGen/NodeNamer.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
                 else
                 {
                     // Use only as many digits as necessary to express the largest count.
-                    var digitsRequired = (int)Math.Ceiling(Math.Log10(nodeList.Count + 1));
+                    var digitsRequired = (int)Math.Ceiling(Math.Log10(nodeList.Count));
                     var counterFormat = new string('0', digitsRequired);
 
                     for (var i = 0; i < nodeList.Count; i++)


### PR DESCRIPTION
Also, fixing a bug in the NodeNamer that caused it to add leading 0's to object counters unnecessarily when there were exactly 10/100/1000/etc objects.