### PR TITLE
Support reading of drawing direction.

### DIFF
--- a/source/LottieData/DrawingDirection.cs
+++ b/source/LottieData/DrawingDirection.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
+{
+    /// <summary>
+    /// A rotation value.
+    /// </summary>
+#if PUBLIC_LottieData
+    public
+#endif
+    enum DrawingDirection
+    {
+        Forward = 0,
+        Unknown1 = 1,
+        Unknown2 = 2,
+        Unknown3 = 3,
+    }
+}

--- a/source/LottieData/Ellipse.cs
+++ b/source/LottieData/Ellipse.cs
@@ -7,21 +7,18 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 #if PUBLIC_LottieData
     public
 #endif
-    sealed class Ellipse : ShapeLayerContent
+    sealed class Ellipse : Shape
     {
         public Ellipse(
             in ShapeLayerContentArgs args,
-            bool direction,
+            DrawingDirection drawingDirection,
             IAnimatableVector3 position,
             IAnimatableVector3 diameter)
-            : base(in args)
+            : base(in args, drawingDirection)
         {
-            Direction = direction;
             Position = position;
             Diameter = diameter;
         }
-
-        public bool Direction { get; }
 
         public IAnimatableVector3 Position { get; }
 

--- a/source/LottieData/LottieData.projitems
+++ b/source/LottieData/LottieData.projitems
@@ -6,8 +6,6 @@
     <SharedGUID>b3db16ee-a821-4474-a188-e64926529bbd</SharedGUID>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)DrawingDirection.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Shape.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Animatable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\ExtensionMethods.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\AnimatableVector3.cs" />
@@ -20,6 +18,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)\Color.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\ColorGradientStop.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\CubicBezierEasing.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\DrawingDirection.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Easing.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Ellipse.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\EmbeddedImageAsset.cs" />
@@ -66,6 +65,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)\Sequence.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Serialization\LottieCompositionXmlSerializer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Serialization\LottieCompositionYamlSerializer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Shape.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\ShapeContentType.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\ShapeFill.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\ShapeGroup.cs" />

--- a/source/LottieData/LottieData.projitems
+++ b/source/LottieData/LottieData.projitems
@@ -6,6 +6,8 @@
     <SharedGUID>b3db16ee-a821-4474-a188-e64926529bbd</SharedGUID>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)DrawingDirection.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Shape.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Animatable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\ExtensionMethods.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\AnimatableVector3.cs" />

--- a/source/LottieData/Path.cs
+++ b/source/LottieData/Path.cs
@@ -7,19 +7,16 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 #if PUBLIC_LottieData
     public
 #endif
-    sealed class Path : ShapeLayerContent
+    sealed class Path : Shape
     {
         public Path(
             in ShapeLayerContentArgs args,
-            bool direction,
+            DrawingDirection drawingDirection,
             Animatable<PathGeometry> geometryData)
-            : base(in args)
+            : base(in args, drawingDirection)
         {
-            Direction = direction;
             Data = geometryData;
         }
-
-        public bool Direction { get; }
 
         public Animatable<PathGeometry> Data { get; }
 
@@ -43,7 +40,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
                         MatchName = MatchName,
                         Name = Name,
                     },
-                    Direction,
+                    DrawingDirection,
                     geometryData);
     }
 }

--- a/source/LottieData/Polystar.cs
+++ b/source/LottieData/Polystar.cs
@@ -7,11 +7,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 #if PUBLIC_LottieData
     public
 #endif
-    sealed class Polystar : ShapeLayerContent
+    sealed class Polystar : Shape
     {
         public Polystar(
             in ShapeLayerContentArgs args,
-            bool direction,
+            DrawingDirection drawingDirection,
             PolyStarType starType,
             Animatable<double> points,
             IAnimatableVector3 position,
@@ -20,9 +20,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
             Animatable<double> outerRadius,
             Animatable<double> innerRoundedness,
             Animatable<double> outerRoundedness)
-            : base(in args)
+            : base(in args, drawingDirection)
         {
-            Direction = direction;
             StarType = starType;
             Points = points;
             Position = position;
@@ -32,8 +31,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
             InnerRoundedness = innerRoundedness;
             OuterRoundedness = outerRoundedness;
         }
-
-        internal bool Direction { get; }
 
         internal PolyStarType StarType { get; }
 

--- a/source/LottieData/Rectangle.cs
+++ b/source/LottieData/Rectangle.cs
@@ -7,23 +7,20 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 #if PUBLIC_LottieData
     public
 #endif
-    sealed class Rectangle : ShapeLayerContent
+    sealed class Rectangle : Shape
     {
         public Rectangle(
             in ShapeLayerContentArgs args,
-            bool direction,
+            DrawingDirection drawingDirection,
             IAnimatableVector3 position,
             IAnimatableVector3 size,
             Animatable<double> cornerRadius)
-            : base(in args)
+            : base(in args, drawingDirection)
         {
-            Direction = direction;
             Position = position;
             Size = size;
             CornerRadius = cornerRadius;
         }
-
-        public bool Direction { get; }
 
         public Animatable<double> CornerRadius { get; }
 

--- a/source/LottieData/Serialization/LottieCompositionYamlSerializer.cs
+++ b/source/LottieData/Serialization/LottieCompositionYamlSerializer.cs
@@ -314,14 +314,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
                     return FromShapeFill((ShapeFill)content, superclassContent);
                 case ShapeContentType.Transform:
                     return FromTransform((Transform)content, superclassContent);
-                case ShapeContentType.Path:
-                    return FromPath((Path)content, superclassContent);
                 case ShapeContentType.Ellipse:
-                    return FromEllipse((Ellipse)content, superclassContent);
-                case ShapeContentType.Rectangle:
-                    return FromRectangle((Rectangle)content, superclassContent);
+                case ShapeContentType.Path:
                 case ShapeContentType.Polystar:
-                    return FromPolystar((Polystar)content, superclassContent);
+                case ShapeContentType.Rectangle:
+                    return FromShape((Shape)content, superclassContent);
                 case ShapeContentType.TrimPath:
                     return FromTrimPath((TrimPath)content, superclassContent);
                 case ShapeContentType.MergePaths:
@@ -330,6 +327,25 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
                     return FromRepeater((Repeater)content, superclassContent);
                 case ShapeContentType.RoundedCorner:
                     return FromRoundedCorner((RoundedCorner)content, superclassContent);
+                default:
+                    throw Unreachable;
+            }
+        }
+
+        YamlObject FromShape(Shape content, YamlMap superclassContent)
+        {
+            superclassContent.Add(nameof(content.DrawingDirection), Scalar(content.DrawingDirection));
+
+            switch (content.ContentType)
+            {
+                case ShapeContentType.Path:
+                    return FromPath((Path)content, superclassContent);
+                case ShapeContentType.Ellipse:
+                    return FromEllipse((Ellipse)content, superclassContent);
+                case ShapeContentType.Rectangle:
+                    return FromRectangle((Rectangle)content, superclassContent);
+                case ShapeContentType.Polystar:
+                    return FromPolystar((Polystar)content, superclassContent);
                 default:
                     throw Unreachable;
             }
@@ -575,7 +591,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
         YamlObject FromPath(Path content, YamlMap superclassContent)
         {
             var result = superclassContent;
-            result.Add(nameof(content.Direction), content.Direction);
             result.Add(nameof(content.Data), FromAnimatable(content.Data, p => FromPathGeometry(p)));
             return result;
         }

--- a/source/LottieData/Shape.cs
+++ b/source/LottieData/Shape.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
+{
+    /// <summary>
+    /// Abstract base class for <see cref="ShapeLayerContent"/> that
+    /// can be stroked and filled.
+    /// </summary>
+#if PUBLIC_LottieData
+    public
+#endif
+    abstract class Shape : ShapeLayerContent
+    {
+        private protected Shape(
+            in ShapeLayerContentArgs args,
+            DrawingDirection drawingDirection)
+            : base(args)
+        {
+            DrawingDirection = drawingDirection;
+        }
+
+        public DrawingDirection DrawingDirection { get; }
+    }
+}

--- a/source/LottieReader/Serialization/Enums.cs
+++ b/source/LottieReader/Serialization/Enums.cs
@@ -41,6 +41,27 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
             return BlendMode.Normal;
         }
 
+        DrawingDirection DToDrawingDirection(double? d)
+        {
+            if (d.HasValue)
+            {
+                if (TryAsExactInt(d.Value, out var intValue))
+                {
+                    switch (intValue)
+                    {
+                        case 0: return DrawingDirection.Forward;
+                        case 1: return DrawingDirection.Unknown1;
+                        case 2: return DrawingDirection.Unknown2;
+                        case 3: return DrawingDirection.Unknown3;
+                    }
+                }
+
+                _issues.UnexpectedValueForType("DrawingDirection", d.ToString());
+            }
+
+            return DrawingDirection.Forward;
+        }
+
         ShapeStroke.LineCapType LcToLineCapType(double? lc)
         {
             if (lc.HasValue)

--- a/source/LottieReader/Serialization/LottieCompositionReader.cs
+++ b/source/LottieReader/Serialization/LottieCompositionReader.cs
@@ -5,7 +5,6 @@
 // Uncomment this to give each element a unique name. This is useful
 // for debugging how an element gets translated.
 //#define UniqueifyNames
-
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/source/LottieReader/Serialization/LottieCompositionReader.cs
+++ b/source/LottieReader/Serialization/LottieCompositionReader.cs
@@ -2,6 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+// Uncomment this to give each element a unique name. This is useful
+// for debugging how an element gets translated.
+//#define UniqueifyNames
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -23,6 +27,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
     {
         readonly ParsingIssues _issues;
         readonly Options _options;
+#if UniqueifyNames
+        // The names discovered so far, and their counts.
+        // This is used to give each element a unique name. This helps
+        // when trying to debug how an element gets translated.
+        readonly Dictionary<string, int> _names = new Dictionary<string, int>();
+#endif // UniqueifyNames
 
         /// <summary>
         /// Specifies optional behavior for the reader.
@@ -276,7 +286,21 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
             }
             else
             {
-                return obj.StringPropertyOrNull("nm") ?? string.Empty;
+                var result = obj.StringPropertyOrNull("nm") ?? string.Empty;
+
+#if UniqueifyNames
+                if (!_names.TryGetValue(result, out var count))
+                {
+                    count = 0;
+                    _names.Add(result, count);
+                }
+
+                count++;
+                _names[result] = count;
+                result = $"{result} #{count:000}";
+#endif // UniqueifyNames
+
+                return result;
             }
         }
 

--- a/source/LottieReader/Serialization/ShapeLayerContents.cs
+++ b/source/LottieReader/Serialization/ShapeLayerContents.cs
@@ -309,9 +309,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
 
             var position = ReadAnimatableVector3(obj.ObjectPropertyOrNull("p"));
             var diameter = ReadAnimatableVector3(obj.ObjectPropertyOrNull("s"));
-            var direction = obj.BoolPropertyOrNull("d") == true;
+            var drawingDirection = DToDrawingDirection(obj.DoublePropertyOrNull("d"));
             obj.AssertAllPropertiesRead();
-            return new Ellipse(in shapeLayerContentArgs, direction, position, diameter);
+            return new Ellipse(in shapeLayerContentArgs, drawingDirection, position, diameter);
         }
 
         Polystar ReadPolystar(
@@ -321,8 +321,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
             // Not clear whether we need to read these properties.
             obj.IgnorePropertyThatIsNotYetSupported("ix");
 
-            var direction = obj.BoolPropertyOrNull("d") == true;
-
+            var drawingDirection = DToDrawingDirection(obj.DoublePropertyOrNull("d"));
             var points = ReadAnimatableFloat(obj.ObjectPropertyOrNull("pt"));
             var position = ReadAnimatableVector3(obj.ObjectPropertyOrNull("p"));
             var rotation = ReadAnimatableFloat(obj.ObjectPropertyOrNull("r"));
@@ -350,7 +349,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
             obj.AssertAllPropertiesRead();
             return new Polystar(
                 in shapeLayerContentArgs,
-                direction,
+                drawingDirection,
                 polystarType,
                 points,
                 position,
@@ -368,13 +367,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
             // Not clear whether we need to read these properties.
             obj.IgnorePropertyThatIsNotYetSupported("hd");
 
-            var direction = obj.BoolPropertyOrNull("d") == true;
+            var drawingDirection = DToDrawingDirection(obj.DoublePropertyOrNull("d"));
             var position = ReadAnimatableVector3(obj.ObjectPropertyOrNull("p"));
             var size = ReadAnimatableVector3(obj.ObjectPropertyOrNull("s"));
             var cornerRadius = ReadAnimatableFloat(obj.ObjectPropertyOrNull("r"));
 
             obj.AssertAllPropertiesRead();
-            return new Rectangle(in shapeLayerContentArgs, direction, position, size, cornerRadius);
+            return new Rectangle(in shapeLayerContentArgs, drawingDirection, position, size, cornerRadius);
         }
 
         Path ReadPath(
@@ -385,9 +384,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
             obj.IgnorePropertyThatIsNotYetSupported("ind", "ix", "hd", "cl", "closed");
 
             var geometry = ReadAnimatableGeometry(obj.ObjectPropertyOrNull("ks"));
-            var direction = obj.BoolPropertyOrNull("d") == true;
+            var drawingDirection = DToDrawingDirection(obj.DoublePropertyOrNull("d"));
             obj.AssertAllPropertiesRead();
-            return new Path(in shapeLayerContentArgs, direction, geometry);
+            return new Path(in shapeLayerContentArgs, drawingDirection, geometry);
         }
 
         TrimPath ReadTrimPath(

--- a/source/YamlData/YamlScalar.cs
+++ b/source/YamlData/YamlScalar.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.YamlData
             {
                 escapedValue = "''";
             }
-            else if (value.StartsWith(" ") || value.EndsWith(" ") || value.StartsWith("#") || value.Contains("{"))
+            else if (value.StartsWith(" ") || value.EndsWith(" ") || value.Contains("#") || value.Contains("{"))
             {
                 escapedValue = $"'{value}'";
             }


### PR DESCRIPTION
Drawing direction determines where the path of the shape starts and ends. This matters when trimming the path. I think that if the shape is closed (e.g. an ellipse) and the drawing is in reverse
then the trim start and trim end get swapped. Still trying to figure out all the details.
There will be at least one more change to support drawing direction. This is just to get the
bones of the parsing in place. Following changes will use it during translation.

Note that the enum values don't have descriptive names because I'm not sure what they should be yet.