### PR TITLE
Make writes to the console transactional where necessary.

### DIFF
--- a/LottieGen/LottieFileProcessor.cs
+++ b/LottieGen/LottieFileProcessor.cs
@@ -362,8 +362,14 @@ sealed class LottieFileProcessor
             outputFilePath,
             LottieCompositionXmlSerializer.ToXml(_lottieComposition).ToString());
 
-        _reporter.WriteInfo("Lottie XML written to:");
-        _reporter.WriteInfo(InfoType.FilePath, $" {outputFilePath}");
+        if (result)
+        {
+            using (_reporter.InfoStream.Lock())
+            {
+                _reporter.WriteInfo("Lottie XML written to:");
+                _reporter.WriteInfo(InfoType.FilePath, $" {outputFilePath}");
+            }
+        }
 
         return result;
     }
@@ -381,8 +387,11 @@ sealed class LottieFileProcessor
 
         if (result)
         {
-            _reporter.WriteInfo("Lottie YAML written to:");
-            _reporter.WriteInfo(InfoType.FilePath, $" {outputFilePath}");
+            using (_reporter.InfoStream.Lock())
+            {
+                _reporter.WriteInfo("Lottie YAML written to:");
+                _reporter.WriteInfo(InfoType.FilePath, $" {outputFilePath}");
+            }
         }
 
         return result;
@@ -403,8 +412,11 @@ sealed class LottieFileProcessor
 
         if (result)
         {
-            _reporter.WriteInfo("WinComp XML written to:");
-            _reporter.WriteInfo(InfoType.FilePath, $" {outputFilePath}");
+            using (_reporter.InfoStream.Lock())
+            {
+                _reporter.WriteInfo("WinComp XML written to:");
+                _reporter.WriteInfo(InfoType.FilePath, $" {outputFilePath}");
+            }
         }
 
         return result;
@@ -424,8 +436,11 @@ sealed class LottieFileProcessor
 
         if (result)
         {
-            _reporter.WriteInfo("WinComp DGML written to:");
-            _reporter.WriteInfo(InfoType.FilePath, $" {outputFilePath}");
+            using (_reporter.InfoStream.Lock())
+            {
+                _reporter.WriteInfo("WinComp DGML written to:");
+                _reporter.WriteInfo(InfoType.FilePath, $" {outputFilePath}");
+            }
         }
 
         return result;
@@ -451,8 +466,11 @@ sealed class LottieFileProcessor
 
         if (result)
         {
-            _reporter.WriteInfo($"C# code for class {_className} written to:");
-            _reporter.WriteInfo(InfoType.FilePath, $" {outputFilePath}");
+            using (_reporter.InfoStream.Lock())
+            {
+                _reporter.WriteInfo($"C# code for class {_className} written to:");
+                _reporter.WriteInfo(InfoType.FilePath, $" {outputFilePath}");
+            }
 
             if (assetList != null)
             {
@@ -500,16 +518,19 @@ sealed class LottieFileProcessor
             return false;
         }
 
-        _reporter.WriteInfo($"Cppwinrt header for class {_className} written to:");
-        _reporter.WriteInfo(InfoType.FilePath, $" {outputHeaderFilePath}");
-
-        _reporter.WriteInfo($"Cppwinrt source for class {_className} written to:");
-        _reporter.WriteInfo(InfoType.FilePath, $" {outputCppFilePath}");
-
-        if (assetList != null)
+        using (_reporter.InfoStream.Lock())
         {
-            // Write out the list of asset files referenced by the code.
-            WriteAssetFiles(assetList);
+            _reporter.WriteInfo($"Cppwinrt header for class {_className} written to:");
+            _reporter.WriteInfo(InfoType.FilePath, $" {outputHeaderFilePath}");
+
+            _reporter.WriteInfo($"Cppwinrt source for class {_className} written to:");
+            _reporter.WriteInfo(InfoType.FilePath, $" {outputCppFilePath}");
+
+            if (assetList != null)
+            {
+                // Write out the list of asset files referenced by the code.
+                WriteAssetFiles(assetList);
+            }
         }
 
         return true;
@@ -551,16 +572,19 @@ sealed class LottieFileProcessor
             return false;
         }
 
-        _reporter.WriteInfo($"CX header for class {_className} written to:");
-        _reporter.WriteInfo(InfoType.FilePath, $" {outputHeaderFilePath}");
-
-        _reporter.WriteInfo($"CX source for class {_className} written to:");
-        _reporter.WriteInfo(InfoType.FilePath, $" {outputCppFilePath}");
-
-        if (assetList != null)
+        using (_reporter.InfoStream.Lock())
         {
-            // Write out the list of asset files referenced by the code.
-            WriteAssetFiles(assetList);
+            _reporter.WriteInfo($"CX header for class {_className} written to:");
+            _reporter.WriteInfo(InfoType.FilePath, $" {outputHeaderFilePath}");
+
+            _reporter.WriteInfo($"CX source for class {_className} written to:");
+            _reporter.WriteInfo(InfoType.FilePath, $" {outputCppFilePath}");
+
+            if (assetList != null)
+            {
+                // Write out the list of asset files referenced by the code.
+                WriteAssetFiles(assetList);
+            }
         }
 
         return true;
@@ -580,8 +604,12 @@ sealed class LottieFileProcessor
         }
         catch (Exception e)
         {
-            _reporter.WriteError($"Failed to write to {filePath}");
-            _reporter.WriteError(e.Message);
+            using (_reporter.ErrorStream.Lock())
+            {
+                _reporter.WriteError($"Failed to write to {filePath}");
+                _reporter.WriteError(e.Message);
+            }
+
             return false;
         }
     }
@@ -595,8 +623,12 @@ sealed class LottieFileProcessor
         }
         catch (Exception e)
         {
-            _reporter.WriteError($"Failed to write to {filePath}");
-            _reporter.WriteError(e.Message);
+            using (_reporter.ErrorStream.Lock())
+            {
+                _reporter.WriteError($"Failed to write to {filePath}");
+                _reporter.WriteError(e.Message);
+            }
+
             return false;
         }
     }
@@ -620,8 +652,11 @@ sealed class LottieFileProcessor
 
     Stream TryReadTextFile(string filePath)
     {
-        _reporter.WriteInfo($"Reading file:");
-        _reporter.WriteInfo(InfoType.FilePath, $" {_file}");
+        using (_reporter.InfoStream.Lock())
+        {
+            _reporter.WriteInfo($"Reading file:");
+            _reporter.WriteInfo(InfoType.FilePath, $" {_file}");
+        }
 
         try
         {
@@ -629,8 +664,12 @@ sealed class LottieFileProcessor
         }
         catch (Exception e)
         {
-            _reporter.WriteError($"Failed to read from {filePath}");
-            _reporter.WriteError(e.Message);
+            using (_reporter.ErrorStream.Lock())
+            {
+                _reporter.WriteError($"Failed to read from {filePath}");
+                _reporter.WriteError(e.Message);
+            }
+
             return null;
         }
     }

--- a/LottieGen/Reporter.cs
+++ b/LottieGen/Reporter.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 
 sealed class Reporter
 {
@@ -121,6 +122,7 @@ sealed class Reporter
     internal sealed class Writer
     {
         readonly TextWriter _wrapped;
+        readonly object _lock = new object();
 
         internal Writer(TextWriter wrapped)
         {
@@ -129,14 +131,20 @@ sealed class Reporter
 
         public void WriteLine()
         {
-            _wrapped.WriteLine();
-            Console.ResetColor();
+            lock (_lock)
+            {
+                _wrapped.WriteLine();
+                Console.ResetColor();
+            }
         }
 
         public void WriteLine(string value)
         {
-            _wrapped.WriteLine(value);
-            Console.ResetColor();
+            lock (_lock)
+            {
+                _wrapped.WriteLine(value);
+                Console.ResetColor();
+            }
         }
 
         /// <summary>
@@ -144,8 +152,29 @@ sealed class Reporter
         /// </summary>
         public void Color(ConsoleColor foregroundColor, ConsoleColor backgroundColor)
         {
-            Console.ForegroundColor = foregroundColor;
-            Console.BackgroundColor = backgroundColor;
+            lock (_lock)
+            {
+                Console.ForegroundColor = foregroundColor;
+                Console.BackgroundColor = backgroundColor;
+            }
+        }
+
+        public IDisposable Lock() => new LockGuard(this);
+
+        sealed class LockGuard : IDisposable
+        {
+            readonly Writer _owner;
+
+            internal LockGuard(Writer owner)
+            {
+                _owner = owner;
+                Monitor.Enter(_owner._lock);
+            }
+
+            public void Dispose()
+            {
+                Monitor.Exit(_owner._lock);
+            }
         }
     }
 }

--- a/LottieGen/Reporter.cs
+++ b/LottieGen/Reporter.cs
@@ -105,8 +105,11 @@ sealed class Reporter
         ConsoleColor foregroundColor,
         ConsoleColor backgroundColor)
     {
-        ErrorStream.Color(foregroundColor, backgroundColor);
-        ErrorStream.WriteLine($"Error: {errorMessage}");
+        using (ErrorStream.Lock())
+        {
+            ErrorStream.Color(foregroundColor, backgroundColor);
+            ErrorStream.WriteLine($"Error: {errorMessage}");
+        }
     }
 
     // Helper for writing info lines to the info stream.
@@ -115,8 +118,11 @@ sealed class Reporter
         ConsoleColor foregroundColor,
         ConsoleColor backgroundColor)
     {
-        InfoStream.Color(foregroundColor, backgroundColor);
-        InfoStream.WriteLine(infoMessage);
+        using (InfoStream.Lock())
+        {
+            InfoStream.Color(foregroundColor, backgroundColor);
+            InfoStream.WriteLine(infoMessage);
+        }
     }
 
     internal sealed class Writer


### PR DESCRIPTION
The recent output coloring made the problem obvious - when we run Lottiegen over multiple files there are numerous threads that are writing to the console and can interleave their writes.
With this change, the writes that need to be kept together have a way of being kept together.