### PR TITLE
Handle rounded rectangles more accurately

### DIFF
--- a/source/LottieData/Polystar.cs
+++ b/source/LottieData/Polystar.cs
@@ -18,8 +18,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
             Animatable<double> rotation,
             Animatable<double> innerRadius,
             Animatable<double> outerRadius,
-            Animatable<double> innerRoundedness,
-            Animatable<double> outerRoundedness)
+            Animatable<double> innerRoundness,
+            Animatable<double> outerRoundness)
             : base(in args, drawingDirection)
         {
             StarType = starType;
@@ -28,8 +28,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
             Rotation = rotation;
             InnerRadius = innerRadius;
             OuterRadius = outerRadius;
-            InnerRoundedness = innerRoundedness;
-            OuterRoundedness = outerRoundedness;
+            InnerRoundness = innerRoundness;
+            OuterRoundness = outerRoundness;
         }
 
         internal PolyStarType StarType { get; }
@@ -44,9 +44,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 
         internal Animatable<double> OuterRadius { get; }
 
-        internal Animatable<double> InnerRoundedness { get; }
+        internal Animatable<double> InnerRoundness { get; }
 
-        internal Animatable<double> OuterRoundedness { get; }
+        internal Animatable<double> OuterRoundness { get; }
 
         /// <inheritdoc/>
         public override ShapeContentType ContentType => ShapeContentType.Polystar;

--- a/source/LottieData/Rectangle.cs
+++ b/source/LottieData/Rectangle.cs
@@ -14,15 +14,22 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
             DrawingDirection drawingDirection,
             IAnimatableVector3 position,
             IAnimatableVector3 size,
-            Animatable<double> cornerRadius)
+            Animatable<double> roundness)
             : base(in args, drawingDirection)
         {
             Position = position;
             Size = size;
-            CornerRadius = cornerRadius;
+            Roundness = roundness;
         }
 
-        public Animatable<double> CornerRadius { get; }
+        /// <summary>
+        /// Determines how round the corners of the rectangle are. If the rectangle
+        /// is a square and the roundness is equal to half of the width then the
+        /// rectangle will be rendered as a circle. Once the roundness value reaches
+        /// half of the minimum of the shortest dimension, increasing it has no
+        /// further effect.
+        /// </summary>
+        public Animatable<double> Roundness { get; }
 
         public IAnimatableVector3 Size { get; }
 

--- a/source/LottieData/RoundedCorner.cs
+++ b/source/LottieData/RoundedCorner.cs
@@ -18,12 +18,15 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
         }
 
         /// <summary>
-        /// The radius of the rounding. If the shape to which this applies is a rectangle
-        /// the rounding will only apply if the rectangle a non-0 roundess value.
+        /// The radius of the rounding.
+        /// </summary>
+        /// <remarks>
+        /// If the shape to which this applies is a rectangle
+        /// the rounding will only apply if the rectangle has a 0 roundess value.
         /// Once the radius value reaches half of the largest dimension of the
         /// rectangle, the result will be equivalent to an ellipse of the same size, and
         /// increasing the radius further will have no further effect.
-        /// </summary>
+        /// </remarks>
         public Animatable<double> Radius { get; }
 
         /// <inheritdoc/>

--- a/source/LottieData/RoundedCorner.cs
+++ b/source/LottieData/RoundedCorner.cs
@@ -21,10 +21,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
         /// The radius of the rounding.
         /// </summary>
         /// <remarks>
-        /// If the shape to which this applies is a rectangle
-        /// the rounding will only apply if the rectangle has a 0 roundess value.
-        /// Once the radius value reaches half of the largest dimension of the
-        /// rectangle, the result will be equivalent to an ellipse of the same size, and
+        /// If the shape to which this applies is a rectangle, the rounding will
+        /// only apply if the rectangle has a 0 roundness value. Once the radius
+        /// value reaches half of the largest dimension of the rectangle, the
+        /// result will be equivalent to an ellipse of the same size, and
         /// increasing the radius further will have no further effect.
         /// </remarks>
         public Animatable<double> Radius { get; }

--- a/source/LottieData/RoundedCorner.cs
+++ b/source/LottieData/RoundedCorner.cs
@@ -17,6 +17,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
             Radius = radius;
         }
 
+        /// <summary>
+        /// The radius of the rounding. If the shape to which this applies is a rectangle
+        /// the rounding will only apply if the rectangle a non-0 roundess value.
+        /// Once the radius value reaches half of the largest dimension of the
+        /// rectangle, the result will be equivalent to an ellipse of the same size, and
+        /// increasing the radius further will have no further effect.
+        /// </summary>
         public Animatable<double> Radius { get; }
 
         /// <inheritdoc/>

--- a/source/LottieData/Serialization/LottieCompositionXmlSerializer.cs
+++ b/source/LottieData/Serialization/LottieCompositionXmlSerializer.cs
@@ -616,7 +616,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
 
                 yield return FromAnimatable(nameof(content.Size), content.Size);
                 yield return FromAnimatable(nameof(content.Position), content.Position);
-                yield return FromAnimatable(nameof(content.CornerRadius), content.CornerRadius);
+                yield return FromAnimatable(nameof(content.Roundness), content.Roundness);
             }
         }
 

--- a/source/LottieData/Serialization/LottieCompositionYamlSerializer.cs
+++ b/source/LottieData/Serialization/LottieCompositionYamlSerializer.cs
@@ -644,7 +644,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
             var result = superclassContent;
             result.Add(nameof(content.Size), FromAnimatable(content.Size));
             result.Add(nameof(content.Position), FromAnimatable(content.Position));
-            result.Add(nameof(content.CornerRadius), FromAnimatable(content.CornerRadius));
+            result.Add(nameof(content.Roundness), FromAnimatable(content.Roundness));
             return result;
         }
 

--- a/source/LottieReader/Serialization/ShapeLayerContents.cs
+++ b/source/LottieReader/Serialization/ShapeLayerContents.cs
@@ -326,23 +326,23 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
             var position = ReadAnimatableVector3(obj.ObjectPropertyOrNull("p"));
             var rotation = ReadAnimatableFloat(obj.ObjectPropertyOrNull("r"));
             var outerRadius = ReadAnimatableFloat(obj.ObjectPropertyOrNull("or"));
-            var outerRoundedness = ReadAnimatableFloat(obj.ObjectPropertyOrNull("os"));
+            var outerRoundness = ReadAnimatableFloat(obj.ObjectPropertyOrNull("os"));
 
             var polystarType = SyToPolystarType(obj.DoublePropertyOrNull("sy")) ?? Polystar.PolyStarType.Polygon;
 
             Animatable<double> innerRadius;
-            Animatable<double> innerRoundedness;
+            Animatable<double> innerRoundness;
 
             switch (polystarType)
             {
                 case Polystar.PolyStarType.Star:
                     innerRadius = ReadAnimatableFloat(obj.ObjectPropertyOrNull("ir"));
-                    innerRoundedness = ReadAnimatableFloat(obj.ObjectPropertyOrNull("is"));
+                    innerRoundness = ReadAnimatableFloat(obj.ObjectPropertyOrNull("is"));
                     break;
 
                 default:
                     innerRadius = null;
-                    innerRoundedness = null;
+                    innerRoundness = null;
                     break;
             }
 
@@ -356,8 +356,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
                 rotation,
                 innerRadius,
                 outerRadius,
-                innerRoundedness,
-                outerRoundedness);
+                innerRoundness,
+                outerRoundness);
         }
 
         Rectangle ReadRectangle(
@@ -370,10 +370,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
             var drawingDirection = DToDrawingDirection(obj.DoublePropertyOrNull("d"));
             var position = ReadAnimatableVector3(obj.ObjectPropertyOrNull("p"));
             var size = ReadAnimatableVector3(obj.ObjectPropertyOrNull("s"));
-            var cornerRadius = ReadAnimatableFloat(obj.ObjectPropertyOrNull("r"));
+            var roundness = ReadAnimatableFloat(obj.ObjectPropertyOrNull("r"));
 
             obj.AssertAllPropertiesRead();
-            return new Rectangle(in shapeLayerContentArgs, drawingDirection, position, size, cornerRadius);
+            return new Rectangle(in shapeLayerContentArgs, drawingDirection, position, size, roundness);
         }
 
         Path ReadPath(

--- a/source/LottieToWinComp/ExpressionFactory.cs
+++ b/source/LottieToWinComp/ExpressionFactory.cs
@@ -69,11 +69,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 
         internal static Scalar RootScalar(string propertyName) => Scalar(RootProperty(propertyName));
 
-        internal static Scalar ConstrainedCornerRadiusScalar(double roundness) => Min(roundness, Min(MySize.X, MySize.Y) / 2);
+        internal static Vector2 ConstrainedCornerRadiusScalar(double roundness)
+            => Vector2(Min(roundness, Min(MySize.X, MySize.Y) / 2), Min(roundness, Min(MySize.X, MySize.Y) / 2));
 
-        internal static Scalar ConstrainedCornerRadiusScalar() => Min(MyRoundness, Min(MySize.X, MySize.Y) / 2);
+        internal static Vector2 ConstrainedCornerRadiusScalar()
+            => Vector2(Min(MyRoundness, Min(MySize.X, MySize.Y) / 2), Min(MyRoundness, Min(MySize.X, MySize.Y) / 2));
 
-        internal static Scalar ConstrainedCornerRadiusScalar(Sn.Vector2 size) => Min(MyRoundness, Math.Min(size.X, size.Y) / 2);
+        internal static Vector2 ConstrainedCornerRadiusScalar(Sn.Vector2 size)
+            => Vector2(Min(MyRoundness, Math.Min(size.X, size.Y) / 2), Min(MyRoundness, Math.Min(size.X, size.Y) / 2));
 
         // The value of a Color property stored as a Vector4 on the theming property set.
         static Vector4 ThemedColor4Property(string propertyName) => Vector4(ThemeProperty(propertyName));

--- a/source/LottieToWinComp/ExpressionFactory.cs
+++ b/source/LottieToWinComp/ExpressionFactory.cs
@@ -22,11 +22,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         internal static readonly Vector2 MyAnchor = MyVector2("Anchor");
         internal static readonly Vector3 MyAnchor3 = Vector3(MyAnchor.X, MyAnchor.Y, 0);
         internal static readonly Vector4 MyColor = MyVector4("Color");
+        internal static readonly Scalar MyCornerRadiusX = MyScalar("CornerRadius.X");
         internal static readonly Scalar MyInheritedOpacity = MyScalar("InheritedOpacity");
         internal static readonly Scalar MyOpacity = MyScalar("Opacity");
         internal static readonly Vector2 MyPosition = MyVector2("Position");
         internal static readonly Vector2 MySize = MyVector2("Size");
         internal static readonly Matrix3x2 MyTransformMatrix = MyMatrix3x2("TransformMatrix");
+        static readonly Scalar MyRoundness = MyScalar("Roundness");
         static readonly Scalar MyTStart = MyScalar("TStart");
         static readonly Scalar MyTEnd = MyScalar("TEnd");
 
@@ -66,6 +68,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         internal static Vector2 PositionToOffsetExpression(Sn.Vector2 position) => Vector2(position) - HalfMySize;
 
         internal static Scalar RootScalar(string propertyName) => Scalar(RootProperty(propertyName));
+
+        internal static Scalar ConstrainedCornerRadiusScalar(double roundness) => Min(roundness, Min(MySize.X, MySize.Y) / 2);
+
+        internal static Scalar ConstrainedCornerRadiusScalar() => Min(MyRoundness, Min(MySize.X, MySize.Y) / 2);
+
+        internal static Scalar ConstrainedCornerRadiusScalar(Sn.Vector2 size) => Min(MyRoundness, Math.Min(size.X, size.Y) / 2);
 
         // The value of a Color property stored as a Vector4 on the theming property set.
         static Vector4 ThemedColor4Property(string propertyName) => Vector4(ThemeProperty(propertyName));

--- a/source/LottieToWinComp/ExpressionFactory.cs
+++ b/source/LottieToWinComp/ExpressionFactory.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         internal static readonly Vector2 MyAnchor = MyVector2("Anchor");
         internal static readonly Vector3 MyAnchor3 = Vector3(MyAnchor.X, MyAnchor.Y, 0);
         internal static readonly Vector4 MyColor = MyVector4("Color");
-        internal static readonly Scalar MyCornerRadiusX = MyScalar("CornerRadius.X");
         internal static readonly Scalar MyInheritedOpacity = MyScalar("InheritedOpacity");
         internal static readonly Scalar MyOpacity = MyScalar("Opacity");
         internal static readonly Vector2 MyPosition = MyVector2("Position");

--- a/source/LottieToWinComp/LottieToWinCompTranslator.cs
+++ b/source/LottieToWinComp/LottieToWinCompTranslator.cs
@@ -2282,9 +2282,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                 // NOTE: magic tiny corner radius number - do not change!
                 roundedRectangleGeometry.CornerRadius = new Sn.Vector2(0.000001F);
 
-                // Convert size and position into offset. This is necessary because a geometry's offset is for
-                // its top left corner, whereas a Lottie position is for its centerpoint.
-                roundedRectangleGeometry.Offset = Vector2(position.InitialValue - (size.InitialValue / 2));
+                roundedRectangleGeometry.Offset = InitialOffset(size: size, position: position);
 
                 if (!size.IsAnimated)
                 {
@@ -2299,7 +2297,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 
                 // Convert size and position into offset. This is necessary because a geometry's offset is for
                 // its top left corner, whereas a Lottie position is for its centerpoint.
-                rectangleGeometry.Offset = Vector2(position.InitialValue - (size.InitialValue / 2));
+                rectangleGeometry.Offset = InitialOffset(size: size, position: position);
 
                 if (!size.IsAnimated)
                 {
@@ -2330,7 +2328,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                     ? shapeContext.RoundedCorner.Radius
                     : shapeContent.Roundness);
 
-            // In After Effects, the rectangle Roundness has no further affect once it reaches min(Size.X, Size.Y)/2.
+            // In After Effects, the rectangle Roundness has no further effect once it reaches min(Size.X, Size.Y)/2.
             // In Composition, the cornerRadius continues to affect the shape even beyond min(Size.X, Size.Y)/2.
             // If size or corner radius are animated, handle this with an expression.
             if (cornerRadius.IsAnimated || size.IsAnimated)
@@ -2375,9 +2373,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                 geometry.CornerRadius = Vector2((float)cornerRadiusValue);
             }
 
-            // Convert size and position into offset. This is necessary because a geometry's offset is for
-            // its top left corner, whereas a Lottie position is for its centerpoint.
-            geometry.Offset = Vector2(position.InitialValue - (size.InitialValue / 2));
+            geometry.Offset = InitialOffset(size:size, position:position);
 
             if (!size.IsAnimated)
             {
@@ -2386,6 +2382,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 
             ApplyRectangleContentCommon(context, shapeContext, shapeContent, compositionShape, size, position, geometry);
         }
+
+        // Convert the size and position for a geometry into an offset.
+        // This is necessary because a geometry's offset describes its
+        // top left corner, whereas a Lottie position describes its centerpoint.
+        static Sn.Vector2 InitialOffset(
+            in TrimmedAnimatable<Vector3> size,
+            in TrimmedAnimatable<Vector3> position)
+            => Vector2(position.InitialValue - (size.InitialValue / 2));
 
         void ApplyRectangleContentCommon(
             TranslationContext context,

--- a/source/LottieToWinComp/LottieToWinCompTranslator.cs
+++ b/source/LottieToWinComp/LottieToWinCompTranslator.cs
@@ -2341,30 +2341,25 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                     if (size.IsAnimated)
                     {
                         // Both size and cornerRadius are animated.
-                        var cornerRadiusExpression = _c.CreateExpressionAnimation(ExpressionFactory.ConstrainedCornerRadiusScalar());
+                        var cornerRadiusExpression = _c.CreateExpressionAnimation(ConstrainedCornerRadiusScalar());
                         cornerRadiusExpression.SetReferenceParameter("my", geometry);
-                        StartExpressionAnimation(geometry, "CornerRadius.X", cornerRadiusExpression);
+                        StartExpressionAnimation(geometry, "CornerRadius", cornerRadiusExpression);
                     }
                     else
                     {
                         // Only the cornerRadius is animated.
-                        var cornerRadiusExpression = _c.CreateExpressionAnimation(ExpressionFactory.ConstrainedCornerRadiusScalar(Vector2(size.InitialValue)));
+                        var cornerRadiusExpression = _c.CreateExpressionAnimation(ConstrainedCornerRadiusScalar(Vector2(size.InitialValue)));
                         cornerRadiusExpression.SetReferenceParameter("my", geometry);
-                        StartExpressionAnimation(geometry, "CornerRadius.X", cornerRadiusExpression);
+                        StartExpressionAnimation(geometry, "CornerRadius", cornerRadiusExpression);
                     }
                 }
                 else
                 {
                     // Only the size is animated.
-                    var cornerRadiusExpression = _c.CreateExpressionAnimation(ExpressionFactory.ConstrainedCornerRadiusScalar(cornerRadius.InitialValue));
+                    var cornerRadiusExpression = _c.CreateExpressionAnimation(ConstrainedCornerRadiusScalar(cornerRadius.InitialValue));
                     cornerRadiusExpression.SetReferenceParameter("my", geometry);
-                    StartExpressionAnimation(geometry, "CornerRadius.X", cornerRadiusExpression);
+                    StartExpressionAnimation(geometry, "CornerRadius", cornerRadiusExpression);
                 }
-
-                // Tie the CornerRadius.Y value to the CornerRadius.X value.
-                var yEqualsXExpression = _c.CreateExpressionAnimation(ExpressionFactory.MyCornerRadiusX);
-                yEqualsXExpression.SetReferenceParameter("my", geometry);
-                StartExpressionAnimation(geometry, "CornerRadius.Y", yEqualsXExpression);
             }
             else
             {

--- a/source/WinCompData/CompositionObject.cs
+++ b/source/WinCompData/CompositionObject.cs
@@ -141,15 +141,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData
         /// <param name="propertyName">The name of the property.</param>
         public void StopAnimation(string propertyName)
         {
-            // We also need to stop animations on any sub-channels and super-channels.
+            // We also need to stop animations on any sub-channels.
             // For example, if the property is TransformMatrix we must also stop animations
-            // on TransformMatrix.M11, TransformMatrix.M12, etc; and if the property is
-            // TransformMatrix.M11 we must also stop animations on TransformMatrix,
-            // TransformMatrix.M12, etc.
-            //
-            // If there's a dot in the name it is a sub-channel name.
-            var firstDotIndex = propertyName.IndexOf('.');
-            var rootPropertyPrefix = $"{(firstDotIndex >= 0 ? propertyName.Substring(0, firstDotIndex) : propertyName)}.";
+            // on TransformMatrix.M11, TransformMatrix.M12, etc..
+            var rootPropertyPrefix = $"{propertyName}.";
 
             for (var i = 0; i < _animators.Count; i++)
             {

--- a/source/WinCompData/CompositionObject.cs
+++ b/source/WinCompData/CompositionObject.cs
@@ -143,10 +143,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData
         {
             // We also need to stop animations on any sub-channels and the root property.
             // Examples:
-            //  Sub-channels: stopping TransformMatrix must also stop
-            //    TransformMatrix.M11, TransformMatrix.M12, etc..
-            //  Root property: stopping TransformMatrix.M11 must also
-            //    stop TransformMatrix.
+            //  Sub-channels: stopping CornerRadius must also stop
+            //    CornerRadius.X, CornerRadius.Y, etc..
+            //  Root property: stopping CornerRadius.X must also
+            //    stop CornerRadius.
             // If there's a dot in the name it is a sub-channel name.
             var subChannelPrefix = $"{propertyName}.";
             var firstDotIndex = propertyName.IndexOf('.');

--- a/source/WinCompData/CompositionObject.cs
+++ b/source/WinCompData/CompositionObject.cs
@@ -143,10 +143,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData
         {
             // We also need to stop animations on any sub-channels and the root property.
             // Examples:
-            //  Sub-channels: stopping CornerRadius must also stop
-            //    CornerRadius.X, CornerRadius.Y, etc..
-            //  Root property: stopping CornerRadius.X must also
-            //    stop CornerRadius.
+            //  Sub-channels: stopping Offset must also stop
+            //    Offset.X, Offset.Y, etc..
+            //  Root property: stopping Offset.X must also
+            //    stop OFfset.
             // If there's a dot in the name it is a sub-channel name.
             var subChannelPrefix = $"{propertyName}.";
             var firstDotIndex = propertyName.IndexOf('.');

--- a/source/WinCompData/CompositionObject.cs
+++ b/source/WinCompData/CompositionObject.cs
@@ -141,17 +141,24 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData
         /// <param name="propertyName">The name of the property.</param>
         public void StopAnimation(string propertyName)
         {
-            // We also need to stop animations on any sub-channels.
-            // For example, if the property is TransformMatrix we must also stop animations
-            // on TransformMatrix.M11, TransformMatrix.M12, etc..
-            var rootPropertyPrefix = $"{propertyName}.";
+            // We also need to stop animations on any sub-channels and the root property.
+            // Examples:
+            //  Sub-channels: stopping TransformMatrix must also stop
+            //    TransformMatrix.M11, TransformMatrix.M12, etc..
+            //  Root property: stopping TransformMatrix.M11 must also
+            //    stop TransformMatrix.
+            // If there's a dot in the name it is a sub-channel name.
+            var subChannelPrefix = $"{propertyName}.";
+            var firstDotIndex = propertyName.IndexOf('.');
+            var rootPropertyName = $"{(firstDotIndex >= 0 ? propertyName.Substring(0, firstDotIndex) : string.Empty)}.";
 
             for (var i = 0; i < _animators.Count; i++)
             {
                 var animatorPropertyName = _animators[i].AnimatedProperty;
 
                 if (animatorPropertyName == propertyName ||
-                    animatorPropertyName.StartsWith(rootPropertyPrefix))
+                    animatorPropertyName == rootPropertyName ||
+                    animatorPropertyName.StartsWith(subChannelPrefix))
                 {
                     _animators.RemoveAt(i);
 

--- a/source/WinCompData/CompositionObject.cs
+++ b/source/WinCompData/CompositionObject.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData
             //  Sub-channels: stopping Offset must also stop
             //    Offset.X, Offset.Y, etc..
             //  Root property: stopping Offset.X must also
-            //    stop OFfset.
+            //    stop Offset.
             // If there's a dot in the name it is a sub-channel name.
             var subChannelPrefix = $"{propertyName}.";
             var firstDotIndex = propertyName.IndexOf('.');


### PR DESCRIPTION
Composition and After Effects use different models for expression rounded rectangles. Composition has a Vector2 CornerRadius that can be set to anything. As the radius trends towards half the size the rectangle looks more like an ellipse, but when the CornerRadius gets bigger than half the size it starts looking like a weird 4-sided star thing. After Effects uses a scalar Roundness value and always caps the value so that you can't go beyond a circle.

Previously we were not accounting for this difference in models.

This is not a complete fix, but it fixes a lot of egregious cases. It's not complete because there is another After Effects concept called "Rounded corners" which interacts with rounded rectangles in a complex fashion, and we don't yet support that correctly. It seems to be really rare though, so not a big deal.

This change also undoes part of a previous "fix" to the code for stopping an animation on a WinCompData.CompositionObject. Due to a misunderstanding about how that's supposed to work, we would stop some animations that shouldn't have been stopped.