### PR TITLE
Prevent duplicated keyframe progress

### DIFF
--- a/source/LottieToWinComp/LottieToWinCompTranslator.cs
+++ b/source/LottieToWinComp/LottieToWinCompTranslator.cs
@@ -4454,12 +4454,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             {
                 AdjustProgress(ref progress);
 
-                if (progress > 1)
-                {
-                    // We ran out of room. The key frame will be ignored.
-                    Debug.Fail("Progress > 1");
-                }
-                else
+                // If progress is > 1 then we have no more room to add key frames.
+                // This can happen as a result of extra key frames being added for
+                // various reasons. The dropped key frames shouldn't matter as they
+                // would only affect a very small amount of time at the end of the
+                // animation.
+                if (progress <= 1)
                 {
                     keyFrameInserter(animation, progress, value, easing);
                 }
@@ -4473,12 +4473,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             {
                 AdjustProgress(ref progress);
 
-                if (progress > 1)
-                {
-                    // We ran out of room. The key frame will be ignored.
-                    Debug.Fail("Progress > 1");
-                }
-                else
+                // If progress is > 1 then we have no more room to add key frames.
+                // This can happen as a result of extra key frames being added for
+                // various reasons. The dropped key frames shouldn't matter as they
+                // would only affect a very small amount of time at the end of the
+                // animation.
+                if (progress <= 1)
                 {
                     expressionKeyFrameInserter(animation, progress, expression, easing);
                 }

--- a/source/LottieToWinComp/LottieToWinCompTranslator.cs
+++ b/source/LottieToWinComp/LottieToWinCompTranslator.cs
@@ -889,8 +889,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             var layerOpacity = context.TrimAnimatable(context.Layer.Transform.Opacity);
 
             // Convert the layer's in point and out point into absolute progress (0..1) values.
-            var inProgress = GetInPointProgress(context);
-            var outProgress = GetOutPointProgress(context);
+            var inProgress = context.InPointAsProgress;
+            var outProgress = context.OutPointAsProgress;
 
             if (inProgress > 1 || outProgress <= 0 || inProgress >= outProgress || layerOpacity.AlwaysEquals(LottieData.Opacity.Transparent))
             {
@@ -970,8 +970,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             var layerOpacity = context.TrimAnimatable(context.Layer.Transform.Opacity);
 
             // Convert the layer's in point and out point into absolute progress (0..1) values.
-            var inProgress = GetInPointProgress(context);
-            var outProgress = GetOutPointProgress(context);
+            var inProgress = context.InPointAsProgress;
+            var outProgress = context.OutPointAsProgress;
 
             if (inProgress > 1 || outProgress <= 0 || inProgress >= outProgress || layerOpacity.AlwaysEquals(LottieData.Opacity.Transparent))
             {
@@ -1072,8 +1072,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             var layerOpacity = context.TrimAnimatable(context.Layer.Transform.Opacity);
 
             // Convert the layer's in point and out point into absolute progress (0..1) values.
-            var inProgress = GetInPointProgress(context);
-            var outProgress = GetOutPointProgress(context);
+            var inProgress = context.InPointAsProgress;
+            var outProgress = context.OutPointAsProgress;
 
             if (inProgress > 1 || outProgress <= 0 || inProgress >= outProgress || layerOpacity.AlwaysEquals(LottieData.Opacity.Transparent))
             {
@@ -4437,20 +4437,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 
             // Start the animation scaled and offset.
             StartKeyframeAnimation(targetObject, targetPropertyName, compositionAnimation, scale, offset);
-        }
-
-        float GetInPointProgress(TranslationContext context)
-        {
-            var result = (context.Layer.InPoint - context.StartTime) / context.DurationInFrames;
-
-            return (float)result;
-        }
-
-        float GetOutPointProgress(TranslationContext context)
-        {
-            var result = (context.Layer.OutPoint - context.StartTime) / context.DurationInFrames;
-
-            return (float)result;
         }
 
         static ShapeFill.PathFillType GetPathFillType(ShapeFill fill) => fill is null ? ShapeFill.PathFillType.EvenOdd : fill.FillType;

--- a/source/LottieToWinComp/PathGeometryGroup.cs
+++ b/source/LottieToWinComp/PathGeometryGroup.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             // Store the keyframes in a dictionary, keyed by frame.
             var ps = paths.ToArray();
 
-            var groupsByFrame = new Dictionary<double, GeometryKeyFrame[]>(new FrameComparer(context))
+            var groupsByFrame = new Dictionary<double, GeometryKeyFrame[]>(context.FrameNumberComparer)
             {
                 { 0, new GeometryKeyFrame[ps.Length] },
             };
@@ -140,24 +140,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             internal Easing Easing { get; }
 
             internal PathGeometry Geometry { get; }
-        }
-
-        sealed class FrameComparer : IEqualityComparer<double>
-        {
-            readonly TranslationContext _context;
-
-            internal FrameComparer(TranslationContext context)
-            {
-                _context = context;
-            }
-
-            public bool Equals(double x, double y) => ProgressOf(x) == ProgressOf(y);
-
-            public int GetHashCode(double obj) => ProgressOf(obj).GetHashCode();
-
-            // Converts a frame number into a progress value.
-            float ProgressOf(double value) =>
-                (float)((value - _context.StartTime) / _context.DurationInFrames);
         }
     }
 }

--- a/source/LottieToWinComp/PathGeometryGroup.cs
+++ b/source/LottieToWinComp/PathGeometryGroup.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.Toolkit.Uwp.UI.Lottie.LottieData;
@@ -62,6 +63,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                         array = new GeometryKeyFrame[ps.Length];
                         groupsByFrame.Add(kf.Frame, array);
                     }
+
+                    // NOTE: this could result in a key frame being overwritten and
+                    // lost if the frame numbers are very close together. This seems
+                    // to be extremely rare, so rather than trying to be too clever
+                    // here we'll just let it happen. The assert should help us find
+                    // any cases where this happens to determine if we should be trying
+                    // harder.
+                    Debug.Assert(array[i] is null, "Path key frames very close together");
 
                     array[i] = new GeometryKeyFrame(p, kf.Value, kf.Easing);
                 }

--- a/source/LottieToWinComp/TranslationContext.cs
+++ b/source/LottieToWinComp/TranslationContext.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 
         /// <summary>
         /// Compares frame numbers for equality. This takes into account the lossiness of the conversion
-        /// that is done from <see cref="float"/> frame numbers to <see cref="double"/> progress values.
+        /// that is done from <see cref="double"/> frame numbers to <see cref="float"/> progress values.
         /// </summary>
         sealed class FrameNumberEqualityComparer : IEqualityComparer<double>
         {

--- a/source/LottieToWinComp/TranslationContext.cs
+++ b/source/LottieToWinComp/TranslationContext.cs
@@ -49,6 +49,18 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 
         public override string ToString() => Layer.Name ?? Layer.Type.ToString();
 
+        /// <summary>
+        /// The <see cref="Layer"/>'s in point as a progress value.
+        /// </summary>
+        internal float InPointAsProgress =>
+            (float)((Layer.InPoint - StartTime) / DurationInFrames);
+
+        /// <summary>
+        /// The <see cref="Layer"/>'s out point as a progress value.
+        /// </summary>
+        internal float OutPointAsProgress =>
+            (float)((Layer.OutPoint - StartTime) / DurationInFrames);
+
         // Constructs a context for the given layer that is a child of this context.
         internal For<T> SubContext<T>(T layer)
             where T : Layer

--- a/source/WinCompData/KeyFrameAnimation.cs
+++ b/source/WinCompData/KeyFrameAnimation.cs
@@ -58,7 +58,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData
                 throw new ArgumentException($"Progress must be >=0 and <=1. Value: {progress}");
             }
 
-            _keyFrames.Add(progress, new ValueKeyFrame { Progress = progress, Value = value, Easing = easing });
+            // It is legal to insert a key frame at a progress value that already has
+            // a key frame. Last one wins.
+            _keyFrames[progress] = new ValueKeyFrame { Progress = progress, Value = value, Easing = easing };
         }
 
         public IEnumerable<KeyFrame> KeyFrames => _keyFrames.Values;


### PR DESCRIPTION
I found a Lottie file that during translation would generate 2 keyframes at the same progress. That's illegal for Composition.
The Lottie file that triggered this had one path in a geometry group at frame 48 and another in the same group at 48.000000357.

This issue is caused by the fact that we convert unique key frame numbers as doubles to progress values as floats. Floats have less resolution, so if 2 keyframes were really close together then they might end up with identical progress values.

It's also an issue when we group animated paths because the 2 paths might have key frame numbers that are slightly different but end up at the same progress value. As long as we prevent identical progress values that's fine, but if we can be a bit smarter about how we compare frame numbers during grouping we can group more effectively.