### PR TITLE
Include the offset in the name of a gradient stop.

### DIFF
--- a/source/UIDataCodeGen/CodeGen/NodeNamer.cs
+++ b/source/UIDataCodeGen/CodeGen/NodeNamer.cs
@@ -161,23 +161,27 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
 
         static NodeName NameCompositionColorGradientStop(CompositionColorGradientStop obj)
         {
+            var offsetId = FloatAsId1(obj.Offset);
+
             if (obj.Animators.Count > 0)
             {
+                var baseName = $"AnimatedGradientStop_{offsetId}";
+
                 // Gradient stop is animated. Give it a name based on the colors in the animation.
                 var colorAnimation = obj.Animators.Where(a => a.AnimatedProperty == "Color").First().Animation;
                 if (colorAnimation is ColorKeyFrameAnimation colorKeyFrameAnimation)
                 {
-                    return NodeName.FromNameAndDescription("AnimatedGradientStop", DescribeAnimationRange(colorKeyFrameAnimation));
+                    return NodeName.FromNameAndDescription(baseName, DescribeAnimationRange(colorKeyFrameAnimation));
                 }
                 else
                 {
-                    return NodeName.FromNonTypeName("AnimatedGradientStop");
+                    return NodeName.FromNonTypeName(baseName);
                 }
             }
             else
             {
                 // Gradient stop is not animated. Give it a name based on the color.
-                return NodeName.FromNameAndDescription("GradientStop", obj.Color.Name);
+                return NodeName.FromNameAndDescription($"GradientStop_{offsetId}", obj.Color.Name);
             }
         }
 
@@ -304,6 +308,23 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
         // A float for use in an id.
         static string FloatAsId(float value)
             => value.ToString("0.###", CultureInfo.InvariantCulture).Replace('.', 'p').Replace('-', 'm');
+
+        // A float for use in an id where the float is always in the range of [0..1].
+        static string FloatAsId1(float value)
+        {
+            if (value < 0 || value > 1)
+            {
+                throw new ArgumentException();
+            }
+
+            // Return "0" or "1" or "pNM" where N and M are the first and second
+            // digits after the decimal point.
+            return value == 0
+                    ? "0"
+                    : (value == 1)
+                        ? "1"
+                        : value.ToString("0.##", CultureInfo.InvariantCulture).Substring(1).Replace('.', 'p');
+        }
 
         static string NameOf(IDescribable obj) => obj.Name;
 


### PR DESCRIPTION
This is to make it easier to see from the factory method for a gradient where the gradient stops lie.
I'm adding this because I started investigating why gradient stops are sometimes different from run to run of LottieGen and realized that this change would make reading the generated code easier to help figure out what's going on.