### PR TITLE
Stop using CompositionRectangleGeometry

### DIFF
--- a/source/Lottie/Instantiator.cs
+++ b/source/Lottie/Instantiator.cs
@@ -1255,7 +1255,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
                 result.Offset = obj.Offset.Value;
             }
 
-            result.Size = obj.Size;
+            if (obj.Size.HasValue)
+            {
+                result.Size = obj.Size.Value;
+            }
+
             StartAnimations(obj, result);
             return result;
         }
@@ -1273,7 +1277,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
                 result.Offset = obj.Offset.Value;
             }
 
-            result.Size = obj.Size;
+            if (obj.Size.HasValue)
+            {
+                result.Size = obj.Size.Value;
+            }
+
             result.CornerRadius = obj.CornerRadius;
             StartAnimations(obj, result);
             return result;

--- a/source/LottieToWinComp/CompositionObjectFactory.cs
+++ b/source/LottieToWinComp/CompositionObjectFactory.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Reflection.Metadata.Ecma335;
 using Microsoft.Toolkit.Uwp.UI.Lottie.LottieData;
 using Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData;
 using Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Mgce;

--- a/source/LottieToWinComp/CompositionObjectFactory.cs
+++ b/source/LottieToWinComp/CompositionObjectFactory.cs
@@ -112,16 +112,19 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                 roundedRectangleGeometry.CornerRadius = new Sn.Vector2(0.000001F);
                 roundedRectangleGeometry.Size = size;
                 roundedRectangleGeometry.Offset = offset;
+
                 result = roundedRectangleGeometry;
             }
             else
             {
                 // Later versions do not need the rounded rectangle workaround.
+                ConsumeVersionFeature(c_rectangleGeometryIsUnreliableUntil);
+
                 var rectangleGeometry = _compositor.CreateRectangleGeometry();
                 rectangleGeometry.Size = size;
                 rectangleGeometry.Offset = offset;
+
                 result = rectangleGeometry;
-                ConsumeVersionFeature(c_rectangleGeometryIsUnreliableUntil);
             }
 
             return result;

--- a/source/LottieToWinComp/LottieToWinCompTranslator.cs
+++ b/source/LottieToWinComp/LottieToWinCompTranslator.cs
@@ -2269,41 +2269,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         {
             Debug.Assert(shapeContent.Roundness.AlwaysEquals(0) && shapeContext.RoundedCorner is null, "Precondition");
 
-            CompositionGeometry geometry;
-
-            // Use a non-rounded rectangle geometry.
-            if (_targetUapVersion <= 7)
-            {
-                // V7 did not reliably draw non-rounded rectangles.
-                // Work around the problem by using a rounded rectangle with a tiny corner radius.
-                var roundedRectangleGeometry = _c.CreateRoundedRectangleGeometry();
-                geometry = roundedRectangleGeometry;
-
-                // NOTE: magic tiny corner radius number - do not change!
-                roundedRectangleGeometry.CornerRadius = new Sn.Vector2(0.000001F);
-
-                roundedRectangleGeometry.Offset = InitialOffset(size: size, position: position);
-
-                if (!size.IsAnimated)
-                {
-                    roundedRectangleGeometry.Size = Vector2(size.InitialValue);
-                }
-            }
-            else
-            {
-                // V8 and beyond doesn't need the rounded rectangle workaround.
-                var rectangleGeometry = _c.CreateRectangleGeometry();
-                geometry = rectangleGeometry;
-
-                // Convert size and position into offset. This is necessary because a geometry's offset is for
-                // its top left corner, whereas a Lottie position is for its centerpoint.
-                rectangleGeometry.Offset = InitialOffset(size: size, position: position);
-
-                if (!size.IsAnimated)
-                {
-                    rectangleGeometry.Size = Vector2(size.InitialValue);
-                }
-            }
+            var geometry = _c.CreateRectangleGeometry(
+                                size: size.IsAnimated ? (Sn.Vector2?)null : Vector2(size.InitialValue),
+                                offset: InitialOffset(size: size, position: position));
 
             compositionShape.Geometry = geometry;
 
@@ -5005,24 +4973,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 
                     var rectangle = _owner._c.CreateSpriteShape();
 
-                    if (_owner._targetUapVersion <= 7)
-                    {
-                        // V7 did not reliably draw non-rounded rectangles.
-                        // Work around the problem by using a rounded rectangle with a tiny corner radius.
-                        var roundedRectangleGeometry = _owner._c.CreateRoundedRectangleGeometry();
-
-                        // NOTE: magic tiny corner radius number - do not change!
-                        roundedRectangleGeometry.CornerRadius = new Sn.Vector2(0.000001F);
-                        roundedRectangleGeometry.Size = Vector2(_context.Layer.Width, _context.Layer.Height);
-                        rectangle.Geometry = roundedRectangleGeometry;
-                    }
-                    else
-                    {
-                        // V8 and beyond doesn't need the rounded rectangle workaround.
-                        var rectangleGeometry = _owner._c.CreateRectangleGeometry();
-                        rectangleGeometry.Size = Vector2(_context.Layer.Width, _context.Layer.Height);
-                        rectangle.Geometry = rectangleGeometry;
-                    }
+                    rectangle.Geometry = _owner._c.CreateRectangleGeometry(
+                                            size: new Sn.Vector2(_context.Layer.Width, _context.Layer.Height),
+                                            offset: null);
 
                     containerContentNode.Shapes.Add(rectangle);
 

--- a/source/UIDataCodeGen/CodeGen/NodeNamer.cs
+++ b/source/UIDataCodeGen/CodeGen/NodeNamer.cs
@@ -329,8 +329,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
         static string NameOf(IDescribable obj) => obj.Name;
 
         // A Vector2 for use in an id.
-        static string Vector2AsId(Vector2 size)
-            => size.X == size.Y ? FloatAsId(size.X) : $"{FloatAsId(size.X)}x{FloatAsId(size.Y)}";
+        static string Vector2AsId(Vector2? size)
+            => size.HasValue
+                ? (size.Value.X == size.Value.Y ? FloatAsId(size.Value.X) : $"{FloatAsId(size.Value.X)}x{FloatAsId(size.Value.Y)}")
+                : string.Empty;
 
         // The code we hit is supposed to be unreachable. This indicates a bug.
         static Exception Unreachable => new InvalidOperationException("Unreachable code executed");

--- a/source/UIDataCodeGen/CodeGen/NodeNamer.cs
+++ b/source/UIDataCodeGen/CodeGen/NodeNamer.cs
@@ -161,7 +161,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
 
         static NodeName NameCompositionColorGradientStop(CompositionColorGradientStop obj)
         {
-            var offsetId = FloatAsId1(obj.Offset);
+            var offsetId = FloatAsId(obj.Offset);
 
             if (obj.Animators.Count > 0)
             {
@@ -308,23 +308,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
         // A float for use in an id.
         static string FloatAsId(float value)
             => value.ToString("0.###", CultureInfo.InvariantCulture).Replace('.', 'p').Replace('-', 'm');
-
-        // A float for use in an id where the float is always in the range of [0..1].
-        static string FloatAsId1(float value)
-        {
-            if (value < 0 || value > 1)
-            {
-                throw new ArgumentException();
-            }
-
-            // Return "0" or "1" or "pNM" where N and M are the first and second
-            // digits after the decimal point.
-            return value == 0
-                    ? "0"
-                    : (value == 1)
-                        ? "1"
-                        : value.ToString("0.##", CultureInfo.InvariantCulture).Substring(1).Replace('.', 'p');
-        }
 
         static string NameOf(IDescribable obj) => obj.Name;
 

--- a/source/WinCompData/CompositionRectangleGeometry.cs
+++ b/source/WinCompData/CompositionRectangleGeometry.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData
 
         public Vector2? Offset { get; set; }
 
-        public Vector2 Size { get; set; }
+        public Vector2? Size { get; set; }
 
         /// <inheritdoc/>
         public override CompositionObjectType Type => CompositionObjectType.CompositionRectangleGeometry;

--- a/source/WinCompData/CompositionRoundedRectangleGeometry.cs
+++ b/source/WinCompData/CompositionRoundedRectangleGeometry.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData
 
         public Vector2? Offset { get; set; }
 
-        public Vector2 Size { get; set; }
+        public Vector2? Size { get; set; }
 
         /// <inheritdoc/>
         public override CompositionObjectType Type => CompositionObjectType.CompositionRoundedRectangleGeometry;


### PR DESCRIPTION
CompositionRectangleGeoemetry doesn't anti-alias correctly. Rounded rectangles with tiny corner radiuses work fine, so use them instead.

Rectangles are expected to be fixed eventually, and when they are we can take advantage of their better (than rounded) perf, but until then they aren't reliable.
