### PR TITLE
Ignore the "ml2" field in Lottie files.

### DIFF
--- a/source/LottieReader/Serialization/ShapeLayerContents.cs
+++ b/source/LottieReader/Serialization/ShapeLayerContents.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
         {
             // Not clear whether we need to read these properties.
             // "ml2" is some sort of extra miter limit value that does not seem to be supported by
-            // BodyMovin. It's a mystery as to what it means or how hit is getting into the file,
+            // BodyMovin. It's a mystery as to what it means or how it is getting into the file,
             // but quite a few files have it.
             obj.IgnorePropertyThatIsNotYetSupported("fillEnabled", "hd", "ml2");
 

--- a/source/LottieReader/Serialization/ShapeLayerContents.cs
+++ b/source/LottieReader/Serialization/ShapeLayerContents.cs
@@ -85,7 +85,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
             in ShapeLayerContent.ShapeLayerContentArgs shapeLayerContentArgs)
         {
             // Not clear whether we need to read these properties.
-            obj.IgnorePropertyThatIsNotYetSupported("fillEnabled", "hd");
+            // "ml2" is some sort of extra miter limit value that does not seem to be supported by
+            // BodyMovin. It's a mystery as to what it means or how hit is getting into the file,
+            // but quite a few files have it.
+            obj.IgnorePropertyThatIsNotYetSupported("fillEnabled", "hd", "ml2");
 
             var color = ReadAnimatableColor(obj.ObjectPropertyOrNull("c"));
             var opacity = ReadAnimatableOpacity(obj.ObjectPropertyOrNull("o"));


### PR DESCRIPTION
It's a mystery as to what this field does. It appears to be related to miter limit, but that's already handled by "ml". Some tool is adding it, although BodyMovin importer doesn't seem to know what it is.