### PR TITLE
Add ability to automatically bind to the colors in a Lottie's palette.

### DIFF
--- a/LottieGen/CommandLineOptions.cs
+++ b/LottieGen/CommandLineOptions.cs
@@ -35,6 +35,8 @@ sealed class CommandLineOptions
     // The error should be a sentence (starts with a capital letter, and ends with a period).
     internal string ErrorDescription { get; private set; }
 
+    internal bool GenerateColorBindings { get; private set; }
+
     internal bool GenerateDependencyObject { get; private set; }
 
     internal bool HelpRequested { get; private set; }
@@ -83,6 +85,11 @@ sealed class CommandLineOptions
         if (DisableTranslationOptimizer)
         {
             sb.Append($" -{nameof(DisableTranslationOptimizer)}");
+        }
+
+        if (GenerateColorBindings)
+        {
+            sb.Append($" -{nameof(GenerateColorBindings)}");
         }
 
         if (GenerateDependencyObject)
@@ -134,6 +141,7 @@ sealed class CommandLineOptions
         Ambiguous,
         DisableCodeGenOptimizer,
         DisableTranslationOptimizer,
+        GenerateColorBindings,
         GenerateDependencyObject,
         Help,
         InputFile,
@@ -156,14 +164,14 @@ sealed class CommandLineOptions
 
         // Convert the language strings to language values.
         var languageTokenizer = new CommandlineTokenizer<Lang>(Lang.Ambiguous)
-                .AddKeyword("csharp", Lang.CSharp)
-                .AddKeyword("cppcx", Lang.Cx)
-                .AddKeyword("cx", Lang.Cx)
-                .AddKeyword("cppwinrt", Lang.Cppwinrt)
-                .AddKeyword("winrtcpp", Lang.Cppwinrt)
-                .AddKeyword("lottieyaml", Lang.LottieYaml)
-                .AddKeyword("dgml", Lang.WinCompDgml)
-                .AddKeyword("stats", Lang.Stats);
+                .AddKeyword(Lang.CSharp)
+                .AddKeyword(Lang.Cx, "cppcx")
+                .AddKeyword(Lang.Cx)
+                .AddKeyword(Lang.Cppwinrt)
+                .AddKeyword(Lang.Cppwinrt, "winrtcpp")
+                .AddKeyword(Lang.LottieYaml)
+                .AddKeyword(Lang.WinCompDgml, "dgml")
+                .AddKeyword(Lang.Stats);
 
         var languages = new List<Lang>();
 
@@ -192,21 +200,22 @@ sealed class CommandLineOptions
     {
         // Define the keywords accepted on the command line.
         var tokenizer = new CommandlineTokenizer<Keyword>(Keyword.Ambiguous)
-            .AddPrefixedKeyword("?", Keyword.Help)
-            .AddPrefixedKeyword("disablecodegenoptimizer", Keyword.DisableCodeGenOptimizer)
-            .AddPrefixedKeyword("disabletranslationoptimizer", Keyword.DisableTranslationOptimizer)
-            .AddPrefixedKeyword("generatedependencyobject", Keyword.GenerateDependencyObject)
-            .AddPrefixedKeyword("help", Keyword.Help)
-            .AddPrefixedKeyword("inputfile", Keyword.InputFile)
-            .AddPrefixedKeyword("interface", Keyword.Interface)
-            .AddPrefixedKeyword("language", Keyword.Language)
-            .AddPrefixedKeyword("minimumuapversion", Keyword.MinimumUapVersion)
-            .AddPrefixedKeyword("namespace", Keyword.Namespace)
-            .AddPrefixedKeyword("outputfolder", Keyword.OutputFolder)
-            .AddPrefixedKeyword("public", Keyword.Public)
-            .AddPrefixedKeyword("strict", Keyword.Strict)
-            .AddPrefixedKeyword("targetuapversion", Keyword.TargetUapVersion)
-            .AddPrefixedKeyword("testmode", Keyword.TestMode);
+            .AddPrefixedKeyword(Keyword.Help, "?")
+            .AddPrefixedKeyword(Keyword.DisableCodeGenOptimizer)
+            .AddPrefixedKeyword(Keyword.DisableTranslationOptimizer)
+            .AddPrefixedKeyword(Keyword.GenerateColorBindings)
+            .AddPrefixedKeyword(Keyword.GenerateDependencyObject)
+            .AddPrefixedKeyword(Keyword.Help)
+            .AddPrefixedKeyword(Keyword.InputFile)
+            .AddPrefixedKeyword(Keyword.Interface)
+            .AddPrefixedKeyword(Keyword.Language)
+            .AddPrefixedKeyword(Keyword.MinimumUapVersion)
+            .AddPrefixedKeyword(Keyword.Namespace)
+            .AddPrefixedKeyword(Keyword.OutputFolder)
+            .AddPrefixedKeyword(Keyword.Public)
+            .AddPrefixedKeyword(Keyword.Strict)
+            .AddPrefixedKeyword(Keyword.TargetUapVersion)
+            .AddPrefixedKeyword(Keyword.TestMode);
 
         // The last keyword recognized. This defines what the following parameter value is for,
         // or None if not expecting a parameter value.
@@ -228,6 +237,9 @@ sealed class CommandLineOptions
                         case Keyword.None:
                             ErrorDescription = $"Unexpected: \"{arg}\".";
                             return;
+                        case Keyword.GenerateColorBindings:
+                            GenerateColorBindings = true;
+                            break;
                         case Keyword.GenerateDependencyObject:
                             GenerateDependencyObject = true;
                             break;

--- a/LottieGen/CommandLineOptions.cs
+++ b/LottieGen/CommandLineOptions.cs
@@ -200,11 +200,11 @@ sealed class CommandLineOptions
     {
         // Define the keywords accepted on the command line.
         var tokenizer = new CommandlineTokenizer<Keyword>(Keyword.Ambiguous)
-            .AddPrefixedKeyword(Keyword.Help, "?")
             .AddPrefixedKeyword(Keyword.DisableCodeGenOptimizer)
             .AddPrefixedKeyword(Keyword.DisableTranslationOptimizer)
             .AddPrefixedKeyword(Keyword.GenerateColorBindings)
             .AddPrefixedKeyword(Keyword.GenerateDependencyObject)
+            .AddPrefixedKeyword(Keyword.Help, "?")
             .AddPrefixedKeyword(Keyword.Help)
             .AddPrefixedKeyword(Keyword.InputFile)
             .AddPrefixedKeyword(Keyword.Interface)

--- a/LottieGen/CommandLineTokenizer.cs
+++ b/LottieGen/CommandLineTokenizer.cs
@@ -18,14 +18,20 @@ sealed class CommandlineTokenizer<TKeywordId>
         _ambiguousValue = ambiguousValue;
     }
 
-    internal CommandlineTokenizer<TKeywordId> AddPrefixedKeyword(string keyword, TKeywordId id)
+    internal CommandlineTokenizer<TKeywordId> AddPrefixedKeyword(TKeywordId id) =>
+        AddPrefixedKeyword(id, Enum.GetName(typeof(TKeywordId), id));
+
+    internal CommandlineTokenizer<TKeywordId> AddPrefixedKeyword(TKeywordId id, string keyword)
     {
-        AddKeyword($"-{keyword}", id);
-        return AddKeyword($"/{keyword}", id);
+        AddKeyword(id, $"-{keyword}");
+        return AddKeyword(id, $"/{keyword}");
     }
 
+    internal CommandlineTokenizer<TKeywordId> AddKeyword(TKeywordId id) =>
+        AddKeyword(id, Enum.GetName(typeof(TKeywordId), id));
+
     // Add a keyword to the recognizer.
-    internal CommandlineTokenizer<TKeywordId> AddKeyword(string keyword, TKeywordId id)
+    internal CommandlineTokenizer<TKeywordId> AddKeyword(TKeywordId id, string keyword)
     {
         TrieNode currrentNode = _root;
 

--- a/LottieGen/LottieFileProcessor.cs
+++ b/LottieGen/LottieFileProcessor.cs
@@ -765,7 +765,7 @@ sealed class LottieFileProcessor
             return _isTranslatedSuccessfully.Value;
         }
 
-        var options = new TranslationOptions
+        var configuration = new TranslatorConfiguration
         {
             AddCodegenDescriptions = true,
             TranslatePropertyBindings = true,
@@ -775,9 +775,8 @@ sealed class LottieFileProcessor
 
         var translationResult = LottieToMultiVersionWinCompTranslator.TryTranslateLottieComposition(
             lottieComposition: _lottieComposition,
-            options: options,
-            minimumUapVersion: _minimumUapVersion,
-            strictTranslation: false);
+            configuration: configuration,
+            minimumUapVersion: _minimumUapVersion);
 
         _translationResults = translationResult.TranslationResults;
         _translationIssues = translationResult.Issues;

--- a/LottieGen/LottieFileProcessor.cs
+++ b/LottieGen/LottieFileProcessor.cs
@@ -770,12 +770,12 @@ sealed class LottieFileProcessor
             AddCodegenDescriptions = true,
             TranslatePropertyBindings = true,
             GenerateColorBindings = _options.GenerateColorBindings,
+            TargetUapVersion = _options.TargetUapVersion ?? uint.MaxValue,
         };
 
         var translationResult = LottieToMultiVersionWinCompTranslator.TryTranslateLottieComposition(
             lottieComposition: _lottieComposition,
             options: options,
-            targetUapVersion: _options.TargetUapVersion ?? uint.MaxValue,
             minimumUapVersion: _minimumUapVersion,
             strictTranslation: false);
 

--- a/LottieGen/LottieFileProcessor.cs
+++ b/LottieGen/LottieFileProcessor.cs
@@ -765,13 +765,19 @@ sealed class LottieFileProcessor
             return _isTranslatedSuccessfully.Value;
         }
 
+        var options = new TranslationOptions
+        {
+            AddCodegenDescriptions = true,
+            TranslatePropertyBindings = true,
+            GenerateColorBindings = _options.GenerateColorBindings,
+        };
+
         var translationResult = LottieToMultiVersionWinCompTranslator.TryTranslateLottieComposition(
             lottieComposition: _lottieComposition,
+            options: options,
             targetUapVersion: _options.TargetUapVersion ?? uint.MaxValue,
             minimumUapVersion: _minimumUapVersion,
-            strictTranslation: false,
-            addCodegenDescriptions: true,
-            translatePropertyBindings: true);
+            strictTranslation: false);
 
         _translationResults = translationResult.TranslationResults;
         _translationIssues = translationResult.Issues;

--- a/LottieGen/Program.cs
+++ b/LottieGen/Program.cs
@@ -249,6 +249,10 @@ OVERVIEW:
          -DisableCodeGenOptimizer
                        Disables optimization done by the code generator. This is
                        useful when the generated code is going to be hacked on.
+         -GenerateColorBindings
+                       Generates properties for each distinct color of fills and
+                       strokes so that the colors in the animation can be modified
+                       at runtime.
          -GenerateDependencyObject
                        Generates code that extends DependencyObject. This is useful
                        to allow XAML binding to properties in the Lottie source.

--- a/LottieGen/Program.cs
+++ b/LottieGen/Program.cs
@@ -274,10 +274,9 @@ OVERVIEW:
                        issues will be reported to STDOUT.
          -TargetUapVersion
                        The target UAP version on which the result will run. Must be 7
-                       or higher and >= MinimumUapVersion. Code will be generated
-                       that may take advantage of features in this version in order
-                       to produce a better result. If not specified, defaults to
-                       the latest UAP version.
+                       or higher and >= MinimumUapVersion. This value determines the
+                       minimum SDK version required to compile the generated code.
+                       If not specified, defaults to the latest UAP version.
          -TestMode     Prevents any information from being included that could change
                        from run to run with the same inputs, for example tool version
                        numbers, file paths, and dates. This is designed to enable

--- a/source/Lottie/LottieVisualSource.cs
+++ b/source/Lottie/LottieVisualSource.cs
@@ -407,8 +407,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
                     // an issue if the author is using property bindings incorrectly.
                     translationResult = LottieToWinCompTranslator.TryTranslateLottieComposition(
                         lottieComposition: lottieComposition,
-                        options: new TranslationOptions { TranslatePropertyBindings = true },
-                        targetUapVersion: GetCurrentUapVersion(),
+                        options: new TranslationOptions { TranslatePropertyBindings = true, TargetUapVersion = GetCurrentUapVersion() },
                         strictTranslation: false);
 
                     wincompDataRootVisual = translationResult.RootVisual;

--- a/source/Lottie/LottieVisualSource.cs
+++ b/source/Lottie/LottieVisualSource.cs
@@ -407,10 +407,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
                     // an issue if the author is using property bindings incorrectly.
                     translationResult = LottieToWinCompTranslator.TryTranslateLottieComposition(
                         lottieComposition: lottieComposition,
+                        options: new TranslationOptions { TranslatePropertyBindings = true },
                         targetUapVersion: GetCurrentUapVersion(),
-                        strictTranslation: false,
-                        addCodegenDescriptions: false,
-                        translatePropertyBindings: true);
+                        strictTranslation: false);
 
                     wincompDataRootVisual = translationResult.RootVisual;
                     requiredUapVersion = translationResult.MinimumRequiredUapVersion;

--- a/source/Lottie/LottieVisualSource.cs
+++ b/source/Lottie/LottieVisualSource.cs
@@ -407,8 +407,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
                     // an issue if the author is using property bindings incorrectly.
                     translationResult = LottieToWinCompTranslator.TryTranslateLottieComposition(
                         lottieComposition: lottieComposition,
-                        options: new TranslationOptions { TranslatePropertyBindings = true, TargetUapVersion = GetCurrentUapVersion() },
-                        strictTranslation: false);
+                        configuration: new TranslatorConfiguration { TranslatePropertyBindings = true, TargetUapVersion = GetCurrentUapVersion() });
 
                     wincompDataRootVisual = translationResult.RootVisual;
                     requiredUapVersion = translationResult.MinimumRequiredUapVersion;

--- a/source/LottieToWinComp/LottieToMultiVersionWinCompTranslator.cs
+++ b/source/LottieToWinComp/LottieToMultiVersionWinCompTranslator.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         /// <returns>The results of the translation and the issues.</returns>
         public static MultiVersionTranslationResult TryTranslateLottieComposition(
             LottieComposition lottieComposition,
-            TranslatorConfiguration configuration,
+            in TranslatorConfiguration configuration,
             uint minimumUapVersion)
         {
             if (configuration.TargetUapVersion < LowestValidUapVersion)

--- a/source/LottieToWinComp/LottieToMultiVersionWinCompTranslator.cs
+++ b/source/LottieToWinComp/LottieToMultiVersionWinCompTranslator.cs
@@ -23,22 +23,19 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         /// producing one or more translations.
         /// </summary>
         /// <param name="lottieComposition">The <see cref="LottieComposition"/> to translate.</param>
+        /// <param name="options">Controls optional features of the translator.</param>
         /// <param name="targetUapVersion">The version of UAP that the translator will ensure compatibility with.
         /// Must be >= 7.</param>
         /// <param name="minimumUapVersion">The lowest version of UAP on which the result must run.
         /// Must be >= 7 and &lt;= targetUapVersion.</param>
         /// <param name="strictTranslation">If true, throw an exception if translation issues are found.</param>
-        /// <param name="addCodegenDescriptions">Add descriptions to objects for comments on generated code.</param>
-        /// <param name="translatePropertyBindings">Translate the special property binding language in Lottie object
-        /// names and create bindings to <see cref="WinCompData.CompositionPropertySet"/> values.</param>
         /// <returns>The results of the translation and the issues.</returns>
         public static MultiVersionTranslationResult TryTranslateLottieComposition(
             LottieComposition lottieComposition,
+            TranslationOptions options,
             uint targetUapVersion,
             uint minimumUapVersion,
-            bool strictTranslation,
-            bool addCodegenDescriptions,
-            bool translatePropertyBindings)
+            bool strictTranslation)
         {
             if (targetUapVersion < LowestValidUapVersion)
             {
@@ -52,11 +49,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 
             var translations = Translate(
                 lottieComposition: lottieComposition,
+                options: options,
                 targetUapVersion: targetUapVersion,
                 minimumUapVersion: minimumUapVersion,
-                strictTranslation: strictTranslation,
-                addCodegenDescriptions: addCodegenDescriptions,
-                translatePropertyBindings: translatePropertyBindings).ToArray();
+                strictTranslation: strictTranslation).ToArray();
 
             // Combine the issues that are the same in multiple versions into issues with a version range.
             var dict = new Dictionary<TranslationIssue, UapVersionRange>();
@@ -98,20 +94,18 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 
         static IEnumerable<(TranslationResult translationResult, UapVersionRange versionRange)> Translate(
             LottieComposition lottieComposition,
+            TranslationOptions options,
             uint targetUapVersion,
             uint minimumUapVersion,
-            bool strictTranslation,
-            bool addCodegenDescriptions,
-            bool translatePropertyBindings)
+            bool strictTranslation)
         {
             // First, generate code for the target version.
             var translationResult =
                 LottieToWinCompTranslator.TryTranslateLottieComposition(
                     lottieComposition,
+                    options: options,
                     targetUapVersion: targetUapVersion,
-                    strictTranslation,
-                    addCodegenDescriptions,
-                    translatePropertyBindings);
+                    strictTranslation);
 
             yield return (
                 translationResult,
@@ -132,10 +126,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                 translationResult =
                     LottieToWinCompTranslator.TryTranslateLottieComposition(
                         lottieComposition,
+                        options:options,
                         targetUapVersion: nextLowerTarget,
-                        strictTranslation: strictTranslation,
-                        addCodegenDescriptions: addCodegenDescriptions,
-                        translatePropertyBindings: translatePropertyBindings);
+                        strictTranslation: strictTranslation);
 
                 yield return (
                     translationResult,

--- a/source/LottieToWinComp/LottieToWinComp.projitems
+++ b/source/LottieToWinComp/LottieToWinComp.projitems
@@ -23,6 +23,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)TranslationContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TranslationIssue.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TranslationIssues.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TranslationOptions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TranslationResult.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TrimmedAnimatable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UapVersionRange.cs" />

--- a/source/LottieToWinComp/LottieToWinComp.projitems
+++ b/source/LottieToWinComp/LottieToWinComp.projitems
@@ -23,8 +23,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)TranslationContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TranslationIssue.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TranslationIssues.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)TranslationOptions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TranslationResult.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TranslatorConfiguration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TrimmedAnimatable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UapVersionRange.cs" />
   </ItemGroup>

--- a/source/LottieToWinComp/LottieToWinCompTranslator.cs
+++ b/source/LottieToWinComp/LottieToWinCompTranslator.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         /// <returns>The result of the translation.</returns>
         public static TranslationResult TryTranslateLottieComposition(
             LottieComposition lottieComposition,
-            TranslatorConfiguration configuration)
+            in TranslatorConfiguration configuration)
         {
             // Set up the translator.
             using (var translator = new LottieToWinCompTranslator(
@@ -3052,7 +3052,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             else
             {
                 // Opacity isn't animated.
-                // Create an expression that multiples the alpha channel of the color by the opacity value.
+                // Create an expression that multiplies the alpha channel of the color by the opacity value.
                 var anim = _c.CreateExpressionAnimation(ThemedColorMultipliedByOpacity(bindingName, opacity.NonAnimatedValue));
                 anim.SetReferenceParameter(ThemePropertiesName, _themePropertySet);
                 StartExpressionAnimation(result, nameof(result.Color), anim);

--- a/source/LottieToWinComp/LottieToWinCompTranslator.cs
+++ b/source/LottieToWinComp/LottieToWinCompTranslator.cs
@@ -107,17 +107,16 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         LottieToWinCompTranslator(
             LottieComposition lottieComposition,
             Compositor compositor,
-            TranslationOptions options,
-            bool strictTranslation)
+            TranslatorConfiguration configuration)
         {
             _lc = lottieComposition;
-            _targetUapVersion = options.TargetUapVersion;
-            _c = new CompositionObjectFactory(compositor, options.TargetUapVersion);
-            _issues = new TranslationIssues(strictTranslation);
-            _addDescriptions = options.AddCodegenDescriptions;
-            _translatePropertyBindings = options.TranslatePropertyBindings;
+            _targetUapVersion = configuration.TargetUapVersion;
+            _c = new CompositionObjectFactory(compositor, configuration.TargetUapVersion);
+            _issues = new TranslationIssues(configuration.StrictTranslation);
+            _addDescriptions = configuration.AddCodegenDescriptions;
+            _translatePropertyBindings = configuration.TranslatePropertyBindings;
 
-            if (options.GenerateColorBindings)
+            if (configuration.GenerateColorBindings)
             {
                 _colorPalette = new Dictionary<Color, string>();
             }
@@ -138,20 +137,17 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         /// Attempts to translates the given <see cref="LottieComposition"/>.
         /// </summary>
         /// <param name="lottieComposition">The <see cref="LottieComposition"/> to translate.</param>
-        /// <param name="options">Controls optional features of the translator.</param>
-        /// <param name="strictTranslation">If true, throw an exception if translation issues are found.</param>
+        /// <param name="configuration">Controls the configuration of the translator.</param>
         /// <returns>The result of the translation.</returns>
         public static TranslationResult TryTranslateLottieComposition(
             LottieComposition lottieComposition,
-            TranslationOptions options,
-            bool strictTranslation)
+            TranslatorConfiguration configuration)
         {
             // Set up the translator.
             using (var translator = new LottieToWinCompTranslator(
                 lottieComposition,
                 new Compositor(),
-                options: options,
-                strictTranslation: strictTranslation))
+                configuration: configuration))
             {
                 // Translate the Lottie content to a Composition graph.
                 translator.Translate();
@@ -161,7 +157,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                 var resultRequiredUapVersion = translator._c.HighestUapVersionUsed;
 
                 // See if the version is compatible with what the caller requested.
-                if (options.TargetUapVersion < resultRequiredUapVersion)
+                if (configuration.TargetUapVersion < resultRequiredUapVersion)
                 {
                     // We couldn't translate it and meet the requirement for the requested minimum version.
                     rootVisual = null;
@@ -3050,7 +3046,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                     // The opacity is animated, but it might be non-animated after trimming.
                     if (trimmed.IsAnimated)
                     {
-                        ApplyOpacityKeyFrameAnimation(context, context.TrimAnimatable(animatable), result.Properties, propertyName, propertyName, null);
+                        ApplyOpacityKeyFrameAnimation(context, trimmed, result.Properties, propertyName, propertyName, null);
                     }
                 }
 

--- a/source/LottieToWinComp/LottieToWinCompTranslator.cs
+++ b/source/LottieToWinComp/LottieToWinCompTranslator.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         LottieToWinCompTranslator(
             LottieComposition lottieComposition,
             Compositor compositor,
-            TranslatorConfiguration configuration)
+            in TranslatorConfiguration configuration)
         {
             _lc = lottieComposition;
             _targetUapVersion = configuration.TargetUapVersion;

--- a/source/LottieToWinComp/LottieToWinCompTranslator.cs
+++ b/source/LottieToWinComp/LottieToWinCompTranslator.cs
@@ -108,12 +108,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             LottieComposition lottieComposition,
             Compositor compositor,
             TranslationOptions options,
-            bool strictTranslation,
-            uint targetUapVersion)
+            bool strictTranslation)
         {
             _lc = lottieComposition;
-            _targetUapVersion = targetUapVersion;
-            _c = new CompositionObjectFactory(compositor, targetUapVersion);
+            _targetUapVersion = options.TargetUapVersion;
+            _c = new CompositionObjectFactory(compositor, options.TargetUapVersion);
             _issues = new TranslationIssues(strictTranslation);
             _addDescriptions = options.AddCodegenDescriptions;
             _translatePropertyBindings = options.TranslatePropertyBindings;
@@ -140,13 +139,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         /// </summary>
         /// <param name="lottieComposition">The <see cref="LottieComposition"/> to translate.</param>
         /// <param name="options">Controls optional features of the translator.</param>
-        /// <param name="targetUapVersion">The version of UAP that the translator will ensure compatibility with. Must be >= 7.</param>
         /// <param name="strictTranslation">If true, throw an exception if translation issues are found.</param>
         /// <returns>The result of the translation.</returns>
         public static TranslationResult TryTranslateLottieComposition(
             LottieComposition lottieComposition,
             TranslationOptions options,
-            uint targetUapVersion,
             bool strictTranslation)
         {
             // Set up the translator.
@@ -154,8 +151,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                 lottieComposition,
                 new Compositor(),
                 options: options,
-                strictTranslation: strictTranslation,
-                targetUapVersion))
+                strictTranslation: strictTranslation))
             {
                 // Translate the Lottie content to a Composition graph.
                 translator.Translate();
@@ -165,7 +161,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                 var resultRequiredUapVersion = translator._c.HighestUapVersionUsed;
 
                 // See if the version is compatible with what the caller requested.
-                if (targetUapVersion < resultRequiredUapVersion)
+                if (options.TargetUapVersion < resultRequiredUapVersion)
                 {
                     // We couldn't translate it and meet the requirement for the requested minimum version.
                     rootVisual = null;

--- a/source/LottieToWinComp/TranslationContext.cs
+++ b/source/LottieToWinComp/TranslationContext.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using Microsoft.Toolkit.Uwp.UI.Lottie.LottieData;
 using Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Optimization;
-using Microsoft.Toolkit.Uwp.UI.Lottie.LottieMetadata;
 using Sn = System.Numerics;
 
 namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp

--- a/source/LottieToWinComp/TranslationOptions.cs
+++ b/source/LottieToWinComp/TranslationOptions.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
+{
+    /// <summary>
+    /// Describes options to use when translating a Lottie file.
+    /// </summary>
+    public struct TranslationOptions
+    {
+        /// <summary>
+        /// Add descriptions that can be used by code generators to make code more readable.
+        /// </summary>
+        public bool AddCodegenDescriptions { get; set; }
+
+        /// <summary>
+        /// Make the colors used by fills and strokes bindable so that they can be altered at runtime.
+        /// </summary>
+        public bool GenerateColorBindings { get; set; }
+
+        /// <summary>
+        /// Translate the special property binding language in Lottie object
+        /// names and create bindings to <see cref="WinCompData.CompositionPropertySet"/> values.
+        /// </summary>
+        public bool TranslatePropertyBindings { get; set; }
+    }
+}

--- a/source/LottieToWinComp/TranslationOptions.cs
+++ b/source/LottieToWinComp/TranslationOptions.cs
@@ -20,6 +20,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         public bool GenerateColorBindings;
 
         /// <summary>
+        /// The version of UAP for which the translator will ensure code compatibility. This
+        /// value determines the minimum required SDK version required to build the generated
+        /// code. Must be &gt;= 7.
+        /// </summary>
+        public uint TargetUapVersion;
+
+        /// <summary>
         /// Translate the special property binding language in Lottie object
         /// names and create bindings to <see cref="WinCompData.CompositionPropertySet"/> values.
         /// </summary>

--- a/source/LottieToWinComp/TranslationOptions.cs
+++ b/source/LottieToWinComp/TranslationOptions.cs
@@ -12,17 +12,17 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         /// <summary>
         /// Add descriptions that can be used by code generators to make code more readable.
         /// </summary>
-        public bool AddCodegenDescriptions { get; set; }
+        public bool AddCodegenDescriptions;
 
         /// <summary>
         /// Make the colors used by fills and strokes bindable so that they can be altered at runtime.
         /// </summary>
-        public bool GenerateColorBindings { get; set; }
+        public bool GenerateColorBindings;
 
         /// <summary>
         /// Translate the special property binding language in Lottie object
         /// names and create bindings to <see cref="WinCompData.CompositionPropertySet"/> values.
         /// </summary>
-        public bool TranslatePropertyBindings { get; set; }
+        public bool TranslatePropertyBindings;
     }
 }

--- a/source/LottieToWinComp/TranslatorConfiguration.cs
+++ b/source/LottieToWinComp/TranslatorConfiguration.cs
@@ -5,9 +5,9 @@
 namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 {
     /// <summary>
-    /// Describes options to use when translating a Lottie file.
+    /// Describes a configuration of the <see cref="LottieToWinCompTranslator"/>.
     /// </summary>
-    public struct TranslationOptions
+    public struct TranslatorConfiguration
     {
         /// <summary>
         /// Add descriptions that can be used by code generators to make code more readable.
@@ -18,6 +18,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         /// Make the colors used by fills and strokes bindable so that they can be altered at runtime.
         /// </summary>
         public bool GenerateColorBindings;
+
+        /// <summary>
+        /// If true, throw an exception if translation issues are found.
+        /// </summary>
+        public bool StrictTranslation;
 
         /// <summary>
         /// The version of UAP for which the translator will ensure code compatibility. This

--- a/source/WinCompData/Wui/Color.cs
+++ b/source/WinCompData/Wui/Color.cs
@@ -32,9 +32,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Wui
 
         /// <summary>
         /// Gets a string that describes the color for human consumption. This either returns
-        /// the well known name for the color, or 8 hex digits (with no prefix). The name
-        /// is guaranteed to be unique for a particular ARGB value, and contains only characters
-        /// suitable for use in C# identifiers.
+        /// the well known name for the color, or a name that describes the color as the color
+        /// it is nearest to along with the hex value. The name is guaranteed to be unique for
+        /// any particular ARGB value, and contains only characters suitable for use in C#
+        /// identifiers.
         /// </summary>
         public string Name
         {


### PR DESCRIPTION
When enabled with -GenerateColorBindings, LottieGen will create bindings
for each non-animated color it finds in a fill or stroke. This will
allow the colors to be changed at runtime.

This is particularly handy for animations that have a single color such
as those found at https://www.lottieflow.com.

The feature is less flexible than theme property bindings because:
a) it only supports colors
b) it doesn't give the designer much control over which parts of the
animation are bindable.
c) it doesn't allow the designer to choose the names used for the
bindings.

The binding name is based on the color, so a black color will generate a property
called "ColorBlack".

For single-color Lottie files we could be clever and name the property
"Foreground". I'm not doing that right now because we don't yet know
how the feature will be consumed.