### PR TITLE
Support animated vector2/vector3 with easings that differ between channels

### DIFF
--- a/LottieGen/LottieFileProcessor.cs
+++ b/LottieGen/LottieFileProcessor.cs
@@ -817,4 +817,6 @@ sealed class LottieFileProcessor
 
     // Convert namespaces to a normalized form: replace "::" with ".".
     static string NormalizeNamespace(string @namespace) => @namespace?.Replace("::", ".");
+
+    public override string ToString() => $"{nameof(LottieFileProcessor)} {_file}";
 }

--- a/source/LottieData/Optimization/Optimizer.cs
+++ b/source/LottieData/Optimization/Optimizer.cs
@@ -9,7 +9,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Transactions;
 
 namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Optimization
 {

--- a/source/LottieData/Vector2.cs
+++ b/source/LottieData/Vector2.cs
@@ -27,6 +27,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
         public static Vector2 operator *(Vector2 left, double right) =>
             new Vector2(left.X * right, left.Y * right);
 
+        public static Vector2 operator /(Vector2 left, double right) =>
+            new Vector2(left.X / right, left.Y / right);
+
         public static Vector2 operator +(Vector2 left, Vector2 right) =>
             new Vector2(left.X + right.X, left.Y + right.Y);
 

--- a/source/LottieToWinComp/AnimatableVector3Rewriter.cs
+++ b/source/LottieToWinComp/AnimatableVector3Rewriter.cs
@@ -3,8 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics;
-using System.Linq;
 using Microsoft.Toolkit.Uwp.UI.Lottie.LottieData;
 
 namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
@@ -13,21 +11,20 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
     /// Takes an <see cref="AnimatableVector3"/> and if the easings on the X, Y, or Z channels
     /// are different, returns an equivalent <see cref="AnimatableXYZ"/>.
     /// </summary>
-    static class AnimatableVector3ToAnimatableXYZ
+    static class AnimatableVector3Rewriter
     {
-        // Asserts that the given AnimatableVector3 has the same easing for each channel.
-        internal static void AssertSingleEasing(IAnimatableVector3 value)
-        {
-            if (value is AnimatableVector3 animatableVector3 && HasMultipleEasings(animatableVector3))
-            {
-                Debug.Fail("Multiple easings!");
-            }
-        }
+        /// <summary>
+        /// If the given <see cref="IAnimatableVector3"/> is an <see cref="AnimatableVector3"/> with multiple
+        /// easings, returns an equivalent <see cref="AnimatableXYZ"/> with one easing per channel.
+        /// </summary>
+        /// <returns>An equivalent <see cref="IAnimatableVector3"/> with only one easing per
+        /// channel.</returns>
+        internal static IAnimatableVector3 EnsureOneEasingPerChannel(IAnimatableVector3 animatableVector3) =>
+            animatableVector3 is AnimatableVector3 value ? EnsureOneEasingPerChannel(value) : animatableVector3;
 
-        internal static IAnimatableVector3 SeparateEasings(IAnimatableVector3 animatableVector3) =>
-            animatableVector3 is AnimatableVector3 value ? SeparateEasings(value) : animatableVector3;
-
-        internal static IAnimatableVector3 SeparateEasings(AnimatableVector3 animatableVector3)
+        // If the given AnimatableVector3 has multiple easings, returns an equivalent
+        // AnimatableXYZ with one easing per channel, otherwise returns the given AnimatableVector3.
+        static IAnimatableVector3 EnsureOneEasingPerChannel(AnimatableVector3 animatableVector3)
         {
             // CubicBezierEasings can have multiple easings - one for each channel (X, Y, Z).
             // See if there are any CubicBezierEasings that have different easing for
@@ -73,8 +70,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             return result;
         }
 
-        // Returns true iff the given AnimatableVector3 does not use the same easing for each
-        // of its channels (X, Y, Z).
+        // Returns true iff the key frames in the given AnimatableVector3 do not use the
+        // same easing for each of their channels (X, Y, Z).
         static bool HasMultipleEasings(AnimatableVector3 value)
         {
             if (value.IsAnimated)
@@ -83,24 +80,33 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                 {
                     if (kf.Easing is CubicBezierEasing cubicBezierEasing)
                     {
+                        // Nothing to check if there is only one easing.
                         if (cubicBezierEasing.Beziers.Count > 1)
                         {
                             var xEasing = cubicBezierEasing.Beziers[0];
 
                             if (xEasing != cubicBezierEasing.Beziers[1])
                             {
+                                // The X and Y easings are different from each other.
                                 return true;
                             }
 
+                            // The X easing and the Y easing are the same.
+                            // If there's a Z easing, check whether it's the same too.
                             if (cubicBezierEasing.Beziers.Count > 2 && xEasing != cubicBezierEasing.Beziers[2])
                             {
+                                // The Z easing is different from the X and Y easings.
                                 return true;
                             }
                         }
+
+                        // The easings for each channel in that key frame are the same. Keep
+                        // looking until a key frame is found where the easings are not the same.
                     }
                 }
             }
 
+            // The easings for each channel are the same in each key frame.
             return false;
         }
     }

--- a/source/LottieToWinComp/AnimatableVector3Rewriter.cs
+++ b/source/LottieToWinComp/AnimatableVector3Rewriter.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                 var easing = kf.Easing;
                 if (easing is CubicBezierEasing cubicBezierEasing)
                 {
-                    // Get the bezier for the channel, if there is one, otherwise
+                    // Get the Bezier for the channel, if there is one, otherwise
                     // use the easing from the X channel. Not all Vector3s have
                     // multiple easings, and some are really representing Vector2s
                     // and might have easings for X and Y but probably not for Z,

--- a/source/LottieToWinComp/AnimatableVector3ToAnimatableXYZ.cs
+++ b/source/LottieToWinComp/AnimatableVector3ToAnimatableXYZ.cs
@@ -1,0 +1,107 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.Toolkit.Uwp.UI.Lottie.LottieData;
+
+namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
+{
+    /// <summary>
+    /// Takes an <see cref="AnimatableVector3"/> and if the easings on the X, Y, or Z channels
+    /// are different, returns an equivalent <see cref="AnimatableXYZ"/>.
+    /// </summary>
+    static class AnimatableVector3ToAnimatableXYZ
+    {
+        // Asserts that the given AnimatableVector3 has the same easing for each channel.
+        internal static void AssertSingleEasing(IAnimatableVector3 value)
+        {
+            if (value is AnimatableVector3 animatableVector3 && HasMultipleEasings(animatableVector3))
+            {
+                Debug.Fail("Multiple easings!");
+            }
+        }
+
+        internal static IAnimatableVector3 SeparateEasings(IAnimatableVector3 animatableVector3) =>
+            animatableVector3 is AnimatableVector3 value ? SeparateEasings(value) : animatableVector3;
+
+        internal static IAnimatableVector3 SeparateEasings(AnimatableVector3 animatableVector3)
+        {
+            // CubicBezierEasings can have multiple easings - one for each channel (X, Y, Z).
+            // See if there are any CubicBezierEasings that have different easing for
+            // each channel. It there aren't any, there's nothing to do.
+            if (!HasMultipleEasings(animatableVector3))
+            {
+                return animatableVector3;
+            }
+
+            // Convert the AnimatableVector3 to an AnimatableVectorXYZ so that each channel
+            // can have a separate easing.
+            var xKeyFrames = ExtractKeyFrames(animatableVector3.KeyFrames, v => v.X, 0);
+            var yKeyFrames = ExtractKeyFrames(animatableVector3.KeyFrames, v => v.Y, 1);
+            var zKeyFrames = ExtractKeyFrames(animatableVector3.KeyFrames, v => v.Z, 2);
+            return new AnimatableXYZ(
+                new Animatable<double>(xKeyFrames, animatableVector3.PropertyIndex),
+                new Animatable<double>(yKeyFrames, animatableVector3.PropertyIndex),
+                new Animatable<double>(zKeyFrames, animatableVector3.PropertyIndex));
+        }
+
+        // Extracts the key frames from a single channel of a Vector3.
+        static KeyFrame<double>[] ExtractKeyFrames(
+            ReadOnlySpan<KeyFrame<Vector3>> keyFrames,
+            Func<Vector3, double> valueExtractor,
+            int valueIndex)
+        {
+            var result = new KeyFrame<double>[keyFrames.Length];
+
+            for (var i = 0; i < keyFrames.Length; i++)
+            {
+                var kf = keyFrames[i];
+                var value = valueExtractor(kf.Value);
+                var easing = kf.Easing;
+                if (easing is CubicBezierEasing cubicBezierEasing)
+                {
+                    var bezier = cubicBezierEasing.Beziers.Count > valueIndex ? cubicBezierEasing.Beziers[valueIndex] : cubicBezierEasing.Beziers[0];
+                    easing = new CubicBezierEasing(new[] { bezier });
+                }
+
+                result[i] = new KeyFrame<double>(kf.Frame, value, easing);
+            }
+
+            return result;
+        }
+
+        // Returns true iff the given AnimatableVector3 does not use the same easing for each
+        // of its channels (X, Y, Z).
+        static bool HasMultipleEasings(AnimatableVector3 value)
+        {
+            if (value.IsAnimated)
+            {
+                foreach (var kf in value.KeyFrames)
+                {
+                    if (kf.Easing is CubicBezierEasing cubicBezierEasing)
+                    {
+                        if (cubicBezierEasing.Beziers.Count > 1)
+                        {
+                            var xEasing = cubicBezierEasing.Beziers[0];
+
+                            if (xEasing != cubicBezierEasing.Beziers[1])
+                            {
+                                return true;
+                            }
+
+                            if (cubicBezierEasing.Beziers.Count > 2 && xEasing != cubicBezierEasing.Beziers[2])
+                            {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/source/LottieToWinComp/LottieToWinComp.projitems
+++ b/source/LottieToWinComp/LottieToWinComp.projitems
@@ -6,6 +6,7 @@
     <SharedGUID>0340244a-683c-405e-838b-f93872779532</SharedGUID>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)AnimatableVector3ToAnimatableXYZ.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CanvasGeometryCombiner.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CompositeOpacity.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CompositionObjectFactory.cs" />

--- a/source/LottieToWinComp/LottieToWinComp.projitems
+++ b/source/LottieToWinComp/LottieToWinComp.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>0340244a-683c-405e-838b-f93872779532</SharedGUID>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)AnimatableVector3ToAnimatableXYZ.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)AnimatableVector3Rewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CanvasGeometryCombiner.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CompositeOpacity.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CompositionObjectFactory.cs" />

--- a/source/LottieToWinComp/LottieToWinCompTranslator.cs
+++ b/source/LottieToWinComp/LottieToWinCompTranslator.cs
@@ -4329,7 +4329,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                 null,
                 targetObject,
                 targetPropertyName,
-                longDescription ?? targetPropertyName,
+                longDescription,
                 shortDescription);
         }
 

--- a/source/LottieToWinComp/LottieToWinCompTranslator.cs
+++ b/source/LottieToWinComp/LottieToWinCompTranslator.cs
@@ -2204,14 +2204,37 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                 compositionEllipseGeometry.Center = Vector2(position.InitialValue);
             }
 
-            var diameter = context.TrimAnimatable(shapeContent.Diameter);
-            if (diameter.IsAnimated)
+            var diameter3OrXYZ = AnimatableVector3ToAnimatableXYZ.SeparateEasings(shapeContent.Diameter);
+            if (diameter3OrXYZ is AnimatableXYZ diameterXYZ)
             {
-                ApplyScaledVector2KeyFrameAnimation(context, diameter, 0.5, compositionEllipseGeometry, "Radius");
+                var diameterX = context.TrimAnimatable(diameterXYZ.X);
+                var diameterY = context.TrimAnimatable(diameterXYZ.Y);
+                if (diameterX.IsAnimated)
+                {
+                    ApplyScaledScalarKeyFrameAnimation(context, diameterX, 0.5, compositionEllipseGeometry, "Radius.X", "Radius.X");
+                }
+
+                if (diameterY.IsAnimated)
+                {
+                    ApplyScaledScalarKeyFrameAnimation(context, diameterY, 0.5, compositionEllipseGeometry, "Radius.Y", "Radius.Y");
+                }
+
+                if (!diameterX.IsAnimated || !diameterY.IsAnimated)
+                {
+                    compositionEllipseGeometry.Radius = Vector2(diameter3OrXYZ.InitialValue) * 0.5F;
+                }
             }
             else
             {
-                compositionEllipseGeometry.Radius = Vector2(diameter.InitialValue) * 0.5F;
+                var diameter3 = context.TrimAnimatable<Vector3>((AnimatableVector3)diameter3OrXYZ);
+                if (diameter3.IsAnimated)
+                {
+                    ApplyScaledVector2KeyFrameAnimation(context, diameter3, 0.5, compositionEllipseGeometry, "Radius");
+                }
+                else
+                {
+                    compositionEllipseGeometry.Radius = Vector2(diameter3OrXYZ.InitialValue) * 0.5F;
+                }
             }
 
             TranslateAndApplyShapeContentContext(
@@ -2228,7 +2251,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         {
             var result = _c.CreateSpriteShape();
             var position = context.TrimAnimatable(shapeContent.Position);
-            var size = context.TrimAnimatable(shapeContent.Size);
 
             if (shapeContent.Roundness.AlwaysEquals(0) && shapeContext.RoundedCorner is null)
             {
@@ -2237,7 +2259,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                     shapeContext,
                     shapeContent,
                     position,
-                    size,
                     result);
             }
             else
@@ -2247,7 +2268,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                     shapeContext,
                     shapeContent,
                     position,
-                    size,
                     result);
             }
 
@@ -2259,18 +2279,36 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             ShapeContentContext shapeContext,
             Rectangle shapeContent,
             in TrimmedAnimatable<Vector3> position,
-            in TrimmedAnimatable<Vector3> size,
             CompositionSpriteShape compositionShape)
         {
             Debug.Assert(shapeContent.Roundness.AlwaysEquals(0) && shapeContext.RoundedCorner is null, "Precondition");
 
-            var geometry = _c.CreateRectangleGeometry(
-                                size: size.IsAnimated ? (Sn.Vector2?)null : Vector2(size.InitialValue),
-                                offset: InitialOffset(size: size, position: position));
+            var size3orXYZ = AnimatableVector3ToAnimatableXYZ.SeparateEasings(shapeContent.Size);
+            if (size3orXYZ is AnimatableXYZ sizeXYZ)
+            {
+                var width = context.TrimAnimatable(sizeXYZ.X);
+                var height = context.TrimAnimatable(sizeXYZ.Y);
 
-            compositionShape.Geometry = geometry;
+                var geometry = _c.CreateRectangleGeometry(
+                                    size: (width.IsAnimated || height.IsAnimated) ? (Sn.Vector2?)null : Vector2(width.InitialValue, height.InitialValue),
+                                    offset: InitialOffset(width, height, position: position));
 
-            ApplyRectangleContentCommon(context, shapeContext, shapeContent, compositionShape, size, position, geometry);
+                compositionShape.Geometry = geometry;
+
+                ApplyRectangleContentCommonXY(context, shapeContext, shapeContent, compositionShape, width, height, position, geometry);
+            }
+            else
+            {
+                var size = context.TrimAnimatable<Vector3>((AnimatableVector3)size3orXYZ);
+
+                var geometry = _c.CreateRectangleGeometry(
+                                    size: size.IsAnimated ? (Sn.Vector2?)null : Vector2(size.InitialValue),
+                                    offset: InitialOffset(size: size, position: position));
+
+                compositionShape.Geometry = geometry;
+
+                ApplyRectangleContentCommon(context, shapeContext, shapeContent, compositionShape, size, position, geometry);
+            }
         }
 
         void TranslateAndApplyRoundedRectangleContent(
@@ -2278,7 +2316,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             ShapeContentContext shapeContext,
             Rectangle shapeContent,
             in TrimmedAnimatable<Vector3> position,
-            in TrimmedAnimatable<Vector3> size,
             CompositionSpriteShape compositionShape)
         {
             // Use a rounded rectangle geometry.
@@ -2291,54 +2328,114 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                     ? shapeContext.RoundedCorner.Radius
                     : shapeContent.Roundness);
 
-            // In After Effects, the rectangle Roundness has no further effect once it reaches min(Size.X, Size.Y)/2.
-            // In Composition, the cornerRadius continues to affect the shape even beyond min(Size.X, Size.Y)/2.
-            // If size or corner radius are animated, handle this with an expression.
-            if (cornerRadius.IsAnimated || size.IsAnimated)
+            var size3orXYZ = AnimatableVector3ToAnimatableXYZ.SeparateEasings(shapeContent.Size);
+            if (size3orXYZ is AnimatableXYZ sizeXYZ)
             {
-                if (cornerRadius.IsAnimated)
-                {
-                    geometry.Properties.InsertScalar("Roundness", Float(cornerRadius.InitialValue));
-                    ApplyScalarKeyFrameAnimation(context, cornerRadius, geometry.Properties, "Roundness");
+                var width = context.TrimAnimatable(sizeXYZ.X);
+                var height = context.TrimAnimatable(sizeXYZ.Y);
 
-                    if (size.IsAnimated)
+                // In After Effects, the rectangle Roundness has no further effect once it reaches min(Size.X, Size.Y)/2.
+                // In Composition, the cornerRadius continues to affect the shape even beyond min(Size.X, Size.Y)/2.
+                // If size or corner radius are animated, handle this with an expression.
+                if (cornerRadius.IsAnimated || width.IsAnimated || height.IsAnimated)
+                {
+                    if (cornerRadius.IsAnimated)
                     {
-                        // Both size and cornerRadius are animated.
-                        var cornerRadiusExpression = _c.CreateExpressionAnimation(ConstrainedCornerRadiusScalar());
-                        cornerRadiusExpression.SetReferenceParameter("my", geometry);
-                        StartExpressionAnimation(geometry, "CornerRadius", cornerRadiusExpression);
+                        geometry.Properties.InsertScalar("Roundness", Float(cornerRadius.InitialValue));
+                        ApplyScalarKeyFrameAnimation(context, cornerRadius, geometry.Properties, "Roundness");
+
+                        if (width.IsAnimated || height.IsAnimated)
+                        {
+                            // Both size and cornerRadius are animated.
+                            var cornerRadiusExpression = _c.CreateExpressionAnimation(ConstrainedCornerRadiusScalar());
+                            cornerRadiusExpression.SetReferenceParameter("my", geometry);
+                            StartExpressionAnimation(geometry, "CornerRadius", cornerRadiusExpression);
+                        }
+                        else
+                        {
+                            // Only the cornerRadius is animated.
+                            var cornerRadiusExpression = _c.CreateExpressionAnimation(ConstrainedCornerRadiusScalar(Vector2(width.InitialValue, height.InitialValue)));
+                            cornerRadiusExpression.SetReferenceParameter("my", geometry);
+                            StartExpressionAnimation(geometry, "CornerRadius", cornerRadiusExpression);
+                        }
                     }
                     else
                     {
-                        // Only the cornerRadius is animated.
-                        var cornerRadiusExpression = _c.CreateExpressionAnimation(ConstrainedCornerRadiusScalar(Vector2(size.InitialValue)));
+                        // Only the size is animated.
+                        var cornerRadiusExpression = _c.CreateExpressionAnimation(ConstrainedCornerRadiusScalar(cornerRadius.InitialValue));
                         cornerRadiusExpression.SetReferenceParameter("my", geometry);
                         StartExpressionAnimation(geometry, "CornerRadius", cornerRadiusExpression);
                     }
                 }
                 else
                 {
-                    // Only the size is animated.
-                    var cornerRadiusExpression = _c.CreateExpressionAnimation(ConstrainedCornerRadiusScalar(cornerRadius.InitialValue));
-                    cornerRadiusExpression.SetReferenceParameter("my", geometry);
-                    StartExpressionAnimation(geometry, "CornerRadius", cornerRadiusExpression);
+                    // Static size and corner radius.
+                    var cornerRadiusValue = Math.Min(cornerRadius.InitialValue, Math.Min(width.InitialValue, height.InitialValue) / 2);
+                    geometry.CornerRadius = Vector2((float)cornerRadiusValue);
                 }
+
+                geometry.Offset = InitialOffset(width, height, position: position);
+
+                if (!width.IsAnimated || !height.IsAnimated)
+                {
+                    geometry.Size = Vector2(width.InitialValue, height.InitialValue);
+                }
+
+                ApplyRectangleContentCommonXY(context, shapeContext, shapeContent, compositionShape, width, height, position, geometry);
             }
             else
             {
-                // Static size and corner radius.
-                var cornerRadiusValue = Math.Min(cornerRadius.InitialValue, Math.Min(size.InitialValue.X, size.InitialValue.Y) / 2);
-                geometry.CornerRadius = Vector2((float)cornerRadiusValue);
+                var size = context.TrimAnimatable<Vector3>((AnimatableVector3)size3orXYZ);
+
+                // In After Effects, the rectangle Roundness has no further effect once it reaches min(Size.X, Size.Y)/2.
+                // In Composition, the cornerRadius continues to affect the shape even beyond min(Size.X, Size.Y)/2.
+                // If size or corner radius are animated, handle this with an expression.
+                if (cornerRadius.IsAnimated || size.IsAnimated)
+                {
+                    if (cornerRadius.IsAnimated)
+                    {
+                        geometry.Properties.InsertScalar("Roundness", Float(cornerRadius.InitialValue));
+                        ApplyScalarKeyFrameAnimation(context, cornerRadius, geometry.Properties, "Roundness");
+
+                        if (size.IsAnimated)
+                        {
+                            // Both size and cornerRadius are animated.
+                            var cornerRadiusExpression = _c.CreateExpressionAnimation(ConstrainedCornerRadiusScalar());
+                            cornerRadiusExpression.SetReferenceParameter("my", geometry);
+                            StartExpressionAnimation(geometry, "CornerRadius", cornerRadiusExpression);
+                        }
+                        else
+                        {
+                            // Only the cornerRadius is animated.
+                            var cornerRadiusExpression = _c.CreateExpressionAnimation(ConstrainedCornerRadiusScalar(Vector2(size.InitialValue)));
+                            cornerRadiusExpression.SetReferenceParameter("my", geometry);
+                            StartExpressionAnimation(geometry, "CornerRadius", cornerRadiusExpression);
+                        }
+                    }
+                    else
+                    {
+                        // Only the size is animated.
+                        var cornerRadiusExpression = _c.CreateExpressionAnimation(ConstrainedCornerRadiusScalar(cornerRadius.InitialValue));
+                        cornerRadiusExpression.SetReferenceParameter("my", geometry);
+                        StartExpressionAnimation(geometry, "CornerRadius", cornerRadiusExpression);
+                    }
+                }
+                else
+                {
+                    // Static size and corner radius.
+                    var cornerRadiusValue = Math.Min(cornerRadius.InitialValue, Math.Min(size.InitialValue.X, size.InitialValue.Y) / 2);
+                    geometry.CornerRadius = Vector2((float)cornerRadiusValue);
+                }
+
+                geometry.Offset = InitialOffset(size: size, position: position);
+
+                if (!size.IsAnimated)
+                {
+                    geometry.Size = Vector2(size.InitialValue);
+                }
+
+                ApplyRectangleContentCommon(context, shapeContext, shapeContent, compositionShape, size, position, geometry);
             }
-
-            geometry.Offset = InitialOffset(size: size, position: position);
-
-            if (!size.IsAnimated)
-            {
-                geometry.Size = Vector2(size.InitialValue);
-            }
-
-            ApplyRectangleContentCommon(context, shapeContext, shapeContent, compositionShape, size, position, geometry);
         }
 
         // Convert the size and position for a geometry into an offset.
@@ -2348,6 +2445,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             in TrimmedAnimatable<Vector3> size,
             in TrimmedAnimatable<Vector3> position)
             => Vector2(position.InitialValue - (size.InitialValue / 2));
+
+        static Sn.Vector2 InitialOffset(
+            in TrimmedAnimatable<double> width,
+            in TrimmedAnimatable<double> height,
+            in TrimmedAnimatable<Vector3> position)
+            => Vector2(position.InitialValue - (new Vector3(width.InitialValue, height.InitialValue, 0) / 2));
 
         void ApplyRectangleContentCommon(
             TranslationContext context,
@@ -2407,6 +2510,96 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             var width = size.InitialValue.X;
             var height = size.InitialValue.Y;
             var trimOffsetDegrees = (width / (2 * (width + height))) * 360;
+
+            TranslateAndApplyShapeContentContext(
+                context,
+                shapeContext,
+                compositionRectangle,
+                shapeContent.DrawingDirection == DrawingDirection.Reverse,
+                trimOffsetDegrees: trimOffsetDegrees);
+
+            if (_addDescriptions)
+            {
+                Describe(compositionRectangle, shapeContent.Name);
+                Describe(compositionRectangle.Geometry, $"{shapeContent.Name}.RectangleGeometry");
+            }
+        }
+
+        void ApplyRectangleContentCommonXY(
+            TranslationContext context,
+            ShapeContentContext shapeContext,
+            Rectangle shapeContent,
+            CompositionSpriteShape compositionRectangle,
+            in TrimmedAnimatable<double> width,
+            in TrimmedAnimatable<double> height,
+            in TrimmedAnimatable<Vector3> position,
+            CompositionGeometry geometry)
+        {
+            if (position.IsAnimated || width.IsAnimated || height.IsAnimated)
+            {
+                Expr offsetExpression;
+                if (position.IsAnimated)
+                {
+                    ApplyVector2KeyFrameAnimation(context, position, geometry, nameof(Rectangle.Position));
+                    geometry.Properties.InsertVector2(nameof(Rectangle.Position), Vector2(position.InitialValue));
+                    if (width.IsAnimated || height.IsAnimated)
+                    {
+                        // Size AND position are animated.
+                        offsetExpression = ExpressionFactory.PositionAndSizeToOffsetExpression;
+                        if (width.IsAnimated)
+                        {
+                            ApplyScalarKeyFrameAnimation(context, width, geometry, $"{nameof(Rectangle.Size)}.X");
+                        }
+
+                        if (height.IsAnimated)
+                        {
+                            ApplyScalarKeyFrameAnimation(context, height, geometry, $"{nameof(Rectangle.Size)}.Y");
+                        }
+                    }
+                    else
+                    {
+                        // Only Position is animated
+                        offsetExpression = ExpressionFactory.HalfSizeToOffsetExpression(Vector2(new Vector2(width.InitialValue, height.InitialValue) / 2));
+                    }
+                }
+                else
+                {
+                    // Only Size is animated.
+                    offsetExpression = ExpressionFactory.PositionToOffsetExpression(Vector2(position.InitialValue));
+                    if (width.IsAnimated)
+                    {
+                        ApplyScalarKeyFrameAnimation(context, width, geometry, $"{nameof(Rectangle.Size)}.X");
+                    }
+
+                    if (height.IsAnimated)
+                    {
+                        ApplyScalarKeyFrameAnimation(context, height, geometry, $"{nameof(Rectangle.Size)}.Y");
+                    }
+                }
+
+                var offsetExpressionAnimation = _c.CreateExpressionAnimation(offsetExpression);
+                offsetExpressionAnimation.SetReferenceParameter("my", geometry);
+                StartExpressionAnimation(geometry, "Offset", offsetExpressionAnimation);
+            }
+
+            // Lottie rectangles have 0,0 at top right. That causes problems for TrimPath which expects 0,0 to be top left.
+            // Add an offset to the trim path.
+
+            // TODO - this only works correctly if Size and TrimOffset are not animated. A complete solution requires
+            //        adding another property.
+            var isPartialTrimPath = shapeContext.TrimPath != null &&
+                (shapeContext.TrimPath.Start.IsAnimated || shapeContext.TrimPath.End.IsAnimated || shapeContext.TrimPath.Offset.IsAnimated ||
+                shapeContext.TrimPath.Start.InitialValue.Value != 0 || shapeContext.TrimPath.End.InitialValue.Value != 1);
+
+            if ((width.IsAnimated || height.IsAnimated) && isPartialTrimPath)
+            {
+                // Warn that we might be getting things wrong
+                _issues.AnimatedRectangleWithTrimPathIsNotSupported();
+            }
+
+            var initialWidth = width.InitialValue;
+            var initialHeight = height.InitialValue;
+            var trimOffsetDegrees = (initialWidth / (2 * (initialWidth + initialHeight))) * 360;
 
             TranslateAndApplyShapeContentContext(
                 context,
@@ -3511,7 +3704,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                 transform.Anchor,
                 transform.Position,
                 context.TrimAnimatable(transform.Rotation),
-                context.TrimAnimatable(transform.ScalePercent),
+                transform.ScalePercent,
                 container);
 
             // TODO: set Skew and Skew Axis
@@ -3522,7 +3715,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             IAnimatableVector3 anchor,
             IAnimatableVector3 position,
             in TrimmedAnimatable<Rotation> rotation,
-            in TrimmedAnimatable<Vector3> scalePercent,
+            IAnimatableVector3 scalePercent,
             ContainerShapeOrVisual container)
         {
             // There are many different cases to consider in order to do this optimally:
@@ -3547,20 +3740,48 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             }
 
 #if !NoScaling
-            if (scalePercent.IsAnimated)
+            // If the channels have separate easings, convert to an AnimatableXYZ;
+            var scale = AnimatableVector3ToAnimatableXYZ.SeparateEasings(scalePercent);
+
+            if (scale is AnimatableXYZ scaleXYZ)
             {
-                if (container.IsShape)
+                var trimmedX = context.TrimAnimatable(scaleXYZ.X);
+                var trimmedY = context.TrimAnimatable(scaleXYZ.Y);
+
+                if (trimmedX.IsAnimated)
                 {
-                    ApplyScaledVector2KeyFrameAnimation(context, scalePercent, 1 / 100.0, container, nameof(container.Scale), "Scale");
+                    ApplyScaledScalarKeyFrameAnimation(context, trimmedX, 1 / 100.0, container, $"{nameof(container.Scale)}.X", nameof(container.Scale));
                 }
-                else
+
+                if (trimmedY.IsAnimated)
                 {
-                    ApplyScaledVector3KeyFrameAnimation(context, scalePercent, 1 / 100.0, container, nameof(container.Scale), "Scale");
+                    ApplyScaledScalarKeyFrameAnimation(context, trimmedY, 1 / 100.0, container, $"{nameof(container.Scale)}.Y", nameof(container.Scale));
+                }
+
+                if (!trimmedX.IsAnimated || !trimmedY.IsAnimated)
+                {
+                    container.Scale = Vector2DefaultIsOne(new Vector3(trimmedX.InitialValue, trimmedY.InitialValue, 0) * (1 / 100.0));
                 }
             }
             else
             {
-                container.Scale = Vector2DefaultIsOne(scalePercent.InitialValue * (1 / 100.0));
+                var trimmedScale = context.TrimAnimatable<Vector3>((AnimatableVector3)scale);
+
+                if (trimmedScale.IsAnimated)
+                {
+                    if (container.IsShape)
+                    {
+                        ApplyScaledVector2KeyFrameAnimation(context, trimmedScale, 1 / 100.0, container, nameof(container.Scale), nameof(container.Scale));
+                    }
+                    else
+                    {
+                        ApplyScaledVector3KeyFrameAnimation(context, trimmedScale, 1 / 100.0, container, nameof(container.Scale), nameof(container.Scale));
+                    }
+                }
+                else
+                {
+                    container.Scale = Vector2DefaultIsOne(trimmedScale.InitialValue * (1 / 100.0));
+                }
             }
 #endif
 
@@ -3582,8 +3803,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             var positionX = default(TrimmedAnimatable<double>);
             var positionY = default(TrimmedAnimatable<double>);
             var position3 = default(TrimmedAnimatable<Vector3>);
+            var positionWithSeparateEasings = AnimatableVector3ToAnimatableXYZ.SeparateEasings(position);
 
-            var xyzPosition = position as AnimatableXYZ;
+            var xyzPosition = positionWithSeparateEasings as AnimatableXYZ;
             if (xyzPosition != null)
             {
                 positionX = context.TrimAnimatable(xyzPosition.X);
@@ -3591,7 +3813,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             }
             else
             {
-                position3 = context.TrimAnimatable(position);
+                position3 = context.TrimAnimatable<Vector3>((AnimatableVector3)positionWithSeparateEasings);
             }
 
             var anchorIsAnimated = anchorX.IsAnimated || anchorY.IsAnimated || anchor3.IsAnimated;
@@ -4064,7 +4286,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             CompositionObject targetObject,
             string targetPropertyName,
             string longDescription,
-            string shortDescription)
+            string shortDescription = null)
         {
             Debug.Assert(value.IsAnimated, "Precondition");
             GenericCreateCompositionKeyFrameAnimation(

--- a/source/LottieToWinComp/TranslationContext.cs
+++ b/source/LottieToWinComp/TranslationContext.cs
@@ -113,6 +113,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 
         internal TrimmedAnimatable<Vector3> TrimAnimatable(IAnimatableVector3 animatable)
         {
+            AnimatableVector3ToAnimatableXYZ.AssertSingleEasing(animatable);
             return TrimAnimatable<Vector3>((AnimatableVector3)animatable);
         }
 

--- a/source/LottieToWinComp/TranslationContext.cs
+++ b/source/LottieToWinComp/TranslationContext.cs
@@ -111,10 +111,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         }
 
         internal TrimmedAnimatable<Vector3> TrimAnimatable(IAnimatableVector3 animatable)
-        {
-            AnimatableVector3ToAnimatableXYZ.AssertSingleEasing(animatable);
-            return TrimAnimatable<Vector3>((AnimatableVector3)animatable);
-        }
+            => TrimAnimatable<Vector3>((AnimatableVector3)animatable);
 
         internal TrimmedAnimatable<T> TrimAnimatable<T>(Animatable<T> animatable)
             where T : IEquatable<T>


### PR DESCRIPTION
Lottie allows Vector2/Vector3 to have different easings for each channel. When that happens we cannot translate
them as Vector2/Vector3 animations, because WinComp only supports an easing for the whole Vector2/Vector3.
Now we will recognize this case and first translate to the AnimatableVector3 to an AnimatableVectorXYZ and
create separate animations for each channel.

This change only supports separate easings in that cases that we've seen in the corpus. Complete support is
a lot more expensive code (i.e. expensive to maintain because it requires a lot of repeating of the same
patterns over and over with slight changes).
Current support includes:
* Size of a shape
* Size of a rectangle
* Radius of an ellipse
* Position of a shape