### PR TITLE
Eliminate the ReadOnlySpan from Sequence.

### DIFF
--- a/source/LottieData/Optimization/Optimizer.cs
+++ b/source/LottieData/Optimization/Optimizer.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Optimization
             // If the geometries have different numbers of segments they can't be animated. However
             // in one specific case we can fix that.
             var geometries = value.KeyFrames.SelectToArray(kf => kf.Value);
-            var distinctSegmentCounts = geometries.Select(g => g.BezierSegments.Items.Length).Distinct().Count();
+            var distinctSegmentCounts = geometries.Select(g => g.BezierSegments.Count).Distinct().Count();
 
             if (distinctSegmentCounts != 2)
             {
@@ -61,31 +61,31 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Optimization
                     }
                 }
 
-                switch (segments.Items.Length)
+                switch (segments.Count)
                 {
                     default:
                         return optimized;
                     case 1:
-                        if (!segments.Items[0].IsALine)
+                        if (!segments[0].IsALine)
                         {
                             return optimized;
                         }
 
                         break;
                     case 2:
-                        if (!segments.Items[0].IsALine || !segments.Items[1].IsALine)
+                        if (!segments[0].IsALine || !segments[1].IsALine)
                         {
                             return optimized;
                         }
 
                         // Start of line 0
-                        var a = segments.Items[0].ControlPoint0;
+                        var a = segments[0].ControlPoint0;
 
                         // End of line 0
-                        var b = segments.Items[0].ControlPoint3;
+                        var b = segments[0].ControlPoint3;
 
                         // End of line 1
-                        var c = segments.Items[1].ControlPoint3;
+                        var c = segments[1].ControlPoint3;
 
                         if (!BezierSegment.ArePointsColinear(0, a, b, c))
                         {
@@ -110,7 +110,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Optimization
         // Returns a KeyFrame<PathGeometry> that contains only the first Bezier segment of the given
         // KeyFrame<PathGeometry>.
         static KeyFrame<PathGeometry> HackPathGeometry(KeyFrame<PathGeometry> value) =>
-            value.CloneWithNewValue(new PathGeometry(new Sequence<BezierSegment>(new[] { value.Value.BezierSegments.Items[0] }), isClosed: false));
+            value.CloneWithNewValue(new PathGeometry(new Sequence<BezierSegment>(value.Value.BezierSegments[0]), isClosed: false));
 
         static bool HasNonLinearCubicBezierEasing<T>(KeyFrame<T> keyFrame)
             where T : IEquatable<T>

--- a/source/LottieData/Sequence.cs
+++ b/source/LottieData/Sequence.cs
@@ -16,26 +16,55 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 #if PUBLIC_LottieData
     public
 #endif
-    sealed class Sequence<T> : IEquatable<Sequence<T>>, IEnumerable<T>
+    sealed class Sequence<T> : IEquatable<Sequence<T>>, IEnumerable<T>, IReadOnlyList<T>
     {
         static readonly string ItemTypeName = typeof(T).Name;
         readonly T[] _items;
         int _hashcode;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Sequence{T}"/> class.
+        /// </summary>
+        /// <param name="items">The items in the sequence.</param>
         public Sequence(IEnumerable<T> items)
         {
             _items = items.ToArray();
         }
 
         /// <summary>
-        /// Gets the items in the sequence.
+        /// Initializes a new instance of the <see cref="Sequence{T}"/> class.
         /// </summary>
-        public ReadOnlySpan<T> Items => _items;
+        /// <param name="items">The items in the sequence.</param>
+        /// <param name="takeOwnership">If true, the sequence will take ownership
+        /// of the array.</param>
+        public Sequence(T[] items, bool takeOwnership)
+        {
+            _items = takeOwnership ? items : items.ToArray();
+        }
 
         /// <summary>
-        /// And empty sequence.
+        /// Initializes a new instance of the <see cref="Sequence{T}"/> class.
+        /// Creates a sequence with one item.
         /// </summary>
-        public static Sequence<T> Empty { get; } = new Sequence<T>(Array.Empty<T>());
+        /// <param name="item">The one item in the sequence.</param>
+        public Sequence(T item)
+        {
+            _items = new[] { item };
+        }
+
+        /// <summary>
+        /// An empty sequence.
+        /// </summary>
+        public static Sequence<T> Empty { get; } = new Sequence<T>(Array.Empty<T>(), takeOwnership: true);
+
+        /// <summary>
+        /// True iff there are no items in the sequence.
+        /// </summary>
+        public bool IsEmpty => _items.Length == 0;
+
+        public int Count => ((IReadOnlyCollection<T>)_items).Count;
+
+        public T this[int index] => ((IReadOnlyList<T>)_items)[index];
 
         /// <inheritdoc/>
         public bool Equals(Sequence<T> other) =>

--- a/source/LottieData/Serialization/LottieCompositionYamlSerializer.cs
+++ b/source/LottieData/Serialization/LottieCompositionYamlSerializer.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
         YamlSequence FromSequence<T>(Sequence<T> collection, Func<T, YamlObject> selector)
         {
             var result = new YamlSequence();
-            foreach (var item in collection.Items)
+            foreach (var item in collection)
             {
                 result.Add(selector(item));
             }

--- a/source/LottieReader/Serialization/Animatables.cs
+++ b/source/LottieReader/Serialization/Animatables.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
     sealed partial class LottieCompositionReader
     {
         static readonly Sequence<GradientStop> s_defaultGradientStops =
-            new Sequence<GradientStop>(new[] { new ColorGradientStop(0, Color.Black) });
+            new Sequence<GradientStop>(new ColorGradientStop(0, Color.Black));
 
         static readonly Animatable<double> s_animatableDoubleZero = CreateNonAnimatedAnimatable(0.0);
         static readonly Animatable<Color> s_animatableColorBlack = CreateNonAnimatedAnimatable(Color.Black);
@@ -384,7 +384,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
                     }
                 }
 
-                return new Sequence<GradientStop>(colorStops);
+                return new Sequence<GradientStop>(colorStops, takeOwnership: true);
             }
         }
 
@@ -434,7 +434,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
                     }
                 }
 
-                return new Sequence<GradientStop>(gradientStops);
+                return new Sequence<GradientStop>(gradientStops, takeOwnership : true);
             }
         }
 

--- a/source/LottieReader/Serialization/LottieCompositionReader.cs
+++ b/source/LottieReader/Serialization/LottieCompositionReader.cs
@@ -412,7 +412,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
                 }
             }
 
-            return new PathGeometry(new Sequence<BezierSegment>(beziers), isClosed);
+            return new PathGeometry(new Sequence<BezierSegment>(beziers, takeOwnership: true), isClosed);
         }
 
         static Vector2[] ReadArrayOfVector2(in LottieJsonArrayElement array)

--- a/source/LottieToWinComp/LottieToWinCompTranslator.cs
+++ b/source/LottieToWinComp/LottieToWinCompTranslator.cs
@@ -1999,10 +1999,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             Sn.Matrix3x2 transformMatrix,
             bool optimizeLines)
         {
-            var beziers = figure.BezierSegments.Items;
+            var beziers = figure.BezierSegments;
             using (var builder = new CanvasPathBuilder(null))
             {
-                if (beziers.Length == 0)
+                if (beziers.Count == 0)
                 {
                     builder.BeginFigure(Vector2(0));
                     builder.EndFigure(CanvasFigureLoop.Closed);
@@ -3094,7 +3094,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 
             var gradientStops = context.TrimAnimatable(linearGradient.GradientStops);
 
-            if (gradientStops.InitialValue.Items.IsEmpty)
+            if (gradientStops.InitialValue.IsEmpty)
             {
                 // If there are no gradient stops then we can't create a brush.
                 return null;
@@ -3151,7 +3151,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 
             var gradientStops = context.TrimAnimatable(gradient.GradientStops);
 
-            if (gradientStops.InitialValue.Items.IsEmpty)
+            if (gradientStops.InitialValue.IsEmpty)
             {
                 // If there are no gradient stops then we can't create a brush.
                 return null;
@@ -3319,7 +3319,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             Sequence<GradientStop> gradientStops,
             CompositeOpacity opacity)
         {
-            var optimizedGradientStops = GradientStopOptimizer.OptimizeColorStops(GradientStopOptimizer.Optimize(gradientStops.Items.ToArray()));
+            var optimizedGradientStops = GradientStopOptimizer.OptimizeColorStops(GradientStopOptimizer.Optimize(gradientStops));
 
             if (opacity.IsAnimated)
             {
@@ -3422,7 +3422,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             for (var i = 0; i < stops.Length; i++)
             {
                 var kf = stops[i];
-                var value = kf.Value.Items[stopIndex];
+                var value = kf.Value[stopIndex];
                 var selected = selector(value);
 
                 yield return kf.CloneWithNewValue(selected);
@@ -3899,20 +3899,20 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         // Iff the given paths are offsets translations of each other, gets the translation offset and returns true.
         static bool TryGetPathTranslation(Sequence<BezierSegment> a, Sequence<BezierSegment> b, out Vector2 offset)
         {
-            if (a.Items.Length != b.Items.Length)
+            if (a.Count != b.Count)
             {
                 // We could never animate this anyway.
                 offset = default;
                 return false;
             }
 
-            offset = b.Items[0].ControlPoint0 - a.Items[0].ControlPoint0;
-            for (var i = 1; i < a.Items.Length; i++)
+            offset = b[0].ControlPoint0 - a[0].ControlPoint0;
+            for (var i = 1; i < a.Count; i++)
             {
-                var cp0Offset = b.Items[i].ControlPoint0 - a.Items[i].ControlPoint0;
-                var cp1Offset = b.Items[i].ControlPoint1 - a.Items[i].ControlPoint1;
-                var cp2Offset = b.Items[i].ControlPoint2 - a.Items[i].ControlPoint2;
-                var cp3Offset = b.Items[i].ControlPoint3 - a.Items[i].ControlPoint3;
+                var cp0Offset = b[i].ControlPoint0 - a[i].ControlPoint0;
+                var cp1Offset = b[i].ControlPoint1 - a[i].ControlPoint1;
+                var cp2Offset = b[i].ControlPoint2 - a[i].ControlPoint2;
+                var cp3Offset = b[i].ControlPoint3 - a[i].ControlPoint3;
 
                 // Don't compare the values directly - there could be some rounding errors that
                 // are acceptable. This value is just a guess about what is acceptable. We could


### PR DESCRIPTION
This has been bugging me for ages. It was an attempt to switch the code over to using Span, but in the end it didn't make thing better, and required extra indirections to get at the items in the sequence.
While I'm here I'm adding some other nice touches, including avoiding copying of arrays when create a sequence, and allowing the creation of a sequence from a single item.