### PR TITLE
Recognize animation subchannels when discovering non-default properties.

### DIFF
--- a/source/UIData/Tools/GraphCompactor.cs
+++ b/source/UIData/Tools/GraphCompactor.cs
@@ -127,8 +127,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.Tools
             PushContainerShapeTransformsDown(graph, containerShapes);
             CoalesceContainerShapes2(graph, containerShapes);
             PushPropertiesDownToSpriteShape(graph, containerShapes);
-
-            //PushShapeVisbilityDown(graph, containerShapes);
+            PushShapeVisbilityDown(graph, containerShapes);
         }
 
         // Finds sibling shape containers that have the same properties and combines them.

--- a/source/UIData/Tools/Properties.cs
+++ b/source/UIData/Tools/Properties.cs
@@ -34,7 +34,16 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.Tools
 
             foreach (var animator in obj.Animators)
             {
-                result |= PropertyIdFromName(animator.AnimatedProperty);
+                var animatedPropertyName = animator.AnimatedProperty;
+
+                // The property name may contain subchannels. Trim those off.
+                var dotIndex = animatedPropertyName.IndexOf('.');
+                if (dotIndex > 0)
+                {
+                    animatedPropertyName = animatedPropertyName.Substring(0, dotIndex);
+                }
+
+                result |= PropertyIdFromName(animatedPropertyName);
             }
 
             return result;
@@ -70,7 +79,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.Tools
                 result |= PropertyId.TrimOffset;
             }
 
-            return result | GetNonDefaultCompositionObjectProperties((CompositionObject)obj);
+            return result | GetNonDefaultCompositionObjectProperties(obj);
         }
 
         internal static PropertyId GetNonDefaultShapeProperties(CompositionShape obj)
@@ -111,7 +120,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.Tools
                 result |= PropertyId.TransformMatrix;
             }
 
-            return result | GetNonDefaultCompositionObjectProperties((CompositionObject)obj);
+            return result | GetNonDefaultCompositionObjectProperties(obj);
         }
 
         internal static PropertyId GetNonDefaultSpriteShapeProperties(CompositionSpriteShape obj)
@@ -214,7 +223,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.Tools
                 result |= PropertyId.TransformMatrix;
             }
 
-            return result | GetNonDefaultCompositionObjectProperties((CompositionObject)obj);
+            return result | GetNonDefaultCompositionObjectProperties(obj);
         }
     }
 }

--- a/source/WinCompData/KeyFrameAnimation.cs
+++ b/source/WinCompData/KeyFrameAnimation.cs
@@ -99,6 +99,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData
 
             /// <inheritdoc/>
             public override KeyFrameType Type => KeyFrameType.Value;
+
+            // For debugging only.
+            public override string ToString() => $"ValueKeyFrame: {Value}@{Progress} {Easing}";
         }
 
         public sealed class ExpressionKeyFrame : KeyFrame


### PR DESCRIPTION
This problem has always existed but it didn't matter until we started using subchanel animations for Scale (Scale.X and Scale.Y) in order to support multiple easings.
The issue was that we ask which properties have non-default values by looking at whether the property is set, and whether there is an animation for that property.
But when we find animations for a property we need to ignore the subchannel part of the name (the ".X" part).