### PR TITLE
Use clearer names for automatically generated color bindings.

### DIFF
--- a/source/LottieData/ExtensionMethods.cs
+++ b/source/LottieData/ExtensionMethods.cs
@@ -61,15 +61,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 
             public int Count { get; }
 
-            public IEnumerator<T> GetEnumerator()
-            {
-                throw new NotImplementedException();
-            }
+            public IEnumerator<T> GetEnumerator() => new Enumerator(this);
 
-            IEnumerator IEnumerable.GetEnumerator()
-            {
-                throw new NotImplementedException();
-            }
+            IEnumerator IEnumerable.GetEnumerator() => new Enumerator(this);
 
             sealed class Enumerator : IEnumerator<T>
             {
@@ -89,7 +83,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
                 public bool MoveNext()
                 {
                     _index++;
-                    return _index >= _owner.Count;
+                    return _index < _owner.Count;
                 }
 
                 void IEnumerator.Reset() => _index = -1;

--- a/source/LottieToWinComp/LottieToWinCompTranslator.cs
+++ b/source/LottieToWinComp/LottieToWinCompTranslator.cs
@@ -3182,7 +3182,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 
                 if (!_colorPalette.TryGetValue(paletteColor, out bindingName))
                 {
-                    bindingName = $"Color{Color(paletteColor).Name}";
+                    bindingName = $"Color_{Color(paletteColor).HexWithoutAlpha}";
                     _colorPalette.Add(paletteColor, bindingName);
                 }
 

--- a/source/WinCompData/Wui/Color.cs
+++ b/source/WinCompData/Wui/Color.cs
@@ -90,6 +90,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Wui
         /// </summary>
         public string Hex => $"{ToHex(A)}{ToHex(R)}{ToHex(G)}{ToHex(B)}";
 
+        /// <summary>
+        /// Gets the hex representation of the RGB values of this color.
+        /// </summary>
+        public string HexWithoutAlpha => $"{ToHex(R)}{ToHex(G)}{ToHex(B)}";
+
         // Gets the friendly name if one exists, or null.
         // The same name will not be returned for more than one ARGB value.
         // The result is slightly different from GetWellKnownName in that it will


### PR DESCRIPTION
When LottieGen generates color bindings automatically, it creates WinRT properties for each distinct color in the Lottie. The names of these properties were using the descriptive color names which are great for trying to understand code, but they're unnecessarily complex for property names. For example, naming a property Color_AlmostTurquoise_FF123456 is including information about the color that the user doesn't care about. The user simply wants to identify which property is which. So now we just name the properties "Color_XXXXXX" where XXXXXX is a 6 digit hex representation of the color, ignoring alpha. We continue to use descriptive names for methods and fields, as those are useful during debugging to understand the relationship between an element and what is showing on the screen.

This change also fixes a bug I noticed during testing where the enumerators for sliced lists were never created.