### PR TITLE
Fix issue with C++ multi-version support.

### DIFF
--- a/source/UIDataCodeGen/CodeGen/CppInstantiatorGeneratorBase.cs
+++ b/source/UIDataCodeGen/CodeGen/CppInstantiatorGeneratorBase.cs
@@ -663,9 +663,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
                 builder.OpenScope();
                 builder.WriteBreakableLine($"return {_s.New(info.ClassName)}(", CommaSeparate(GetConstructorArguments(info)), ");");
                 builder.CloseScope();
-                builder.WriteLine();
-                builder.WriteLine("return nullptr;");
             }
+
+            builder.WriteLine();
+            builder.WriteLine("return nullptr;");
         }
 
         void WriteIsAnimatedVisualSourceDynamicGetSet(CodeBuilder builder)


### PR DESCRIPTION
We were generating a return after each version check instead of checking all the versions before returning. As a result, we'd only run on the highest supported version.