### PR TITLE
CX classes stopped compiling because it wasn't public. Make it public.

### DIFF
--- a/source/UIDataCodeGen/CodeGen/CppInstantiatorGeneratorBase.cs
+++ b/source/UIDataCodeGen/CodeGen/CppInstantiatorGeneratorBase.cs
@@ -449,6 +449,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
 
         private protected abstract void WriteThemeHeader(HeaderBuilder builder);
 
+        private protected abstract void WriteHeaderClassStart(HeaderBuilder builder, IAnimatedVisualSourceInfo info, string inherits);
+
         protected abstract void WriteThemePropertyImpls(CodeBuilder builder);
 
         /// <inheritdoc/>
@@ -825,6 +827,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
             }
         }
 
+        // Wrties the start of the namespace, the start of the class, internal constants, and the theming interface.
         void WriteHeaderNamespaceStart(HeaderBuilder builder, IAnimatedVisualSourceInfo info, string inherits)
         {
             builder.Preamble.WriteLine();
@@ -833,22 +836,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
 
             WriteSourceDescriptionComments(builder.Preamble);
 
-            var visibility = info.Public ? "public " : string.Empty;
-
-            if (_isCppwinrtMode)
-            {
-                builder.Preamble.WriteLine($"{visibility}class {SourceClassName}");
-                builder.Preamble.Indent();
-                builder.Preamble.WriteLine($": public winrt::implements<{SourceClassName}, winrt::{inherits}>");
-                builder.Preamble.UnIndent();
-            }
-            else
-            {
-                builder.Preamble.WriteLine($"{visibility}ref class {SourceClassName} sealed");
-                builder.Preamble.Indent();
-                builder.Preamble.WriteLine($": public {inherits}");
-                builder.Preamble.UnIndent();
-            }
+            WriteHeaderClassStart(builder, info, inherits);
 
             WriteInternalHeaderConstants(builder.Internal);
 

--- a/source/UIDataCodeGen/CodeGen/CppInstantiatorGeneratorBase.cs
+++ b/source/UIDataCodeGen/CodeGen/CppInstantiatorGeneratorBase.cs
@@ -827,7 +827,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
             }
         }
 
-        // Wrties the start of the namespace, the start of the class, internal constants, and the theming interface.
+        // Writes the start of the namespace, the start of the class, internal constants, and the theming interface.
         void WriteHeaderNamespaceStart(HeaderBuilder builder, IAnimatedVisualSourceInfo info, string inherits)
         {
             builder.Preamble.WriteLine();

--- a/source/UIDataCodeGen/CodeGen/CppwinrtInstantiatorGenerator.cs
+++ b/source/UIDataCodeGen/CodeGen/CppwinrtInstantiatorGenerator.cs
@@ -50,6 +50,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
             return (cppText, hText, assetList);
         }
 
+        private protected override void WriteHeaderClassStart(HeaderBuilder builder, IAnimatedVisualSourceInfo info, string inherits)
+        {
+            builder.Preamble.WriteLine($"{(info.Public ? "public" : string.Empty)}class {SourceClassName}");
+            builder.Preamble.Indent();
+            builder.Preamble.WriteLine($": public winrt::implements<{SourceClassName}, winrt::{inherits}>");
+            builder.Preamble.UnIndent();
+        }
+
         private protected override void WriteThemeHeader(HeaderBuilder builder)
         {
             // Add a field to hold the theme property set.

--- a/source/UIDataCodeGen/CodeGen/CppwinrtInstantiatorGenerator.cs
+++ b/source/UIDataCodeGen/CodeGen/CppwinrtInstantiatorGenerator.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
 
         private protected override void WriteHeaderClassStart(HeaderBuilder builder, IAnimatedVisualSourceInfo info, string inherits)
         {
-            builder.Preamble.WriteLine($"{(info.Public ? "public" : string.Empty)}class {SourceClassName}");
+            builder.Preamble.WriteLine($"{(info.Public ? "public " : string.Empty)}class {SourceClassName}");
             builder.Preamble.Indent();
             builder.Preamble.WriteLine($": public winrt::implements<{SourceClassName}, winrt::{inherits}>");
             builder.Preamble.UnIndent();

--- a/source/UIDataCodeGen/CodeGen/CxInstantiatorGenerator.cs
+++ b/source/UIDataCodeGen/CodeGen/CxInstantiatorGenerator.cs
@@ -50,6 +50,17 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
             return (cppText, hText, assetList);
         }
 
+        private protected override void WriteHeaderClassStart(HeaderBuilder builder, IAnimatedVisualSourceInfo info, string inherits)
+        {
+            // NOTE: the CX class is always made public. This is necessary to allow CX
+            // XAML projects to compile (the XAML compiler can't find the metadata for the
+            // class if it isn't made public).
+            builder.Preamble.WriteLine($"public ref class {SourceClassName} sealed");
+            builder.Preamble.Indent();
+            builder.Preamble.WriteLine($": public {inherits}");
+            builder.Preamble.UnIndent();
+        }
+
         private protected override void WriteThemeHeader(HeaderBuilder builder)
         {
             // Add a field to hold the theme property set.


### PR DESCRIPTION
Apparently something changed in the way XAML gets info about CX classes - it used to compile but now it won't compile unless the classes are public. Public classes publish their metadata, which is presumably how XAML is now getting info about the classes. This change makes the CX classes always public.