### PR TITLE
Add a WinUI3 mode to LottieGen.

### DIFF
--- a/LottieGen/CommandLineOptions.cs
+++ b/LottieGen/CommandLineOptions.cs
@@ -68,6 +68,12 @@ sealed class CommandLineOptions
     // a previous version of the tool.
     internal bool TestMode { get; private set; }
 
+    // Experimental feature to control code generation for WinUI3. Eventually there
+    // will be separate versions of LottieGen for WinUI3 and system APIs so there will
+    // be no need for this switch. For now, if you're using LottieGen to generate
+    // code for WinUI3, set this switch and the codegen will need less hand fixing.
+    internal bool WinUI3Mode { get; private set; }
+
     // Returns a command line equivalent to the current set of options. This is intended
     // for adding to generated code so that users can regenerate the code and know that
     // they got the set of options the same as a previous run. It does not include the
@@ -95,6 +101,11 @@ sealed class CommandLineOptions
         if (GenerateDependencyObject)
         {
             sb.Append($" -{nameof(GenerateDependencyObject)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(Interface))
+        {
+            sb.Append($" -{nameof(Interface)} {Interface}");
         }
 
         if (MinimumUapVersion.HasValue)
@@ -127,9 +138,9 @@ sealed class CommandLineOptions
             }
         }
 
-        if (!string.IsNullOrWhiteSpace(Interface))
+        if (WinUI3Mode)
         {
-            sb.Append($" -{nameof(Interface)} {Interface}");
+            sb.Append($" -{nameof(WinUI3Mode)}");
         }
 
         return sb.ToString();
@@ -154,6 +165,7 @@ sealed class CommandLineOptions
         Strict,
         TargetUapVersion,
         TestMode,
+        WinUI3Mode,
     }
 
     // Returns the parsed command line. If ErrorDescription is non-null, then the parse failed.
@@ -215,7 +227,8 @@ sealed class CommandLineOptions
             .AddPrefixedKeyword(Keyword.Public)
             .AddPrefixedKeyword(Keyword.Strict)
             .AddPrefixedKeyword(Keyword.TargetUapVersion)
-            .AddPrefixedKeyword(Keyword.TestMode);
+            .AddPrefixedKeyword(Keyword.TestMode)
+            .AddPrefixedKeyword(Keyword.WinUI3Mode);
 
         // The last keyword recognized. This defines what the following parameter value is for,
         // or None if not expecting a parameter value.
@@ -251,6 +264,9 @@ sealed class CommandLineOptions
                             break;
                         case Keyword.TestMode:
                             TestMode = true;
+                            break;
+                        case Keyword.WinUI3Mode:
+                            WinUI3Mode = true;
                             break;
                         case Keyword.DisableCodeGenOptimizer:
                             DisableCodeGenOptimizer = true;

--- a/LottieGen/LottieFileProcessor.cs
+++ b/LottieGen/LottieFileProcessor.cs
@@ -634,6 +634,7 @@ sealed class LottieFileProcessor
             SourceMetadata = _translationResults[0].SourceMetadata,
             ToolInfo = GetToolInvocationInfo(languageSwitch).ToArray(),
             Width = _lottieComposition.Width,
+            WinUI3 = _options.WinUI3Mode,
         };
 
         if (!string.IsNullOrWhiteSpace(_options.Interface))
@@ -768,7 +769,7 @@ sealed class LottieFileProcessor
         var translationResult = LottieToMultiVersionWinCompTranslator.TryTranslateLottieComposition(
             lottieComposition: _lottieComposition,
             configuration: configuration,
-            minimumUapVersion: _minimumUapVersion);
+            minimumUapVersion: _options.WinUI3Mode ? uint.MaxValue : _minimumUapVersion);
 
         _translationResults = translationResult.TranslationResults;
         _translationIssues = translationResult.Issues;

--- a/LottieGen/Program.cs
+++ b/LottieGen/Program.cs
@@ -67,6 +67,13 @@ sealed class Program
             _reporter.ErrorStream.WriteLine(_options.ErrorDescription);
             return RunResult.InvalidUsage;
         }
+        else if (_options.WinUI3Mode && (_options.MinimumUapVersion.HasValue || _options.TargetUapVersion.HasValue))
+        {
+            // WinUI3 does not permit setting a minimum or target version because WinUI3 implies
+            // the latest version only.
+            _reporter.WriteError($"{nameof(_options.WinUI3Mode)} cannot be used with {nameof(_options.MinimumUapVersion)} or {nameof(_options.TargetUapVersion)}.");
+            return RunResult.InvalidUsage;
+        }
         else if (_options.MinimumUapVersion.HasValue && _options.MinimumUapVersion < LottieToWinCompTranslator.MinimumTargetUapVersion)
         {
             // Unacceptable version.

--- a/LottieGen/Program.cs
+++ b/LottieGen/Program.cs
@@ -281,6 +281,8 @@ OVERVIEW:
                        from run to run with the same inputs, for example tool version
                        numbers, file paths, and dates. This is designed to enable
                        testing of the tool by diffing the outputs.
+         -WinUI3Mode   Generates code that is compatible with WinUI3. This is currently
+                       an experimental feature.
 
 EXAMPLES:
 

--- a/source/UIDataCodeGen/CodeGen/CSharpInstantiatorGenerator.cs
+++ b/source/UIDataCodeGen/CodeGen/CSharpInstantiatorGenerator.cs
@@ -14,6 +14,9 @@ using Mgce = Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Mgce;
 
 namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
 {
+    /// <summary>
+    /// Generates C# code that instantiates a Composition graph.
+    /// </summary>
 #if PUBLIC_UIDataCodeGen
     public
 #endif

--- a/source/UIDataCodeGen/CodeGen/CSharpInstantiatorGenerator.cs
+++ b/source/UIDataCodeGen/CodeGen/CSharpInstantiatorGenerator.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
         readonly Stringifier _s;
         readonly string _interface;
         readonly string _sourceInterface;
+        readonly string _winUiNamespace;
 
         CSharpInstantiatorGenerator(
             CodegenConfiguration configuration,
@@ -34,6 +35,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
             _s = stringifier;
             _interface = AnimatedVisualSourceInfo.InterfaceType.GetQualifiedName(stringifier);
             _sourceInterface = _interface + "Source";
+            _winUiNamespace = Info.WinUi3 ? "Microsoft.UI" : "Windows.UI";
         }
 
         IAnimatedVisualSourceInfo Info => AnimatedVisualSourceInfo;
@@ -83,12 +85,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
                 namespaces.Add("System.ComponentModel");
                 namespaces.Add("System.Runtime.InteropServices.WindowsRuntime");
                 namespaces.Add("Windows.Foundation");
-                namespaces.Add("Windows.UI.Xaml.Media");
+                namespaces.Add($"{_winUiNamespace}.Xaml.Media");
             }
 
             if (Info.GenerateDependencyObject)
             {
-                namespaces.Add("Windows.UI.Xaml");
+                namespaces.Add($"{_winUiNamespace}.Xaml");
             }
 
             if (Info.UsesStreams)
@@ -99,7 +101,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
             namespaces.Add("System");
             namespaces.Add("System.Numerics");
             namespaces.Add("Windows.UI");
-            namespaces.Add("Windows.UI.Composition");
+            namespaces.Add($"{_winUiNamespace}.Composition");
 
             // Write out each namespace using.
             foreach (var n in namespaces)
@@ -371,8 +373,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
              {
                  PropertySetValueType.Color => _s.Color((WinCompData.Wui.Color)prop.DefaultValue),
 
-                 // Scalars are stored as floats, but exposed as doubles as XAML markup prefers doubles.
-                 PropertySetValueType.Scalar => _s.Double((float)prop.DefaultValue),
+             // Scalars are stored as floats, but exposed as doubles as XAML markup prefers doubles.
+             PropertySetValueType.Scalar => _s.Double((float)prop.DefaultValue),
                  PropertySetValueType.Vector2 => _s.Vector2((Vector2)prop.DefaultValue),
                  PropertySetValueType.Vector3 => _s.Vector3((Vector3)prop.DefaultValue),
                  PropertySetValueType.Vector4 => _s.Vector4((Vector4)prop.DefaultValue),

--- a/source/UIDataCodeGen/CodeGen/CSharpInstantiatorGenerator.cs
+++ b/source/UIDataCodeGen/CodeGen/CSharpInstantiatorGenerator.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
 
             namespaces.Add("System");
             namespaces.Add("System.Numerics");
-            namespaces.Add("Windows.UI");
+            namespaces.Add(_winUiNamespace);
             namespaces.Add($"{_winUiNamespace}.Composition");
 
             // Write out each namespace using.

--- a/source/UIDataCodeGen/CodeGen/CodegenConfiguration.cs
+++ b/source/UIDataCodeGen/CodeGen/CodegenConfiguration.cs
@@ -82,5 +82,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
         /// When <c>true</c> the generated class is made public.
         /// </summary>
         public bool Public { get; set; }
+
+        /// <summary>
+        /// When <c>true</c>, makes the generated code suitable for WinUI3.
+        /// This is an experimental feature - the generated code may still need
+        /// some hand tweaking.
+        /// </summary>
+        public bool WinUI3 { get; set; }
     }
 }

--- a/source/UIDataCodeGen/CodeGen/CppwinrtInstantiatorGenerator.cs
+++ b/source/UIDataCodeGen/CodeGen/CppwinrtInstantiatorGenerator.cs
@@ -60,8 +60,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
             {
                 if (SourceInfo.GenerateDependencyObject)
                 {
-                    builder.Private.WriteLine($"static Windows::UI::Xaml::DependencyProperty^ _{prop.Name}Property;");
-                    builder.Private.WriteLine($"static void On{prop.Name}Changed(Windows::UI::Xaml::DependencyObject^ d, Windows::UI::Xaml::DependencyPropertyChangedEventArgs^ e);");
+                    builder.Private.WriteLine($"static {WinUINamespace}::Xaml::DependencyProperty^ _{prop.Name}Property;");
+                    builder.Private.WriteLine($"static void On{prop.Name}Changed({WinUINamespace}::Xaml::DependencyObject^ d, {WinUINamespace}::Xaml::DependencyPropertyChangedEventArgs^ e);");
                 }
                 else
                 {

--- a/source/UIDataCodeGen/CodeGen/CxInstantiatorGenerator.cs
+++ b/source/UIDataCodeGen/CodeGen/CxInstantiatorGenerator.cs
@@ -66,9 +66,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
 
                 if (SourceInfo.GenerateDependencyObject)
                 {
-                    builder.Private.WriteLine($"static Windows::UI::Xaml::DependencyProperty^ _{S.CamelCase(prop.Name)}Property;");
-                    builder.Private.WriteLine($"static void On{prop.Name}Changed(Windows::UI::Xaml::DependencyObject^ d, Windows::UI::Xaml::DependencyPropertyChangedEventArgs^ e);");
-                    builder.Internal.WriteLine($"static Windows::UI::Xaml::DependencyProperty^ {prop.Name}Property();");
+                    builder.Private.WriteLine($"static {WinUINamespace}::Xaml::DependencyProperty^ _{S.CamelCase(prop.Name)}Property;");
+                    builder.Private.WriteLine($"static void On{prop.Name}Changed({WinUINamespace}::Xaml::DependencyObject^ d, {WinUINamespace}::Xaml::DependencyPropertyChangedEventArgs^ e);");
+                    builder.Internal.WriteLine($"static {WinUINamespace}::Xaml::DependencyProperty^ {prop.Name}Property();");
                     builder.Internal.WriteLine();
                 }
                 else
@@ -93,7 +93,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
             if (hasColorProperty)
             {
                 var b = IsInterfaceCustom ? builder.Internal : builder.Private;
-                b.WriteLine("static Windows::Foundation::Numerics::float4 ColorAsVector4(Windows::UI::Color color);");
+                b.WriteLine($"static Windows::Foundation::Numerics::float4 ColorAsVector4({WinUINamespace}::Color color);");
                 b.WriteLine();
             }
         }

--- a/source/UIDataCodeGen/CodeGen/IAnimatedVisualSourceInfo.cs
+++ b/source/UIDataCodeGen/CodeGen/IAnimatedVisualSourceInfo.cs
@@ -119,5 +119,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
         /// this data is source specific.
         /// </summary>
         SourceMetadata SourceMetadata { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the generated code should target WinUI3. This
+        /// is an experimental feature.
+        /// </summary>
+        bool WinUi3 { get; }
     }
 }

--- a/source/UIDataCodeGen/CodeGen/InstantiatorGeneratorBase.cs
+++ b/source/UIDataCodeGen/CodeGen/InstantiatorGeneratorBase.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
 
             _animatedVisualGenerators = graphs.Select(g => new AnimatedVisualGenerator(this, g.graphRoot, g.requiredUapVersion, graphs.Count > 1)).ToArray();
 
-            // Determined whether theming is enabled.
+            // Determine whether theming is enabled.
             _isThemed = _animatedVisualGenerators.Any(avg => avg.IsThemed);
 
             // Deal with the nodes that are shared between multiple AnimatedVisual classes.
@@ -3332,9 +3332,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
             internal string TypeName
                 => Type switch
                 {
+                    // Return the interface type for CanvasGeometry. Nobody consumes the class type.
+                    Graph.NodeType.CanvasGeometry => "IGeometrySource2D",
                     Graph.NodeType.CompositionObject => ((CompositionObject)Object).Type.ToString(),
                     Graph.NodeType.CompositionPath => "CompositionPath",
-                    Graph.NodeType.CanvasGeometry => "CanvasGeometry",
                     Graph.NodeType.LoadedImageSurface => "LoadedImageSurface",
                     _ => throw new InvalidOperationException(),
                 };

--- a/source/UIDataCodeGen/CodeGen/InstantiatorGeneratorBase.cs
+++ b/source/UIDataCodeGen/CodeGen/InstantiatorGeneratorBase.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
         readonly bool _disableFieldOptimization;
         readonly bool _generateDependencyObject;
         readonly bool _generatePublicClass;
+        readonly bool _generateForWinui3;
         readonly Stringifier _s;
         readonly IReadOnlyList<AnimatedVisualGenerator> _animatedVisualGenerators;
         readonly LoadedImageSurfaceInfo[] _loadedImageSurfaceInfos;
@@ -73,6 +74,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
             _disableFieldOptimization = configuration.DisableOptimization;
             _generateDependencyObject = configuration.GenerateDependencyObject;
             _generatePublicClass = configuration.Public;
+            _generateForWinui3 = configuration.WinUI3;
             _s = stringifier;
             _toolInfo = configuration.ToolInfo;
             _interfaceType = new TypeName(configuration.InterfaceType);
@@ -732,6 +734,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
         bool IAnimatedVisualSourceInfo.GenerateDependencyObject => _generateDependencyObject;
 
         bool IAnimatedVisualSourceInfo.Public => _generatePublicClass;
+
+        bool IAnimatedVisualSourceInfo.WinUi3 => _generateForWinui3;
 
         string IAnimatedVisualSourceInfo.ThemePropertiesFieldName => ThemePropertiesFieldName;
 


### PR DESCRIPTION
This switch is intended to exist only until we fork LottieGen to be WinUI3 only. Until then it is a convenient way to have the code generator output code that needs little hand tweaking to work with WinUI3.