### PR TITLE
Allow JSON to be loaded from any stream, including memory

### DIFF
--- a/source/Lottie/ContentFactory.cs
+++ b/source/Lottie/ContentFactory.cs
@@ -1,0 +1,73 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using Microsoft.UI.Xaml.Controls;
+using Windows.UI.Composition;
+
+namespace Microsoft.Toolkit.Uwp.UI.Lottie
+{
+    /// <summary>
+    /// Information from which a composition's content can be instantiated. Contains the WinCompData
+    /// translation of a composition and some metadata. This allows multiple instances of the translation
+    /// to be instantiated without requiring repeated translations.
+    /// </summary>
+    sealed class ContentFactory : IAnimatedVisualSource
+    {
+        internal static readonly ContentFactory FailedContent = new ContentFactory(null);
+        readonly LottieVisualDiagnostics _diagnostics;
+        WinCompData.Visual _wincompDataRootVisual;
+        double _width;
+        double _height;
+        TimeSpan _duration;
+
+        internal ContentFactory(LottieVisualDiagnostics diagnostics)
+        {
+            _diagnostics = diagnostics;
+        }
+
+        internal void SetDimensions(double width, double height, TimeSpan duration)
+        {
+            _width = width;
+            _height = height;
+            _duration = duration;
+        }
+
+        internal void SetRootVisual(WinCompData.Visual rootVisual)
+        {
+            _wincompDataRootVisual = rootVisual;
+        }
+
+        internal bool CanInstantiate => _wincompDataRootVisual != null;
+
+        public IAnimatedVisual TryCreateAnimatedVisual(Compositor compositor, out object diagnostics)
+        {
+            var diags = _diagnostics?.Clone();
+            diagnostics = diags;
+
+            if (!CanInstantiate)
+            {
+                return null;
+            }
+            else
+            {
+                var sw = Stopwatch.StartNew();
+                var result = new DisposableAnimatedVisual()
+                {
+                    RootVisual = Instantiator.CreateVisual(compositor, _wincompDataRootVisual),
+                    Size = new System.Numerics.Vector2((float)_width, (float)_height),
+                    Duration = _duration,
+                };
+
+                if (diags != null)
+                {
+                    diags.InstantiationTime = sw.Elapsed;
+                }
+
+                return result;
+            }
+        }
+    }
+}

--- a/source/Lottie/DisposableAnimatedVisual.cs
+++ b/source/Lottie/DisposableAnimatedVisual.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Numerics;
+using Microsoft.UI.Xaml.Controls;
+using Windows.UI.Composition;
+
+namespace Microsoft.Toolkit.Uwp.UI.Lottie
+{
+    sealed class DisposableAnimatedVisual : IAnimatedVisual, IDisposable
+    {
+        public Visual RootVisual { get; set; }
+
+        public TimeSpan Duration { get; set; }
+
+        public Vector2 Size { get; set; }
+
+        public void Dispose()
+        {
+            RootVisual?.Dispose();
+        }
+    }
+}

--- a/source/Lottie/Loader.cs
+++ b/source/Lottie/Loader.cs
@@ -1,0 +1,315 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if DEBUG
+// Uncomment this to slow down async awaits for testing.
+//#define SlowAwaits
+#endif
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Toolkit.Uwp.UI.Lottie.LottieData;
+using Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization;
+using Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp;
+using Windows.Foundation.Metadata;
+using Windows.Storage;
+using Windows.Storage.Streams;
+
+namespace Microsoft.Toolkit.Uwp.UI.Lottie
+{
+    /// <summary>
+    /// Handles loading a composition from a Lottie file. The result of the load
+    /// is a <see cref="ContentFactory"/> that can be used to instantiate a
+    /// Composition tree that will render the Lottie.
+    /// </summary>
+    abstract class Loader
+    {
+        Loader()
+        {
+        }
+
+        private protected abstract Task<(string, Stream)> GetJsonStreamAsync();
+
+        // Asynchronously loads WinCompData from a Lottie file.
+        internal async Task<ContentFactory> LoadAsync(LottieVisualOptions options)
+        {
+            LottieVisualDiagnostics diagnostics = null;
+            Stopwatch sw = null;
+            if (options.HasFlag(LottieVisualOptions.IncludeDiagnostics))
+            {
+                sw = Stopwatch.StartNew();
+                diagnostics = new LottieVisualDiagnostics { Options = options };
+            }
+
+            var result = new ContentFactory(diagnostics);
+
+            // Get the file name and JSON contents.
+            (var fileName, var jsonStream) = await GetJsonStreamAsync();
+
+            if (diagnostics != null)
+            {
+                diagnostics.FileName = fileName;
+                diagnostics.ReadTime = sw.Elapsed;
+                sw.Restart();
+            }
+
+            if (jsonStream is null)
+            {
+                // Failed to load ...
+                return result;
+            }
+
+            // Parsing large Lottie files can take significant time. Do it on
+            // another thread.
+            LottieComposition lottieComposition = null;
+            await CheckedAwaitAsync(Task.Run(() =>
+            {
+                lottieComposition =
+                    LottieCompositionReader.ReadLottieCompositionFromJsonStream(
+                        jsonStream,
+                        LottieCompositionReader.Options.IgnoreMatchNames,
+                        out var readerIssues);
+
+                if (diagnostics != null)
+                {
+                    diagnostics.JsonParsingIssues = ToIssues(readerIssues);
+                }
+            }));
+
+            if (diagnostics != null)
+            {
+                diagnostics.ParseTime = sw.Elapsed;
+                sw.Restart();
+            }
+
+            if (lottieComposition is null)
+            {
+                // Failed to load...
+                return result;
+            }
+
+            if (diagnostics != null)
+            {
+                // Save the LottieComposition in the diagnostics so that the xml and codegen
+                // code can be derived from it.
+                diagnostics.LottieComposition = lottieComposition;
+
+                // Create the marker info.
+                diagnostics.Markers =
+                    lottieComposition.Markers.Select(m =>
+                        new KeyValuePair<string, double>(
+                            m.Name,
+                            m.Frame / (lottieComposition.FramesPerSecond * lottieComposition.Duration.TotalSeconds))).ToArray();
+
+                // Validate the composition and report if issues are found.
+                diagnostics.LottieValidationIssues = ToIssues(LottieCompositionValidator.Validate(lottieComposition));
+                diagnostics.ValidationTime = sw.Elapsed;
+                sw.Restart();
+            }
+
+            result.SetDimensions(
+                width: lottieComposition.Width,
+                height: lottieComposition.Height,
+                duration: lottieComposition.Duration);
+
+            // Translating large Lotties can take significant time. Do it on another thread.
+            WinCompData.Visual wincompDataRootVisual = null;
+            uint requiredUapVersion = 0;
+            var optimizationEnabled = options.HasFlag(LottieVisualOptions.Optimize);
+
+            TranslationResult translationResult;
+            await CheckedAwaitAsync(Task.Run(() =>
+            {
+                // translatePropertyBindings is turned on so that it can report
+                // an issue if the author is using property bindings incorrectly.
+                translationResult = LottieToWinCompTranslator.TryTranslateLottieComposition(
+                    lottieComposition: lottieComposition,
+                    configuration: new TranslatorConfiguration { TranslatePropertyBindings = true, TargetUapVersion = GetCurrentUapVersion() });
+
+                wincompDataRootVisual = translationResult.RootVisual;
+                requiredUapVersion = translationResult.MinimumRequiredUapVersion;
+
+                if (diagnostics != null)
+                {
+                    diagnostics.TranslationIssues = ToIssues(translationResult.TranslationIssues);
+                    diagnostics.TranslationTime = sw.Elapsed;
+                    sw.Restart();
+                }
+
+                // Optimize the resulting translation. This will usually significantly reduce the size of
+                // the Composition code, however it might slow down loading too much on complex Lotties.
+                if (wincompDataRootVisual != null && optimizationEnabled)
+                {
+                    // Optimize.
+                    wincompDataRootVisual = UIData.Tools.Optimizer.Optimize(wincompDataRootVisual, ignoreCommentProperties: true);
+
+                    if (diagnostics != null)
+                    {
+                        diagnostics.OptimizationTime = sw.Elapsed;
+                        sw.Restart();
+                    }
+                }
+            }));
+
+            if (wincompDataRootVisual is null)
+            {
+                // Failed.
+                return result;
+            }
+            else
+            {
+                if (diagnostics != null)
+                {
+                    // Save the root visual so diagnostics can generate XML and codegen.
+                    diagnostics.RootVisual = wincompDataRootVisual;
+                    diagnostics.RequiredUapVersion = requiredUapVersion;
+                }
+
+                result.SetRootVisual(wincompDataRootVisual);
+                return result;
+            }
+        }
+
+        static Issue[] ToIssues(IEnumerable<(string Code, string Description)> issues)
+            => issues.Select(issue => new Issue { Code = issue.Code, Description = issue.Description }).ToArray();
+
+        static Issue[] ToIssues(IEnumerable<TranslationIssue> issues)
+            => issues.Select(issue => new Issue { Code = issue.Code, Description = issue.Description }).ToArray();
+
+        static async Task<(string, Stream)> GetStorageFileStreamAsync(StorageFile storageFile)
+        {
+            var randomAccessStream = await storageFile.OpenReadAsync();
+            return (storageFile.Name, randomAccessStream.AsStreamForRead());
+        }
+
+        /// <summary>
+        /// Gets the highest UAP version supported by the current process.
+        /// </summary>
+        /// <returns>The highest UAP version supported by the current process.</returns>
+        static uint GetCurrentUapVersion()
+        {
+            // Start testing on version 2. We know that at least version 1 is supported because
+            // we are running in UAP code.
+            var versionToTest = 2u;
+
+            // Keep querying until IsApiContractPresent fails to find the version.
+            while (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", (ushort)versionToTest))
+            {
+                // Keep looking ...
+                versionToTest++;
+            }
+
+            // Query failed on versionToTest. Return the previous version.
+            return versionToTest - 1;
+        }
+
+        [Conditional("DEBUG")]
+        static void AssertNotNull<T>(T obj)
+            where T : class
+        {
+            if (obj is null)
+            {
+                Debug.Assert(obj != null, "Unexpected null");
+            }
+        }
+
+        // A loader that loads from an IInputStream.
+        internal sealed class FromInputStream : Loader
+        {
+            readonly IInputStream _inputStream;
+
+            internal FromInputStream(IInputStream inputStream)
+            {
+                AssertNotNull(inputStream);
+                _inputStream = inputStream;
+            }
+
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+            private protected override async Task<(string, Stream)> GetJsonStreamAsync()
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+            {
+                return (string.Empty, _inputStream.AsStreamForRead());
+            }
+        }
+
+        // A loader that loads from a StorageFile.
+        internal sealed class FromStorageFile : Loader
+        {
+            readonly StorageFile _storageFile;
+
+            internal FromStorageFile(StorageFile storageFile)
+            {
+                AssertNotNull(storageFile);
+                _storageFile = storageFile;
+            }
+
+            private protected override Task<(string, Stream)> GetJsonStreamAsync() =>
+                GetStorageFileStreamAsync(_storageFile);
+        }
+
+        // A loader that loads from a Uri.
+        internal sealed class FromUri : Loader
+        {
+            readonly Uri _uri;
+
+            internal FromUri(Uri uri)
+            {
+                AssertNotNull(uri);
+                _uri = uri;
+            }
+
+            private protected override async Task<(string, Stream)> GetJsonStreamAsync()
+            {
+                var absoluteUri = Uris.GetAbsoluteUri(_uri);
+                if (absoluteUri != null)
+                {
+                    if (absoluteUri.Scheme.StartsWith("ms-"))
+                    {
+                        return await GetStorageFileStreamAsync(await StorageFile.GetFileFromApplicationUriAsync(absoluteUri));
+                    }
+                    else
+                    {
+                        var winrtClient = new Windows.Web.Http.HttpClient();
+                        var response = await winrtClient.GetAsync(absoluteUri);
+
+                        var result = await response.Content.ReadAsInputStreamAsync();
+                        return (absoluteUri.LocalPath, result.AsStreamForRead());
+                    }
+                }
+
+                return (null, null);
+            }
+        }
+
+        // ----
+        // BEGIN: DEBUGGING HELPERS
+        // ----
+
+        // For testing purposes, slows down a task.
+#if SlowAwaits
+        const int _checkedDelayMs = 5;
+        async
+#endif
+        static Task CheckedAwaitAsync(Task task)
+        {
+#if SlowAwaits
+            await Task.Delay(_checkedDelayMs);
+            await task;
+            await Task.Delay(_checkedDelayMs);
+#else
+#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
+            return task;
+#pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
+#endif
+        }
+
+        // ----
+        // END: DEBUGGING HELPERS
+        // ----
+    }
+}

--- a/source/Lottie/Lottie.projitems
+++ b/source/Lottie/Lottie.projitems
@@ -6,11 +6,15 @@
     <SharedGUID>8ef7bd77-28e9-4998-8dbb-8036f988fe65</SharedGUID>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)ContentFactory.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)DisposableAnimatedVisual.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GenericDataToJson.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Instantiator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Loader.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)LottieVisualDiagnostics.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)LottieVisualOptions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)LottieVisualSource.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Uris.cs" />
   </ItemGroup>
 </Project>

--- a/source/Lottie/LottieVisualSource.cs
+++ b/source/Lottie/LottieVisualSource.cs
@@ -2,26 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if DEBUG
-// Uncomment this to slow down async awaits for testing.
-//#define SlowAwaits
-#endif
-
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading.Tasks;
-using Microsoft.Toolkit.Uwp.UI.Lottie.LottieData;
-using Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization;
-using Microsoft.Toolkit.Uwp.UI.Lottie.LottieMetadata;
-using Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp;
 using Microsoft.UI.Xaml.Controls;
 using Windows.Foundation;
 using Windows.Foundation.Metadata;
 using Windows.Storage;
+using Windows.Storage.Streams;
 using Windows.UI.Composition;
 using Windows.UI.Xaml;
 
@@ -33,7 +21,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
     /// </summary>
     public sealed class LottieVisualSource : DependencyObject, IDynamicAnimatedVisualSource
     {
-        readonly StorageFile _storageFile;
         EventRegistrationTokenTable<TypedEventHandler<IDynamicAnimatedVisualSource, object>> _compositionInvalidatedEventTokenTable;
         int _loadVersion;
         Uri _uriSource;
@@ -64,18 +51,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
                 new PropertyMetadata(defaultValue, (d, e) => callback((LottieVisualSource)d, (T)e.OldValue, (T)e.NewValue)));
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="LottieVisualSource"/> class to be used in markup.
+        /// Initializes a new instance of the <see cref="LottieVisualSource"/> class.
         /// </summary>
         public LottieVisualSource()
         {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="LottieVisualSource"/> class from a <see cref="StorageFile"/>.
-        /// </summary>
-        public LottieVisualSource(StorageFile storageFile)
-        {
-            _storageFile = storageFile;
         }
 
         /// <summary>
@@ -102,7 +81,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
         /// <returns>The <see cref="LottieVisualSource"/> for the given url.</returns>
         public static LottieVisualSource CreateFromString(string uri)
         {
-            var uriUri = StringToUri(uri);
+            var uriUri = Uris.StringToUri(uri);
             if (uriUri is null)
             {
                 return null;
@@ -114,13 +93,25 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
         /// <summary>
         /// Sets the source for the <see cref="LottieVisualSource"/>.
         /// </summary>
-        /// <param name="file">A file that refers to a JSON Lottie file.</param>
+        /// <param name="stream">A stream containing the text of a JSON Lottie file encoded as UTF-8.</param>
         /// <returns>An <see cref="IAsyncAction"/> that completes when the load completes or fails.</returns>
-        [DefaultOverload]
+        [Overload("SetSourceStreamAsync")]
+        public IAsyncAction SetSourceAsync(IInputStream stream)
+        {
+            _uriSource = null;
+            return LoadAsync(stream is null ? null : new Loader.FromInputStream(stream)).AsAsyncAction();
+        }
+
+        /// <summary>
+        /// Sets the source for the <see cref="LottieVisualSource"/>.
+        /// </summary>
+        /// <param name="file">A file that is a JSON Lottie file.</param>
+        /// <returns>An <see cref="IAsyncAction"/> that completes when the load completes or fails.</returns>
+        [Overload("SetSourceFileAsync")]
         public IAsyncAction SetSourceAsync(StorageFile file)
         {
             _uriSource = null;
-            return LoadAsync(file is null ? null : new Loader(this, file)).AsAsyncAction();
+            return LoadAsync(file is null ? null : new Loader.FromStorageFile(file)).AsAsyncAction();
         }
 
         /// <summary>
@@ -128,6 +119,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
         /// </summary>
         /// <param name="sourceUri">A URI that refers to a JSON Lottie file.</param>
         /// <returns>An <see cref="IAsyncAction"/> that completes when the load completes or fails.</returns>
+        [DefaultOverload]
         public IAsyncAction SetSourceAsync(Uri sourceUri)
         {
             _uriSource = sourceUri;
@@ -136,7 +128,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
             // This will not trigger loading because it will be seen as no change
             // from the current (just set) _uriSource value.
             UriSource = sourceUri;
-            return LoadAsync(sourceUri is null ? null : new Loader(this, sourceUri)).AsAsyncAction();
+            return LoadAsync(sourceUri is null ? null : new Loader.FromUri(sourceUri)).AsAsyncAction();
         }
 
         /// <summary>
@@ -177,7 +169,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
                 // No content has been loaded yet.
                 // Return an IAnimatedVisual that produces nothing.
                 diagnostics = null;
-                return new Comp();
+                return new DisposableAnimatedVisual();
             }
             else
             {
@@ -215,7 +207,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
             {
                 try
                 {
-                    await LoadAsync(new Loader(this, UriSource));
+                    await LoadAsync(new Loader.FromUri(UriSource));
                 }
                 catch
                 {
@@ -283,407 +275,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
             }
         }
 
-        static Issue[] ToIssues(IEnumerable<(string Code, string Description)> issues)
-            => issues.Select(issue => new Issue { Code = issue.Code, Description = issue.Description }).ToArray();
-
-        static Issue[] ToIssues(IEnumerable<TranslationIssue> issues)
-            => issues.Select(issue => new Issue { Code = issue.Code, Description = issue.Description }).ToArray();
-
-        // Handles loading a composition from a Lottie file.
-        sealed class Loader
-        {
-            readonly LottieVisualSource _owner;
-            readonly Uri _uri;
-            readonly StorageFile _storageFile;
-
-            internal Loader(LottieVisualSource owner, Uri uri)
-            {
-                _owner = owner;
-                _uri = uri;
-            }
-
-            internal Loader(LottieVisualSource owner, StorageFile storageFile)
-            {
-                _owner = owner;
-                _storageFile = storageFile;
-            }
-
-            // Asynchronously loads WinCompData from a Lottie file.
-            internal async Task<ContentFactory> LoadAsync(LottieVisualOptions options)
-            {
-                if (_uri is null && _storageFile is null)
-                {
-                    // Request to load null. Return a null ContentFactory.
-                    return null;
-                }
-
-                LottieVisualDiagnostics diagnostics = null;
-                Stopwatch sw = null;
-                if (options.HasFlag(LottieVisualOptions.IncludeDiagnostics))
-                {
-                    sw = Stopwatch.StartNew();
-                    diagnostics = new LottieVisualDiagnostics { Options = options };
-                }
-
-                var result = new ContentFactory(diagnostics);
-
-                // Get the file name and contents.
-                (var fileName, var jsonStream) = await GetFileStreamAsync();
-
-                if (diagnostics != null)
-                {
-                    diagnostics.FileName = fileName;
-                    diagnostics.ReadTime = sw.Elapsed;
-                    sw.Restart();
-                }
-
-                if (jsonStream is null)
-                {
-                    // Failed to load ...
-                    return result;
-                }
-
-                // Parsing large Lottie files can take significant time. Do it on
-                // another thread.
-                LottieData.LottieComposition lottieComposition = null;
-                await CheckedAwaitAsync(Task.Run(() =>
-                {
-                    lottieComposition =
-                        LottieCompositionReader.ReadLottieCompositionFromJsonStream(
-                            jsonStream,
-                            LottieCompositionReader.Options.IgnoreMatchNames,
-                            out var readerIssues);
-
-                    if (diagnostics != null)
-                    {
-                        diagnostics.JsonParsingIssues = ToIssues(readerIssues);
-                    }
-                }));
-
-                if (diagnostics != null)
-                {
-                    diagnostics.ParseTime = sw.Elapsed;
-                    sw.Restart();
-                }
-
-                if (lottieComposition is null)
-                {
-                    // Failed to load...
-                    return result;
-                }
-
-                if (diagnostics != null)
-                {
-                    // Save the LottieComposition in the diagnostics so that the xml and codegen
-                    // code can be derived from it.
-                    diagnostics.LottieComposition = lottieComposition;
-
-                    // Create the marker info.
-                    diagnostics.Markers =
-                        lottieComposition.Markers.Select(m =>
-                            new KeyValuePair<string, double>(
-                                m.Name,
-                                m.Frame / (lottieComposition.FramesPerSecond * lottieComposition.Duration.TotalSeconds))).ToArray();
-
-                    // Validate the composition and report if issues are found.
-                    diagnostics.LottieValidationIssues = ToIssues(LottieCompositionValidator.Validate(lottieComposition));
-                    diagnostics.ValidationTime = sw.Elapsed;
-                    sw.Restart();
-                }
-
-                result.SetDimensions(
-                    width: lottieComposition.Width,
-                    height: lottieComposition.Height,
-                    duration: lottieComposition.Duration);
-
-                // Translating large Lotties can take significant time. Do it on another thread.
-                WinCompData.Visual wincompDataRootVisual = null;
-                uint requiredUapVersion = 0;
-                var optimizationEnabled = _owner.Options.HasFlag(LottieVisualOptions.Optimize);
-
-                TranslationResult translationResult;
-                await CheckedAwaitAsync(Task.Run(() =>
-                {
-                    // translatePropertyBindings is turned on so that it can report
-                    // an issue if the author is using property bindings incorrectly.
-                    translationResult = LottieToWinCompTranslator.TryTranslateLottieComposition(
-                        lottieComposition: lottieComposition,
-                        configuration: new TranslatorConfiguration { TranslatePropertyBindings = true, TargetUapVersion = GetCurrentUapVersion() });
-
-                    wincompDataRootVisual = translationResult.RootVisual;
-                    requiredUapVersion = translationResult.MinimumRequiredUapVersion;
-
-                    if (diagnostics != null)
-                    {
-                        diagnostics.TranslationIssues = ToIssues(translationResult.TranslationIssues);
-                        diagnostics.TranslationTime = sw.Elapsed;
-                        sw.Restart();
-                    }
-
-                    // Optimize the resulting translation. This will usually significantly reduce the size of
-                    // the Composition code, however it might slow down loading too much on complex Lotties.
-                    if (wincompDataRootVisual != null && optimizationEnabled)
-                    {
-                        // Optimize.
-                        wincompDataRootVisual = UIData.Tools.Optimizer.Optimize(wincompDataRootVisual, ignoreCommentProperties: true);
-
-                        if (diagnostics != null)
-                        {
-                            diagnostics.OptimizationTime = sw.Elapsed;
-                            sw.Restart();
-                        }
-                    }
-                }));
-
-                if (wincompDataRootVisual is null)
-                {
-                    // Failed.
-                    return result;
-                }
-                else
-                {
-                    if (diagnostics != null)
-                    {
-                        // Save the root visual so diagnostics can generate XML and codegen.
-                        diagnostics.RootVisual = wincompDataRootVisual;
-                        diagnostics.RequiredUapVersion = requiredUapVersion;
-                    }
-
-                    result.SetRootVisual(wincompDataRootVisual);
-                    return result;
-                }
-            }
-
-            Task<(string, Stream)> GetFileStreamAsync()
-                => _storageFile != null
-                    ? GetStorageFileStreamAsync(_storageFile)
-                    : GetUriStreamAsync(_uri);
-
-            Task<(string, string)> ReadFileAsync()
-                    => _storageFile != null
-                        ? ReadStorageFileAsync(_storageFile)
-                        : ReadUriAsync(_uri);
-
-            async Task<(string, string)> ReadUriAsync(Uri uri)
-            {
-                var absoluteUri = GetAbsoluteUri(uri);
-                if (absoluteUri != null)
-                {
-                    if (absoluteUri.Scheme.StartsWith("ms-"))
-                    {
-                        return await ReadStorageFileAsync(await StorageFile.GetFileFromApplicationUriAsync(absoluteUri));
-                    }
-                    else
-                    {
-                        var winrtClient = new Windows.Web.Http.HttpClient();
-                        var response = await winrtClient.GetAsync(absoluteUri);
-                        var result = await response.Content.ReadAsStringAsync();
-                        return (absoluteUri.LocalPath, result);
-                    }
-                }
-
-                return (null, null);
-            }
-
-            async Task<(string, Stream)> GetUriStreamAsync(Uri uri)
-            {
-                var absoluteUri = GetAbsoluteUri(uri);
-                if (absoluteUri != null)
-                {
-                    if (absoluteUri.Scheme.StartsWith("ms-"))
-                    {
-                        return await GetStorageFileStreamAsync(await StorageFile.GetFileFromApplicationUriAsync(absoluteUri));
-                    }
-                    else
-                    {
-                        var winrtClient = new Windows.Web.Http.HttpClient();
-                        var response = await winrtClient.GetAsync(absoluteUri);
-
-                        var result = await response.Content.ReadAsInputStreamAsync();
-                        return (absoluteUri.LocalPath, result.AsStreamForRead());
-                    }
-                }
-
-                return (null, null);
-            }
-
-            async Task<(string, string)> ReadStorageFileAsync(StorageFile storageFile)
-            {
-                Debug.Assert(storageFile != null, "Precondition");
-                var result = await FileIO.ReadTextAsync(storageFile);
-                return (storageFile.Name, result);
-            }
-
-            async Task<(string, Stream)> GetStorageFileStreamAsync(StorageFile storageFile)
-            {
-                var randomAccessStream = await storageFile.OpenReadAsync();
-                return (storageFile.Name, randomAccessStream.AsStreamForRead());
-            }
-        }
-
-        // Parses a string into an absolute URI, or null if the string is malformed.
-        static Uri StringToUri(string uri)
-        {
-            if (!Uri.IsWellFormedUriString(uri, UriKind.RelativeOrAbsolute))
-            {
-                return null;
-            }
-
-            return GetAbsoluteUri(new Uri(uri, UriKind.RelativeOrAbsolute));
-        }
-
-        // Returns an absolute URI. Relative URIs are made relative to ms-appx:///
-        static Uri GetAbsoluteUri(Uri uri)
-        {
-            if (uri is null)
-            {
-                return null;
-            }
-
-            if (uri.IsAbsoluteUri)
-            {
-                return uri;
-            }
-
-            return new Uri($"ms-appx:///{uri}", UriKind.Absolute);
-        }
-
-        // Information from which a composition's content can be instantiated. Contains the WinCompData
-        // translation of a composition and some metadata.
-        sealed class ContentFactory : IAnimatedVisualSource
-        {
-            internal static readonly ContentFactory FailedContent = new ContentFactory(null);
-            readonly LottieVisualDiagnostics _diagnostics;
-            WinCompData.Visual _wincompDataRootVisual;
-            double _width;
-            double _height;
-            TimeSpan _duration;
-
-            internal ContentFactory(LottieVisualDiagnostics diagnostics)
-            {
-                _diagnostics = diagnostics;
-            }
-
-            internal void SetDimensions(double width, double height, TimeSpan duration)
-            {
-                _width = width;
-                _height = height;
-                _duration = duration;
-            }
-
-            internal void SetRootVisual(WinCompData.Visual rootVisual)
-            {
-                _wincompDataRootVisual = rootVisual;
-            }
-
-            internal bool CanInstantiate => _wincompDataRootVisual != null;
-
-            // Clones a new diagnostics object. Will return null if the factory
-            // has no diagnostics object.
-            LottieVisualDiagnostics GetDiagnosticsClone()
-            {
-                return _diagnostics?.Clone();
-            }
-
-            public IAnimatedVisual TryCreateAnimatedVisual(Compositor compositor, out object diagnostics)
-            {
-                var diags = GetDiagnosticsClone();
-                diagnostics = diags;
-
-                if (!CanInstantiate)
-                {
-                    return null;
-                }
-                else
-                {
-                    var sw = Stopwatch.StartNew();
-                    var result = new Comp()
-                    {
-                        RootVisual = Instantiator.CreateVisual(compositor, _wincompDataRootVisual),
-                        Size = new System.Numerics.Vector2((float)_width, (float)_height),
-                        Duration = _duration,
-                    };
-
-                    if (diags != null)
-                    {
-                        diags.InstantiationTime = sw.Elapsed;
-                    }
-
-                    return result;
-                }
-            }
-        }
-
         /// <summary>
         /// Returns a string representation of the <see cref="LottieVisualSource"/> for debugging purposes.
         /// </summary>
         /// <returns>A string representation of the <see cref="LottieVisualSource"/> for debugging purposes.</returns>
         public override string ToString()
         {
-            // TODO - if there's a _contentFactory, it should store the identity and report here
-            var identity = (_storageFile != null) ? _storageFile.Name : _uriSource?.ToString() ?? string.Empty;
+            var identity = _uriSource?.ToString() ?? string.Empty;
             return $"LottieVisualSource({identity})";
         }
-
-        /// <summary>
-        /// Gets the highest UAP version of the current process.
-        /// </summary>
-        /// <returns>The highest UAP version of the current process.</returns>
-        static uint GetCurrentUapVersion()
-        {
-            // Start testing on version 2. We know that at least version 1 is supported because
-            // we are running in UAP code.
-            var versionToTest = 2u;
-
-            // Keep querying until IsApiContractPresent fails to find the version.
-            while (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", (ushort)versionToTest))
-            {
-                // Keep looking ...
-                versionToTest++;
-            }
-
-            // Query failed on versionToTest. Return the previous version.
-            return versionToTest - 1;
-        }
-
-        sealed class Comp : IAnimatedVisual, IDisposable
-        {
-            public Visual RootVisual { get; set; }
-
-            public TimeSpan Duration { get; set; }
-
-            public System.Numerics.Vector2 Size { get; set; }
-
-            public void Dispose()
-            {
-                RootVisual?.Dispose();
-            }
-        }
-
-        // ----
-        // BEGIN: DEBUGGING HELPERS
-        // ----
-
-        // For testing purposes, slows down a task.
-#if SlowAwaits
-        const int _checkedDelayMs = 5;
-        async
-#endif
-        static Task CheckedAwaitAsync(Task task)
-        {
-#if SlowAwaits
-            await Task.Delay(_checkedDelayMs);
-            await task;
-            await Task.Delay(_checkedDelayMs);
-#else
-#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
-            return task;
-#pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
-#endif
-        }
-
-        // ----
-        // END: DEBUGGING HELPERS
-        // ----
     }
 }

--- a/source/Lottie/Uris.cs
+++ b/source/Lottie/Uris.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.Toolkit.Uwp.UI.Lottie
+{
+    static class Uris
+    {
+        /// <summary>
+        /// Parses a string into an absolute URI, or null if the string is malformed.
+        /// Relative URIs are made relative to ms-appx:///.
+        /// </summary>
+        /// <returns>A Uri or null.</returns>
+        public static Uri StringToUri(string uri)
+        {
+            if (!Uri.IsWellFormedUriString(uri, UriKind.RelativeOrAbsolute))
+            {
+                return null;
+            }
+
+            return GetAbsoluteUri(new Uri(uri, UriKind.RelativeOrAbsolute));
+        }
+
+        /// <summary>
+        /// Returns an absolute URI. Relative URIs are made relative to ms-appx:///.
+        /// </summary>
+        /// <returns>A Uri or null.</returns>
+        public static Uri GetAbsoluteUri(Uri uri)
+        {
+            if (uri is null)
+            {
+                return null;
+            }
+
+            if (uri.IsAbsoluteUri)
+            {
+                return uri;
+            }
+
+            return new Uri($"ms-appx:///{uri}", UriKind.Absolute);
+        }
+    }
+}


### PR DESCRIPTION
There was a request (#333) to be able to load Lottie files from memory. This change allows that by enabling any IInputStream to be used.

As part of this change, I found some cruft that I could clean up, and I pulled out the classes for the Loader and ContentFactory and did some other straightforward refactoring.