### PR TITLE
Prevent double periods in LP0002 error message.

### DIFF
--- a/source/Issues/LP0002.md
+++ b/source/Issues/LP0002.md
@@ -1,5 +1,5 @@
 ﻿[comment]: # (name:FatalError)
-[comment]: # (text:Fatal error: {message}.)
+[comment]: # (text:Fatal error: {message})
 
 # Lottie-Windows Warning LP0002
 

--- a/source/LottieReader/Serialization/ParsingIssues.cs
+++ b/source/LottieReader/Serialization/ParsingIssues.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
         // LP0001 has been deprecated.
         // Was: Failed to parse JSON. {message}.
 
-        internal void FatalError(string message) => Report("LP0002", $"Fatal error: {message}.");
+        internal void FatalError(string message) => Report("LP0002", $"Fatal error: {message}");
 
         internal void AssetType(string type) => Report("LP0005", $"Unsupported asset type: {type}.");
 


### PR DESCRIPTION
LP0002 is always populated from an exception message, which are supposed to have periods on the end. So most of the time we were getting double periods, which looks bad.