### PR TITLE
Show animator counts in the object status table in generated code.

### DIFF
--- a/source/UIDataCodeGen/CodeGen/InstantiatorGeneratorBase.cs
+++ b/source/UIDataCodeGen/CodeGen/InstantiatorGeneratorBase.cs
@@ -463,18 +463,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
         }
 
         /// <summary>
-        /// Returns text that describes the graph statistics.
+        /// Returns text that describes the graph statistics. This graph shows the
+        /// number of objects instantiated and is designed to help with investigations
+        /// or performance.
         /// </summary>
         /// <returns>A list of strings describing the graph statistics.</returns>
-        IEnumerable<string> GetGraphStatsLines()
-        {
-            foreach (var line in GraphStatsMonospaceTableFormatter.GetGraphStatsLines(
-                                    _animatedVisualGenerators.Select(avg => (avg.StatsName, avg.Objects))
-                                    ))
-            {
-                yield return line;
-            }
-        }
+        IEnumerable<string> GetGraphStatsLines() =>
+            GraphStatsMonospaceTableFormatter.GetGraphStatsLines(
+                                    _animatedVisualGenerators.Select(avg => (avg.StatsName, avg.Objects)));
 
         /// <summary>
         /// Call this to get a list of the asset files referenced by the generated code.

--- a/source/UIDataCodeGen/CodeGen/Tables/GraphStatsMonospaceTableFormatter.cs
+++ b/source/UIDataCodeGen/CodeGen/Tables/GraphStatsMonospaceTableFormatter.cs
@@ -11,6 +11,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen.Tables
 {
     sealed class GraphStatsMonospaceTableFormatter : MonospaceTableFormatter
     {
+        /// <summary>
+        /// Returns text that describes the graph statistics.
+        /// </summary>
+        /// <returns>A formatted string for each line in the table.</returns>
         internal static IEnumerable<string> GetGraphStatsLines(IEnumerable<(string name, IEnumerable<object> objects)> objects)
         {
             var objs = objects.ToArray();
@@ -32,11 +36,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen.Tables
                 headerColumns[i + 1] = ColumnData.Create(name);
             }
 
+            // Get the CompositionObjects for each animated visual.
             var compositionObjects =
                 (from x in objs
                  select (from o in x.objects
                          where o is CompositionObject
                          select (CompositionObject)o).ToArray()).ToArray();
+
+            var (expressionAnimatorCount, keyFrameAnimatorCount) = GetAnimatorCountRecords(compositionObjects);
 
             var rows = new[] {
                 Row.HeaderTop,
@@ -44,7 +51,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen.Tables
                 Row.HeaderBottom,
                 GetCompositionObjectCountRecord(compositionObjects, "All CompositionObjects", (o) => true),
                 Row.Separator,
-                GetAnimatorCountRecord(compositionObjects),
+                expressionAnimatorCount,
+                keyFrameAnimatorCount,
+                Row.Separator,
                 GetCompositionObjectCountRecord(compositionObjects, "Animated brushes", (o) => o is CompositionBrush b && b.Animators.Count > 0),
                 GetCompositionObjectCountRecord(compositionObjects, "Animated gradient stops", (o) => o is CompositionColorGradientStop s && s.Animators.Count > 0),
                 GetCompositionObjectCountRecord(compositionObjects, "ExpressionAnimations", (o) => o.Type == CompositionObjectType.ExpressionAnimation),
@@ -62,6 +71,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen.Tables
                 Row.BodyBottom,
             };
 
+            // Convert the rows into strings.
             return GetTableLines(rows);
         }
 
@@ -82,18 +92,45 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen.Tables
             return new Row.ColumnData(result);
         }
 
-        static Row GetAnimatorCountRecord(CompositionObject[][] objects)
+        // Returns a row describing the number of animators for each animated visual.
+        // The parameter is a set of objects for each generator.
+        static (Row expressions, Row keyFrames) GetAnimatorCountRecords(CompositionObject[][] objects)
         {
-            var result = new ColumnData[objects.Length + 1];
-            result[0] = ColumnData.Create("Animators", TextAlignment.Left);
+            var expressions = new ColumnData[objects.Length + 1];
+            var keyFrames = new ColumnData[objects.Length + 1];
+            expressions[0] = ColumnData.Create("Expression animators", TextAlignment.Left);
+            keyFrames[0] = ColumnData.Create("KeyFrame animators", TextAlignment.Left);
 
             for (var i = 0; i < objects.Length; i++)
             {
-                var count = objects[i].Select(o => o.Animators.Count).Sum();
-                result[i + 1] = ColumnData.Create(count);
+                var (expressionsCount, keyFramesCount) = GetAnimatorCountColumns(objects[i]);
+                expressions[i + 1] = expressionsCount;
+                keyFrames[i + 1] = keyFramesCount;
             }
 
-            return new Row.ColumnData(result);
+            return (new Row.ColumnData(expressions), new Row.ColumnData(keyFrames));
+        }
+
+        /// <summary>
+        /// Returns columns describing the counts of animators for the given <see cref="CompositionObject"/>s.
+        /// </summary>
+        /// <returns>The animator counts columns.</returns>
+        static (ColumnData expressions, ColumnData keyFrames) GetAnimatorCountColumns(IEnumerable<CompositionObject> objects)
+        {
+            var expressions = 0;
+            var keyFrames = 0;
+
+            foreach (var obj in objects)
+            {
+                var animators = obj.Animators;
+                var expressionsCount = animators.Where(a => a.Animation.Type == CompositionObjectType.ExpressionAnimation).Count();
+                expressions += expressionsCount;
+
+                // Key frame animations are the animations that are not expression animations.
+                keyFrames += animators.Count - expressionsCount;
+            }
+
+            return (ColumnData.Create(expressions), ColumnData.Create(keyFrames));
         }
     }
 }

--- a/source/UIDataCodeGen/CodeGen/Tables/MonospaceTableFormatter.cs
+++ b/source/UIDataCodeGen/CodeGen/Tables/MonospaceTableFormatter.cs
@@ -15,6 +15,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen.Tables
     // that is specific to a particular data set.
     abstract class MonospaceTableFormatter
     {
+        /// <summary>
+        /// Converts a list of <see cref="Row"/>s into monospaced strings.
+        /// </summary>
+        /// <returns>Text for each <see cref="Row"/>.</returns>
         protected static IEnumerable<string> GetTableLines(IEnumerable<Row> rows)
         {
             // Get the width of each column in each row and find the maximum width

--- a/source/WinCompData/CompositionAnimation.cs
+++ b/source/WinCompData/CompositionAnimation.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData
         /// Returns the reference parameters that have been set on this <see cref="CompositionAnimation"/>.
         /// The list is returned ordered alphabetically by key.
         /// </summary>
-        public IEnumerable<KeyValuePair<string, CompositionObject>> ReferenceParameters => _referencedParameters;
+        public IReadOnlyCollection<KeyValuePair<string, CompositionObject>> ReferenceParameters => _referencedParameters;
 
         internal abstract CompositionAnimation Clone();
     }


### PR DESCRIPTION
We were showing the number of animation objects previously, but that doesn't really tell you how expensive animations are in DWM because the one animation might be started multiple times. Animator counts are a better representation of cost.

Here's an example of the extra info. Note the animators, and parameters counts.

```// ___________________________________________________________
// |       Object stats       | UAP v12 count | UAP v8 count |
// |__________________________|_______________|______________|
// | All CompositionObjects   |           567 |          567 |
// |--------------------------+---------------+--------------|
// | Expression animators     |            51 |           51 |
// | KeyFrame animators       |            50 |           50 |
// | Reference parameters     |            51 |           51 |
// |--------------------------+---------------+--------------|
// | Animated brushes         |             1 |            1 |
```