### PR TITLE
Change the default for IsAnimatedVisualSourceDynamic.

### DIFF
--- a/source/UIDataCodeGen/CodeGen/CSharpInstantiatorGenerator.cs
+++ b/source/UIDataCodeGen/CodeGen/CSharpInstantiatorGenerator.cs
@@ -409,7 +409,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
             // Declare variables.
             builder.WriteLine($"{_s.Const(_s.TypeInt32)} c_loadedImageSurfaceCount = {Info.LoadedImageSurfaces.Count};");
             builder.WriteLine($"{_s.TypeInt32} _loadCompleteEventCount;");
-            builder.WriteLine("bool _isAnimatedVisualSourceDynamic = true;");
+            builder.WriteLine("bool _isAnimatedVisualSourceDynamic;");
             builder.WriteLine("bool _isTryCreateAnimatedVisualCalled;");
             builder.WriteLine("bool _isImageLoadingStarted;");
             builder.WriteLine("EventRegistrationTokenTable<TypedEventHandler<Microsoft.UI.Xaml.Controls.IDynamicAnimatedVisualSource, object>> _animatedVisualInvalidatedEventTokenTable;");

--- a/source/UIDataCodeGen/CodeGen/CppInstantiatorGeneratorBase.cs
+++ b/source/UIDataCodeGen/CodeGen/CppInstantiatorGeneratorBase.cs
@@ -984,7 +984,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
             builder.Private.WriteLine($"const int c_loadedImageSurfaceCount = {SourceInfo.LoadedImageSurfaces.Distinct().Count()};");
             builder.Private.WriteLine("double m_imageSuccessfulLoadingProgress{};");
             builder.Private.WriteLine("int m_loadCompleteEventCount{};");
-            builder.Private.WriteLine("bool m_isAnimatedVisualSourceDynamic{true};");
+            builder.Private.WriteLine("bool m_isAnimatedVisualSourceDynamic{};");
             builder.Private.WriteLine("bool m_isImageLoadingCompleted{}");
             builder.Private.WriteLine("bool m_isTryCreateAnimatedVisualCalled{}");
             builder.Private.WriteLine("bool m_isImageLoadingStarted{}");


### PR DESCRIPTION
See #340 
This only affects Lotties with non-embedded images. When IsAnimatedVisualSourceDynamic is true the load of the Lottie is not considered complete until all the images have loaded. This guarantees that you never see a Lottie that is missing its images.
When IsAnimatedVisualSourceDynamic is false, the Lottie will load synchronously and the image will pop in when they are finally loaded.
Lotties with non-embedded images are quite rare, and one dev that tried to use them found them to be difficult because they had to wait for the Lottie to be loaded before playing. But they really didn't care about the images taking too long (they were on disk so they should show up really quickly). If we had made IsAnimatedVisualSourceDynamic default to false they wouldn't have had to deal with waiting for the loading and would never have noticed any issue.
So, assuming that most use case are similar (i.e. the images are on disk and there is no need to wait for the images to load), I'm changing the default value false. You can always turn on IsAnimatedVisualSourceDynamic if you need it, but I'm pretty sure hardly anyone ever will.