### PR TITLE
Go back to using latest .NET 3.1 SDK.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,7 @@ steps:
 - task: UseDotNet@2
   inputs:
     packageType: 'sdk' # Options: runtime, sdk
-    version: '3.1.302' # Using .302 because the .401 upgrade broke the build.
+    version: '3.1.x'
 
 # Nerdbank.GitVersioning
 - script: nbgv cloud


### PR DESCRIPTION
We'd previously had to stick to 3.1.302 due to build issues.