### PR TITLE
Show the current UAP version in Lottie Viewer.

### DIFF
--- a/LottieViewer/MainPage.xaml
+++ b/LottieViewer/MainPage.xaml
@@ -212,18 +212,22 @@
                         <Border Style="{StaticResource SeparatorStyle}"
                             Visibility="{x:Bind _stage.DiagnosticsViewModel.DiagnosticsObject, Converter={StaticResource VisibilityConverter}, ConverterParameter=whatthe, Mode=OneWay}"/>
 
-                        <!-- App version -->
+                        <!-- App version info. -->
                         <Grid>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="26"/>
                                 <RowDefinition/>
+                                <RowDefinition/>
                             </Grid.RowDefinitions>
-                            <TextBlock FontWeight="Bold" >Lottie Viewer app</TextBlock>
+                            <TextBlock FontWeight="Bold">Lottie Viewer version</TextBlock>
                             <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,0,0,2">
-                                <TextBlock Foreground="LightGray" MinWidth="60" Text="Version"/>
+                                <TextBlock Foreground="LightGray" MinWidth="60">App</TextBlock>
                                 <TextBlock Foreground="White" Text="{x:Bind AppVersion}" MaxWidth="250" />
                             </StackPanel>
-
+                            <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="0,0,0,2">
+                                <TextBlock Foreground="LightGray" MinWidth="60">UAP</TextBlock>
+                                <TextBlock Foreground="White" Text="{x:Bind UapVersion}" MaxWidth="250" />
+                            </StackPanel>
                         </Grid>
                     </StackPanel>
                 </ScrollViewer>

--- a/LottieViewer/MainPage.xaml.cs
+++ b/LottieViewer/MainPage.xaml.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 using LottieViewer.ViewModel;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.DataTransfer;
+using Windows.Foundation.Metadata;
 using Windows.Storage;
 using Windows.Storage.Pickers;
 using Windows.UI;
@@ -65,6 +66,26 @@ namespace LottieViewer
                 var version = Package.Current.Id.Version;
 
                 return string.Format("{0}.{1}.{2}.{3}", version.Major, version.Minor, version.Build, version.Revision);
+            }
+        }
+
+        public string UapVersion
+        {
+            get
+            {
+                // Start testing on version 2. We know that at least version 1 is supported because
+                // we are running in UAP code.
+                var versionToTest = 2u;
+
+                // Keep querying until IsApiContractPresent fails to find the version.
+                while (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", (ushort)versionToTest))
+                {
+                    // Keep looking ...
+                    versionToTest++;
+                }
+
+                // Query failed on versionToTest. Return the previous version.
+                return (versionToTest - 1).ToString();
             }
         }
 


### PR DESCRIPTION
Because Lotties can render differently on different UAP versions, it's important that users know what version of UAP they're using. That way, when they say "this doesn't look right", and I say "looks fine to me", we can check the UAP version easily to determine whether that accounts for the difference.