### PR TITLE
Cleanup: remove redundant type tags.

### DIFF
--- a/Lottie-Windows.sln
+++ b/Lottie-Windows.sln
@@ -195,6 +195,7 @@ Global
 		source\LottieToWinComp\LottieToWinComp.projitems*{bcedf904-f986-42ec-a22d-e0662777b7f9}*SharedItemsImports = 5
 		source\NullablesAttributes\NullablesAttributes.projitems*{bcedf904-f986-42ec-a22d-e0662777b7f9}*SharedItemsImports = 5
 		source\CompMetadata\CompMetadata.projitems*{cb12d5ba-a6fe-41e2-b555-83c903cce92a}*SharedItemsImports = 5
+		source\DotLottie\DotLottie.projitems*{cb12d5ba-a6fe-41e2-b555-83c903cce92a}*SharedItemsImports = 5
 		source\GenericData\GenericData.projitems*{cb12d5ba-a6fe-41e2-b555-83c903cce92a}*SharedItemsImports = 5
 		source\LottieData\LottieData.projitems*{cb12d5ba-a6fe-41e2-b555-83c903cce92a}*SharedItemsImports = 5
 		source\LottieMetadata\LottieMetadata.projitems*{cb12d5ba-a6fe-41e2-b555-83c903cce92a}*SharedItemsImports = 5

--- a/source/LottieData/DropShadowEffect.cs
+++ b/source/LottieData/DropShadowEffect.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
         public DropShadowEffect(
             string name,
             bool isEnabled,
-            Animatable<Rotation> direction,
             Animatable<Color> color,
+            Animatable<Rotation> direction,
             Animatable<double> distance,
             Animatable<bool> isShadowOnly,
             Animatable<Opacity> opacity,
@@ -34,14 +34,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
         }
 
         /// <summary>
-        /// The angle from the shadow caster to the shadow.
-        /// </summary>
-        public Animatable<Rotation> Direction { get; }
-
-        /// <summary>
         /// The color of the shadow.
         /// </summary>
         public Animatable<Color> Color { get; }
+
+        /// <summary>
+        /// The angle from the shadow caster to the shadow.
+        /// </summary>
+        public Animatable<Rotation> Direction { get; }
 
         /// <summary>
         /// The distance from the shadow caster to the shadow.

--- a/source/LottieData/Ellipse.cs
+++ b/source/LottieData/Ellipse.cs
@@ -27,7 +27,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
         /// <inheritdoc/>
         public override ShapeContentType ContentType => ShapeContentType.Ellipse;
 
-        /// <inheritdoc/>
-        public override LottieObjectType ObjectType => LottieObjectType.Ellipse;
+        public override ShapeType ShapeType => ShapeType.Ellipse;
     }
 }

--- a/source/LottieData/ImageLayer.cs
+++ b/source/LottieData/ImageLayer.cs
@@ -24,8 +24,5 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 
         /// <inheritdoc/>
         public override LayerType Type => LayerType.Image;
-
-        /// <inheritdoc/>
-        public override LottieObjectType ObjectType => LottieObjectType.ImageLayer;
     }
 }

--- a/source/LottieData/Layer.cs
+++ b/source/LottieData/Layer.cs
@@ -92,6 +92,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 
         public MatteType LayerMatteType { get; }
 
+        /// <inheritdoc/>
+        public override sealed LottieObjectType ObjectType => LottieObjectType.Layer;
+
         public ref struct LayerArgs
         {
             public string Name { get; set; }

--- a/source/LottieData/LinearGradientFill.cs
+++ b/source/LottieData/LinearGradientFill.cs
@@ -34,8 +34,5 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 
         /// <inheritdoc/>
         public override ShapeContentType ContentType => ShapeContentType.LinearGradientFill;
-
-        /// <inheritdoc/>
-        public override LottieObjectType ObjectType => LottieObjectType.LinearGradientFill;
     }
 }

--- a/source/LottieData/LinearGradientStroke.cs
+++ b/source/LottieData/LinearGradientStroke.cs
@@ -35,9 +35,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
         /// <inheritdoc/>
         public override ShapeContentType ContentType => ShapeContentType.LinearGradientStroke;
 
-        /// <inheritdoc/>
-        public override LottieObjectType ObjectType => LottieObjectType.LinearGradientStroke;
-
         public override ShapeStrokeKind StrokeKind => ShapeStrokeKind.LinearGradient;
     }
 }

--- a/source/LottieData/LottieData.projitems
+++ b/source/LottieData/LottieData.projitems
@@ -72,6 +72,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ShapeLayer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShapeLayerContent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShapeStroke.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ShapeType.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SolidColorFill.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SolidColorStroke.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SolidLayer.cs" />

--- a/source/LottieData/LottieObjectType.cs
+++ b/source/LottieData/LottieObjectType.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 #endif
     enum LottieObjectType
     {
+        Effect,
         Layer,
         LottieComposition,
         Marker,

--- a/source/LottieData/MergePaths.cs
+++ b/source/LottieData/MergePaths.cs
@@ -22,9 +22,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
         /// <inheritdoc/>
         public override ShapeContentType ContentType => ShapeContentType.MergePaths;
 
-        /// <inheritdoc/>
-        public override LottieObjectType ObjectType => LottieObjectType.MergePaths;
-
         public enum MergeMode
         {
             Merge,

--- a/source/LottieData/NullLayer.cs
+++ b/source/LottieData/NullLayer.cs
@@ -16,8 +16,5 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 
         /// <inheritdoc/>
         public override LayerType Type => LayerType.Null;
-
-        /// <inheritdoc/>
-        public override LottieObjectType ObjectType => LottieObjectType.NullLayer;
     }
 }

--- a/source/LottieData/Path.cs
+++ b/source/LottieData/Path.cs
@@ -23,8 +23,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
         /// <inheritdoc/>
         public override ShapeContentType ContentType => ShapeContentType.Path;
 
-        /// <inheritdoc/>
-        public override LottieObjectType ObjectType => LottieObjectType.Shape;
+        public override ShapeType ShapeType => ShapeType.Path;
 
         /// <summary>
         /// Returns a path with the same properties except with the given

--- a/source/LottieData/Polystar.cs
+++ b/source/LottieData/Polystar.cs
@@ -51,8 +51,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
         /// <inheritdoc/>
         public override ShapeContentType ContentType => ShapeContentType.Polystar;
 
-        /// <inheritdoc/>
-        public override LottieObjectType ObjectType => LottieObjectType.Polystar;
+        public override sealed ShapeType ShapeType => ShapeType.Polystar;
 
         public enum PolyStarType
         {

--- a/source/LottieData/PreCompLayer.cs
+++ b/source/LottieData/PreCompLayer.cs
@@ -32,8 +32,5 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 
         /// <inheritdoc/>
         public override LayerType Type => LayerType.PreComp;
-
-        /// <inheritdoc/>
-        public override LottieObjectType ObjectType => LottieObjectType.PreCompLayer;
     }
 }

--- a/source/LottieData/RadialGradientFill.cs
+++ b/source/LottieData/RadialGradientFill.cs
@@ -42,8 +42,5 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 
         /// <inheritdoc/>
         public override ShapeContentType ContentType => ShapeContentType.RadialGradientFill;
-
-        /// <inheritdoc/>
-        public override LottieObjectType ObjectType => LottieObjectType.RadialGradientFill;
     }
 }

--- a/source/LottieData/RadialGradientStroke.cs
+++ b/source/LottieData/RadialGradientStroke.cs
@@ -43,9 +43,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
         /// <inheritdoc/>
         public override ShapeContentType ContentType => ShapeContentType.RadialGradientStroke;
 
-        /// <inheritdoc/>
-        public override LottieObjectType ObjectType => LottieObjectType.RadialGradientStroke;
-
         public override ShapeStrokeKind StrokeKind => ShapeStrokeKind.RadialGradient;
     }
 }

--- a/source/LottieData/Rectangle.cs
+++ b/source/LottieData/Rectangle.cs
@@ -38,7 +38,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
         /// <inheritdoc/>
         public override ShapeContentType ContentType => ShapeContentType.Rectangle;
 
-        /// <inheritdoc/>
-        public override LottieObjectType ObjectType => LottieObjectType.Rectangle;
+        public override ShapeType ShapeType => ShapeType.Rectangle;
     }
 }

--- a/source/LottieData/Repeater.cs
+++ b/source/LottieData/Repeater.cs
@@ -41,8 +41,5 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 
         /// <inheritdoc/>
         public override ShapeContentType ContentType => ShapeContentType.Repeater;
-
-        /// <inheritdoc/>
-        public override LottieObjectType ObjectType => LottieObjectType.Repeater;
     }
 }

--- a/source/LottieData/RoundCorners.cs
+++ b/source/LottieData/RoundCorners.cs
@@ -31,8 +31,5 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 
         /// <inheritdoc/>
         public override ShapeContentType ContentType => ShapeContentType.RoundCorners;
-
-        /// <inheritdoc/>
-        public override LottieObjectType ObjectType => LottieObjectType.RoundCorners;
     }
 }

--- a/source/LottieData/Serialization/LottieCompositionYamlSerializer.cs
+++ b/source/LottieData/Serialization/LottieCompositionYamlSerializer.cs
@@ -72,14 +72,17 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
 
             switch (obj.ObjectType)
             {
+                case LottieObjectType.Effect:
+                    return FromEffect((Effect)obj, superclassContent);
+
+                case LottieObjectType.Layer:
+                    return FromLayer((Layer)obj, superclassContent);
+
                 case LottieObjectType.LottieComposition:
                     return FromLottieComposition((LottieComposition)obj, superclassContent);
 
                 case LottieObjectType.Marker:
                     return FromMarker((Marker)obj, superclassContent);
-
-                case LottieObjectType.Layer:
-                    return FromLayer((Layer)obj, superclassContent);
 
                 case LottieObjectType.ShapeLayerContent:
                     return FromShapeLayerContent((ShapeLayerContent)obj, superclassContent);
@@ -334,24 +337,29 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
             };
         }
 
-        YamlObject FromEffect(Effect effect)
-        {
-            var result = new YamlMap
-            {
-                { nameof(effect.Name), effect.Name },
-                { nameof(effect.Type), effect.Type.ToString() },
-            };
+        YamlObject FromEffect(Effect effect) =>
+            FromEffect(effect, GetLottieObjectContent(effect));
 
+        YamlObject FromEffect(Effect effect, YamlMap superclassContent)
+        {
+            superclassContent.Add(nameof(effect.Type), effect.Type.ToString());
             return effect.Type switch
             {
-                Effect.EffectType.DropShadow => FromDropShadowEffect((DropShadowEffect)effect, result),
+                Effect.EffectType.DropShadow => FromDropShadowEffect((DropShadowEffect)effect, superclassContent),
                 _ => throw Unreachable,
             };
         }
 
         YamlObject FromDropShadowEffect(DropShadowEffect effect, YamlMap superclassContent)
         {
-            return superclassContent;
+            var result = superclassContent;
+            result.Add(nameof(effect.Color), FromAnimatable(effect.Color));
+            result.Add(nameof(effect.Direction), FromAnimatable(effect.Direction));
+            result.Add(nameof(effect.Distance), FromAnimatable(effect.Distance));
+            result.Add(nameof(effect.IsShadowOnly), FromAnimatable(effect.IsShadowOnly));
+            result.Add(nameof(effect.Opacity), FromAnimatable(effect.Opacity));
+            result.Add(nameof(effect.Softness), FromAnimatable(effect.Softness));
+            return result;
         }
 
         YamlObject FromMask(Mask mask)
@@ -452,6 +460,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
             => animatable.IsAnimated
                 ? FromEnumerable(animatable.KeyFrames, kf => FromKeyFrame(kf, valueSelector))
                 : valueSelector(animatable.InitialValue);
+
+        YamlObject FromAnimatable(Animatable<bool> animatable) => FromAnimatable(animatable, Scalar);
 
         YamlObject FromAnimatable(Animatable<Color> animatable) => FromAnimatable(animatable, Scalar);
 
@@ -656,6 +666,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
             var result = superclassContent;
             return result;
         }
+
+        YamlScalar Scalar(bool value) => Scalar(value, value ? "true" : "false");
 
         YamlScalar Scalar(Color value) => Scalar(value, $"'{value}'");
 

--- a/source/LottieData/Serialization/LottieCompositionYamlSerializer.cs
+++ b/source/LottieData/Serialization/LottieCompositionYamlSerializer.cs
@@ -78,30 +78,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
                 case LottieObjectType.Marker:
                     return FromMarker((Marker)obj, superclassContent);
 
-                case LottieObjectType.ImageLayer:
-                case LottieObjectType.NullLayer:
-                case LottieObjectType.PreCompLayer:
-                case LottieObjectType.ShapeLayer:
-                case LottieObjectType.SolidLayer:
-                case LottieObjectType.TextLayer:
+                case LottieObjectType.Layer:
                     return FromLayer((Layer)obj, superclassContent);
 
-                case LottieObjectType.Ellipse:
-                case LottieObjectType.LinearGradientFill:
-                case LottieObjectType.LinearGradientStroke:
-                case LottieObjectType.MergePaths:
-                case LottieObjectType.Polystar:
-                case LottieObjectType.RadialGradientFill:
-                case LottieObjectType.RadialGradientStroke:
-                case LottieObjectType.Rectangle:
-                case LottieObjectType.Repeater:
-                case LottieObjectType.RoundCorners:
-                case LottieObjectType.Shape:
-                case LottieObjectType.ShapeGroup:
-                case LottieObjectType.SolidColorFill:
-                case LottieObjectType.SolidColorStroke:
-                case LottieObjectType.Transform:
-                case LottieObjectType.TrimPath:
+                case LottieObjectType.ShapeLayerContent:
                     return FromShapeLayerContent((ShapeLayerContent)obj, superclassContent);
 
                 default:

--- a/source/LottieData/Shape.cs
+++ b/source/LottieData/Shape.cs
@@ -22,5 +22,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
         }
 
         public DrawingDirection DrawingDirection { get; }
+
+        public abstract ShapeType ShapeType { get; }
     }
 }

--- a/source/LottieData/ShapeGroup.cs
+++ b/source/LottieData/ShapeGroup.cs
@@ -26,8 +26,5 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 
         /// <inheritdoc/>
         public override ShapeContentType ContentType => ShapeContentType.Group;
-
-        /// <inheritdoc/>
-        public override LottieObjectType ObjectType => LottieObjectType.ShapeGroup;
     }
 }

--- a/source/LottieData/ShapeLayer.cs
+++ b/source/LottieData/ShapeLayer.cs
@@ -27,8 +27,5 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 
         /// <inheritdoc/>
         public override LayerType Type => LayerType.Shape;
-
-        /// <inheritdoc/>
-        public override LottieObjectType ObjectType => LottieObjectType.ShapeLayer;
     }
 }

--- a/source/LottieData/ShapeLayerContent.cs
+++ b/source/LottieData/ShapeLayerContent.cs
@@ -25,6 +25,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
         /// </summary>
         public abstract ShapeContentType ContentType { get; }
 
+        public override sealed LottieObjectType ObjectType => LottieObjectType.ShapeLayerContent;
+
         public ref struct ShapeLayerContentArgs
         {
             public string Name { get; set; }

--- a/source/LottieData/ShapeType.cs
+++ b/source/LottieData/ShapeType.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -7,11 +7,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 #if PUBLIC_LottieData
     public
 #endif
-    enum LottieObjectType
+    enum ShapeType
     {
-        Layer,
-        LottieComposition,
-        Marker,
-        ShapeLayerContent,
+        Ellipse,
+        Path,
+        Polystar,
+        Rectangle,
     }
 }

--- a/source/LottieData/SolidColorFill.cs
+++ b/source/LottieData/SolidColorFill.cs
@@ -25,8 +25,5 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 
         /// <inheritdoc/>
         public override ShapeContentType ContentType => ShapeContentType.SolidColorFill;
-
-        /// <inheritdoc/>
-        public override LottieObjectType ObjectType => LottieObjectType.SolidColorFill;
     }
 }

--- a/source/LottieData/SolidColorStroke.cs
+++ b/source/LottieData/SolidColorStroke.cs
@@ -41,9 +41,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
         /// <inheritdoc/>
         public override ShapeContentType ContentType => ShapeContentType.SolidColorStroke;
 
-        /// <inheritdoc/>
-        public override LottieObjectType ObjectType => LottieObjectType.SolidColorStroke;
-
         public override ShapeStrokeKind StrokeKind => ShapeStrokeKind.SolidColor;
     }
 }

--- a/source/LottieData/SolidLayer.cs
+++ b/source/LottieData/SolidLayer.cs
@@ -29,8 +29,5 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 
         /// <inheritdoc/>
         public override LayerType Type => LayerType.Solid;
-
-        /// <inheritdoc/>
-        public override LottieObjectType ObjectType => LottieObjectType.SolidLayer;
     }
 }

--- a/source/LottieData/TextLayer.cs
+++ b/source/LottieData/TextLayer.cs
@@ -24,8 +24,5 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 
         /// <inheritdoc/>
         public override LayerType Type => LayerType.Text;
-
-        /// <inheritdoc/>
-        public override LottieObjectType ObjectType => LottieObjectType.TextLayer;
     }
 }

--- a/source/LottieData/Transform.cs
+++ b/source/LottieData/Transform.cs
@@ -45,8 +45,5 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 
         /// <inheritdoc/>
         public override ShapeContentType ContentType => ShapeContentType.Transform;
-
-        /// <inheritdoc/>
-        public override LottieObjectType ObjectType => LottieObjectType.Transform;
     }
 }

--- a/source/LottieData/TrimPath.cs
+++ b/source/LottieData/TrimPath.cs
@@ -40,9 +40,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
         /// <inheritdoc/>
         public override ShapeContentType ContentType => ShapeContentType.TrimPath;
 
-        /// <inheritdoc/>
-        public override LottieObjectType ObjectType => LottieObjectType.TrimPath;
-
         /// <summary>
         /// Returns a new <see cref="TrimPath"/> that trims in the reverse direction of this
         /// <see cref="TrimPath"/>.

--- a/source/LottieReader/Serialization/Effects.cs
+++ b/source/LottieReader/Serialization/Effects.cs
@@ -130,8 +130,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
             return new DropShadowEffect(
                 effectName,
                 isEnabled,
-                direction: direction,
                 color: color,
+                direction: direction,
                 distance: distance,
                 isShadowOnly: isShadowOnly,
                 opacity: opacity,


### PR DESCRIPTION
These type tags evolved a little unevenly. The goal is that the tags represent each of the direct subclasses, but some of the tags were referring to subclasses of subclasses.