### PR TITLE
Fix crash on some cases of path groups.

### DIFF
--- a/Lottie-Windows.sln
+++ b/Lottie-Windows.sln
@@ -195,6 +195,7 @@ Global
 		source\LottieToWinComp\LottieToWinComp.projitems*{bcedf904-f986-42ec-a22d-e0662777b7f9}*SharedItemsImports = 5
 		source\NullablesAttributes\NullablesAttributes.projitems*{bcedf904-f986-42ec-a22d-e0662777b7f9}*SharedItemsImports = 5
 		source\CompMetadata\CompMetadata.projitems*{cb12d5ba-a6fe-41e2-b555-83c903cce92a}*SharedItemsImports = 5
+		source\DotLottie\DotLottie.projitems*{cb12d5ba-a6fe-41e2-b555-83c903cce92a}*SharedItemsImports = 5
 		source\GenericData\GenericData.projitems*{cb12d5ba-a6fe-41e2-b555-83c903cce92a}*SharedItemsImports = 5
 		source\LottieData\LottieData.projitems*{cb12d5ba-a6fe-41e2-b555-83c903cce92a}*SharedItemsImports = 5
 		source\LottieMetadata\LottieMetadata.projitems*{cb12d5ba-a6fe-41e2-b555-83c903cce92a}*SharedItemsImports = 5

--- a/source/LottieToWinComp/PathGeometryGroup.cs
+++ b/source/LottieToWinComp/PathGeometryGroup.cs
@@ -123,6 +123,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                         KeyFrame<PathGeometry>? nextKeyFrame = null;
                         if (frameIndex > 0)
                         {
+                            // If there was a previous key frame, get it. It is guaranteed
+                            // by the algorithm that all records[<frameIndex] have non-null values.
                             previousKeyFrame = records[frameIndex - 1].Geometries[pathIndex];
                         }
 

--- a/source/LottieToWinComp/PathGeometryGroup.cs
+++ b/source/LottieToWinComp/PathGeometryGroup.cs
@@ -157,6 +157,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                 }
             }
 
+            // Create the result by creating a key frame containing a PathGeometryGroup for each record,
+            // and use the "preferred easing" to ease between the key frames.
             result =
                 new Animatable<PathGeometryGroup>(
                     keyFrames:
@@ -251,6 +253,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                 yield return new PathGeometryGroupKeyFrames(currentFrame, geometries, preferredEasing!, easingIsCorrect);
 
                 // Advance the enumerators that are on the current frame unless they are completed.
+                // NOTE: we don't need to care about whether the enumerators are completed because
+                //       they will continue to return the last value, but we might as well avoid
+                //       some unnecessary work.
                 for (var i = 0; i < enumerators.Length; i++)
                 {
                     var enumerator = enumerators[i];

--- a/source/LottieToWinComp/Paths.cs
+++ b/source/LottieToWinComp/Paths.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         /// Groups multiple Shapes into a D2D geometry group.
         /// </summary>
         /// <returns>The shape.</returns>
-        public static CompositionShape TranslatePathGroupContent(ShapeContext context, IEnumerable<Path> paths)
+        public static CompositionShape TranslatePathGroupContent(ShapeContext context, IReadOnlyList<Path> paths)
         {
             var groupingSucceeded = PathGeometryGroup.TryGroupPaths(context, paths, out var grouped);
 

--- a/source/LottieToWinComp/Paths.cs
+++ b/source/LottieToWinComp/Paths.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         /// <returns>The shape.</returns>
         public static CompositionShape TranslatePathGroupContent(ShapeContext context, IReadOnlyList<Path> paths)
         {
-            var groupingSucceeded = PathGeometryGroup.TryGroupPaths(context, paths, out var grouped);
+            var grouped = PathGeometryGroup.GroupPaths(context, paths, out var groupingSucceeded);
 
             // If any of the paths have different directions we may not get the translation
             // right, so check that case and warn the user.


### PR DESCRIPTION
As a result of looking again at the algorithm that we use to combine animated paths I decided it needed a lot more documentation and to be rewritten to make sure that we handle all cases.