### PR TITLE
Validate marker names.

### DIFF
--- a/LottieGen/LottieJsonFileProcessor.cs
+++ b/LottieGen/LottieJsonFileProcessor.cs
@@ -122,6 +122,12 @@ sealed class LottieJsonFileProcessor
             return false;
         }
 
+        // Validate the Lottie.
+        foreach (var issue in LottieCompositionValidator.Validate(lottieComposition))
+        {
+            _reporter.WriteInfo(InfoType.Issue, IssueToString(_jsonFilePath, issue));
+        }
+
         _lottieStats = new Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Tools.Stats(lottieComposition);
 
         var codeGenResult = TryGenerateCode(lottieComposition);

--- a/source/Issues/LV0004.md
+++ b/source/Issues/LV0004.md
@@ -1,0 +1,15 @@
+﻿[comment]: # (name:NonUniqueMarkerName)
+[comment]: # (text:Marker name is not unique: {markerName}.)
+
+# Lottie-Windows Warning LV0004
+
+A Lottie file contains a marker name that is used for more than one marker.
+
+## Remarks
+While After Effects does not require markers to have unique names, most usages require each
+marker name them to refer to distinct positions in the Lottie file.
+
+## Resources
+
+* [Lottie-Windows repository](https://aka.ms/lottie)
+* [Questions and feedback via Github](https://github.com/windows-toolkit/Lottie-Windows/issues)

--- a/source/LottieData/LottieCompositionValidator.cs
+++ b/source/LottieData/LottieCompositionValidator.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 
             var validator = new LottieCompositionValidator(lottieComposition);
 
+            validator.ValidateUniqueMarkerNames();
             validator.ValidateLayerInPointBeforeOutPoint();
             validator.ValidateParentPointsToValidLayer();
             validator.ValidateNoParentCycles();
@@ -163,6 +164,18 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
                 {
                     _issues.InvalidLayerParent(layer.Parent.ToString());
                 }
+            }
+        }
+
+        /// <summary>
+        /// Validates that marker names are unique.
+        /// </summary>
+        void ValidateUniqueMarkerNames()
+        {
+            var nonUniqueMarkersByName = _lottieComposition.Markers.GroupBy(m => m.Name).Where(g => g.Count() > 1);
+            foreach (var group in nonUniqueMarkersByName)
+            {
+                _issues.NonUniqueMarkerName(group.Key);
             }
         }
     }

--- a/source/LottieData/ValidationIssues.cs
+++ b/source/LottieData/ValidationIssues.cs
@@ -38,6 +38,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData
 
         internal void InvalidLayerParent(string layerParent) => Report("LV0003", $"Invalid layer parent: {layerParent}.");
 
+        internal void NonUniqueMarkerName(string markerName) => Report("LV0004", $"Marker name is not unique: {markerName}.");
+
         void Report(string code, string description)
         {
             _issues.Add((code, description));

--- a/source/UIDataCodeGen/Serialization/CompositionObjectDgmlSerializer.cs
+++ b/source/UIDataCodeGen/Serialization/CompositionObjectDgmlSerializer.cs
@@ -26,6 +26,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
         static readonly Category CategoryEffectBrush = new Category("EffectBrush", Colors.LightGray);
         static readonly Category CategoryEllipse = new Category("Ellipse", Colors.DarkGoldenrod);
         static readonly Category CategoryEllipseAnimated = new Category("AnimatedEllipse", "Animated Ellipse", Colors.Goldenrod);
+        static readonly Category CategoryLayerVisual = new Category("LayerVisual", Colors.DarkRed);
+        static readonly Category CategoryLayerVisualAnimated = new Category("AnimatedLayerVisual", "Animated LayerVisual", Colors.Crimson);
         static readonly Category CategoryPath = new Category("Path", Colors.DarkOrange);
         static readonly Category CategoryPathAnimated = new Category("AnimatedPath", "Animated Path", Colors.Orange);
         static readonly Category CategoryRectangle = new Category("Rectangle", Colors.SandyBrown);
@@ -270,7 +272,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
             internal string? Id { get; private set; }
 
             // The links from this node to its children.
-            internal IEnumerable<ObjectData> Children => _children;
+            internal IReadOnlyList<ObjectData> Children => _children;
 
             // Called after the graph has been created. Do things here that depend on other nodes
             // in the graph.
@@ -327,8 +329,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
                             Category = GetCategory((CompositionSpriteShape)obj);
                             break;
                         case CompositionObjectType.ContainerVisual:
-                        case CompositionObjectType.LayerVisual:
                             Category = IsAnimatedCompositionObject ? CategoryContainerVisualAnimated : CategoryContainerVisual;
+                            break;
+                        case CompositionObjectType.LayerVisual:
+                            Category = IsAnimatedCompositionObject ? CategoryLayerVisualAnimated : CategoryLayerVisual;
                             break;
                         case CompositionObjectType.ShapeVisual:
                             Category = IsAnimatedCompositionObject ? CategoryShapeVisualAnimated : CategoryShapeVisual;
@@ -359,7 +363,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
                 }
             }
 
-            public override string? ToString() => Id;
+            public override string? ToString() => $"{Id} {Name}";
 
             bool IsAnimatedCompositionObject
             {
@@ -367,16 +371,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
                 {
                     var obj = (CompositionObject)Object;
                     return obj.Animators.Any() || obj.Properties.Animators.Any();
-                }
-            }
-
-            bool IsSpriteShapeWithAnimatedGeometory
-            {
-                get
-                {
-                    var obj = (CompositionSpriteShape)Object;
-                    var geometry = obj.Geometry;
-                    return geometry != null && (geometry.Animators.Any() || geometry.Properties.Animators.Any());
                 }
             }
 


### PR DESCRIPTION
Marker names don't have to be unique, but it's usually a bug if they are, so issue a warning if non-unique markers are found.
LottieGen didn't have validation turned on for some reason - now it does.
Small tweak in the DGML output: give LayerVisual its own category. This allows it to be displayed with a unique color.