### PR TITLE
Eliminate the default value checks from ConvertTo class.

### DIFF
--- a/source/LottieToWinComp/Brushes.cs
+++ b/source/LottieToWinComp/Brushes.cs
@@ -238,7 +238,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                 }
                 else
                 {
-                    sprite.StrokeThickness = ConvertTo.FloatDefaultIsOne(strokeThickness.InitialValue);
+                    sprite.StrokeThickness = ConvertTo.Float(strokeThickness.InitialValue);
                 }
             }
 
@@ -249,7 +249,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             // Lottie (and SVG/CSS) defines miter limit as (miter_length / stroke_thickness).
             // WUC defines miter limit as (miter_length / (2*stroke_thickness).
             // WUC requires the value not be < 1.
-            sprite.StrokeMiterLimit = ConvertTo.FloatDefaultIsOne(Math.Max(shapeStroke.MiterLimit / 2, 1));
+            sprite.StrokeMiterLimit = ConvertTo.Float(Math.Max(shapeStroke.MiterLimit / 2, 1));
 
             sprite.StrokeBrush = brush;
         }

--- a/source/LottieToWinComp/ConvertTo.cs
+++ b/source/LottieToWinComp/ConvertTo.cs
@@ -26,10 +26,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 
         public static float Float(Trim value) => (float)value.Value;
 
-        public static float? FloatDefaultIsZero(double value) => value == 0 ? null : (float?)value;
-
-        public static float? FloatDefaultIsOne(double value) => value == 1 ? null : (float?)value;
-
         public static float Opacity(Opacity value) => (float)value.Value;
 
         public static float PercentF(double value) => (float)value / 100F;
@@ -44,13 +40,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 
         public static Sn.Vector2 Vector2(float x) => new Sn.Vector2(x, x);
 
-        public static Sn.Vector2? Vector2DefaultIsOne(Vector3 vector2)
-            => vector2.X == 1 && vector2.Y == 1 ? null : (Sn.Vector2?)Vector2(vector2);
-
-        public static Sn.Vector2? Vector2DefaultIsZero(Sn.Vector2 vector2)
-            => vector2.X == 0 && vector2.Y == 0 ? null : (Sn.Vector2?)vector2;
-
-        public static Sn.Vector2 ClampedVector2(Vector3 vector3) => ClampedVector2((float)vector3.X, (float)vector3.Y);
+        public static Sn.Vector2? Vector2(Sn.Vector2 vector2) => (Sn.Vector2?)vector2;
 
         public static Sn.Vector2 ClampedVector2(LottieData.Vector2 vector2) => ClampedVector2((float)vector2.X, (float)vector2.Y);
 
@@ -59,17 +49,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         public static Sn.Vector3 Vector3(double x, double y, double z) => new Sn.Vector3((float)x, (float)y, (float)z);
 
         public static Sn.Vector3 Vector3(Vector3 vector3) => new Sn.Vector3((float)vector3.X, (float)vector3.Y, (float)vector3.Z);
-
-        public static Sn.Vector3? Vector3DefaultIsZero(Sn.Vector2 vector2)
-            => vector2.X == 0 && vector2.Y == 0 ? null : (Sn.Vector3?)Vector3(vector2);
-
-        public static Sn.Vector3? Vector3DefaultIsOne(Sn.Vector3 vector3)
-            => vector3.X == 1 && vector3.Y == 1 && vector3.Z == 1 ? null : (Sn.Vector3?)vector3;
-
-        public static Sn.Vector3? Vector3DefaultIsOne(Vector3 vector3)
-            => Vector3DefaultIsOne(new Sn.Vector3((float)vector3.X, (float)vector3.Y, (float)vector3.Z));
-
-        public static Sn.Vector3 Vector3(Sn.Vector2 vector2) => Vector3(vector2.X, vector2.Y, 0);
 
         public static Sn.Vector4 Vector4(WinCompData.Wui.Color color) => new Sn.Vector4(color.R, color.G, color.B, color.A);
 

--- a/source/LottieToWinComp/Masks.cs
+++ b/source/LottieToWinComp/Masks.cs
@@ -428,14 +428,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 
             var sourceVisualSurface = objectFactory.CreateVisualSurface();
             sourceVisualSurface.SourceVisual = sourceIntermediateParent;
-            sourceVisualSurface.SourceSize = ConvertTo.Vector2DefaultIsZero(size);
-            sourceVisualSurface.SourceOffset = ConvertTo.Vector2DefaultIsZero(offset);
+            sourceVisualSurface.SourceSize = ConvertTo.Vector2(size);
+            sourceVisualSurface.SourceOffset = ConvertTo.Vector2(offset);
             var sourceVisualSurfaceBrush = objectFactory.CreateSurfaceBrush(sourceVisualSurface);
 
             var destinationVisualSurface = objectFactory.CreateVisualSurface();
             destinationVisualSurface.SourceVisual = destinationIntermediateParent;
-            destinationVisualSurface.SourceSize = ConvertTo.Vector2DefaultIsZero(size);
-            destinationVisualSurface.SourceOffset = ConvertTo.Vector2DefaultIsZero(offset);
+            destinationVisualSurface.SourceSize = ConvertTo.Vector2(size);
+            destinationVisualSurface.SourceOffset = ConvertTo.Vector2(offset);
             var destinationVisualSurfaceBrush = objectFactory.CreateSurfaceBrush(destinationVisualSurface);
 
             var compositeEffect = new CompositeEffect();

--- a/source/LottieToWinComp/Transforms.cs
+++ b/source/LottieToWinComp/Transforms.cs
@@ -473,7 +473,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             }
             else
             {
-                container.RotationAngleInDegrees = ConvertTo.FloatDefaultIsZero(rotation.InitialValue.Degrees);
+                container.RotationAngleInDegrees = ConvertTo.Float(rotation.InitialValue.Degrees);
             }
 
 #if !NoScaling
@@ -497,7 +497,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 
                 if (!trimmedX.IsAnimated || !trimmedY.IsAnimated)
                 {
-                    container.Scale = ConvertTo.Vector2DefaultIsOne(new Vector3(trimmedX.InitialValue, trimmedY.InitialValue, 0) * (1 / 100.0));
+                    container.Scale = ConvertTo.Vector2(new Vector3(trimmedX.InitialValue, trimmedY.InitialValue, 0) * (1 / 100.0));
                 }
             }
             else
@@ -517,7 +517,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                 }
                 else
                 {
-                    container.Scale = ConvertTo.Vector2DefaultIsOne(trimmedScale.InitialValue * (1 / 100.0));
+                    container.Scale = ConvertTo.Vector2(trimmedScale.InitialValue * (1 / 100.0));
                 }
             }
 #endif
@@ -586,7 +586,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             }
             else
             {
-                container.CenterPoint = ConvertTo.Vector2DefaultIsZero(initialAnchor);
+                container.CenterPoint = ConvertTo.Vector2(initialAnchor);
             }
 
             // If the position or anchor are animated, the offset needs to be calculated via an expression.
@@ -609,7 +609,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                     {
                         if (!positionX.IsAnimated || !positionY.IsAnimated)
                         {
-                            container.Offset = ConvertTo.Vector2DefaultIsZero(initialPosition - initialAnchor);
+                            container.Offset = ConvertTo.Vector2(initialPosition - initialAnchor);
                         }
 
                         if (positionX.IsAnimated)
@@ -668,7 +668,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             if (!positionIsAnimated && !anchorIsAnimated)
             {
                 // Position and Anchor are static. No expression needed.
-                container.Offset = ConvertTo.Vector2DefaultIsZero(initialPosition - initialAnchor);
+                container.Offset = ConvertTo.Vector2(initialPosition - initialAnchor);
             }
 
             // Position is a Lottie-only concept. It offsets the object relative to the Anchor.

--- a/source/UIData/Tools/PropertyValueOptimizer.cs
+++ b/source/UIData/Tools/PropertyValueOptimizer.cs
@@ -50,6 +50,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.Tools
                     case CompositionObjectType.CompositionRadialGradientBrush:
                         OptimizeGradientBrush((CompositionGradientBrush)obj);
                         break;
+                    case CompositionObjectType.CompositionVisualSurface:
+                        OptimizeVisualSurfaceProperties((CompositionVisualSurface)obj);
+                        break;
                 }
             }
 
@@ -135,6 +138,27 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.Tools
         // Remove the centerpoint property if it's redundant, and convert properties to TransformMatrix if possible.
         static void OptimizeShapeProperties(CompositionShape obj)
         {
+            // Unset properties that are set to their default values.
+            if (obj.CenterPoint == Vector2.Zero)
+            {
+                obj.CenterPoint = null;
+            }
+
+            if (obj.Offset == Vector2.Zero)
+            {
+                obj.Offset = null;
+            }
+
+            if (obj.RotationAngleInDegrees == 0)
+            {
+                obj.RotationAngleInDegrees = null;
+            }
+
+            if (obj.Scale == Vector2.One)
+            {
+                obj.Scale = null;
+            }
+
             // Remove the centerpoint if it's not used by Scale or Rotation.
             var nonDefaultProperties = GetNonDefaultShapeProperties(obj);
             if (obj.CenterPoint.HasValue &&
@@ -405,6 +429,20 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.Tools
 
                     obj.TransformMatrix = combinedMatrix;
                 }
+            }
+        }
+
+        static void OptimizeVisualSurfaceProperties(CompositionVisualSurface obj)
+        {
+            // Unset properties that are set to their default values.
+            if (obj.SourceOffset == Vector2.Zero)
+            {
+                obj.SourceOffset = null;
+            }
+
+            if (obj.SourceSize == Vector2.Zero)
+            {
+                obj.SourceSize = null;
             }
         }
 

--- a/source/UIDataCodeGen/CodeGen/Cx/CxInstantiatorGenerator.cs
+++ b/source/UIDataCodeGen/CodeGen/Cx/CxInstantiatorGenerator.cs
@@ -793,7 +793,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen.Cx
                 var propertySetTypeName = PropertySetValueTypeName(properties[0].ActualType);
                 var valueInitializer = properties[0].ExposedType == PropertySetValueType.Color ? "ColorAsVector4(value)" : "value";
 
-                builder.WriteLine($"void {_sourceClassName}::Set{propertyType}Property(String^ propertyName, {typeName} value)");
+                builder.WriteLine($"void {_s.Namespace(SourceInfo.Namespace)}::{_sourceClassName}::Set{propertyType}Property(String^ propertyName, {typeName} value)");
                 builder.OpenScope();
 
                 var firstSeen = false;
@@ -819,7 +819,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen.Cx
                 builder.WriteLine($"if ({SourceInfo.ThemePropertiesFieldName} != nullptr)");
                 builder.OpenScope();
 
-                builder.WriteLine($"{SourceInfo.ThemePropertiesFieldName}.Insert{propertySetTypeName}(propertyName, {valueInitializer});");
+                builder.WriteLine($"{SourceInfo.ThemePropertiesFieldName}->Insert{propertySetTypeName}(propertyName, {valueInitializer});");
                 builder.CloseScope();
                 builder.CloseScope();
             }


### PR DESCRIPTION
The checking for default values should all be in the PropertyValueOptimizer.
Also, fix some bugs in the CX output.