### PR TITLE
Turn off multi-core builds in attempt to diagnose failures to build in master

### DIFF
--- a/build/build.cake
+++ b/build/build.cake
@@ -55,7 +55,7 @@ void MSBuildSolution(
     MSBuildSettings SettingsWithTarget(PlatformTarget platformTarget) =>
         new MSBuildSettings
         {
-            MaxCpuCount = 0,
+            MaxCpuCount = 1,
         }.WithTarget(target);
 
     MSBuildSettings SetProperties(MSBuildSettings settings)


### PR DESCRIPTION
This shouldn't be necessary, but master is on the floor right now and I need a PR to trigger another build.