### PR TITLE
Pin a version of Cake to work around Cake change that broke the build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -224,7 +224,8 @@ msbuild.binlog
 *.project.lock.json
 
 # Cake build directories
-/build/tools/
+/build/tools/**
+!/build/tools/packages.config
 
 # Lottie project internal development directories
 /internal/

--- a/build/tools/packages.config
+++ b/build/tools/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="Cake" version="0.37.0" />
+</packages>


### PR DESCRIPTION
An update to Cake broke the build. For now, pin the version.