### PR TITLE
Make progress values for markers slightly after their exact time

### DIFF
--- a/source/UIDataCodeGen/CodeGen/MarkerInfo.cs
+++ b/source/UIDataCodeGen/CodeGen/MarkerInfo.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Security.Cryptography;
 using Microsoft.Toolkit.Uwp.UI.Lottie.LottieMetadata;
 
 namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen

--- a/source/UIDataCodeGen/CodeGen/MarkerInfo.cs
+++ b/source/UIDataCodeGen/CodeGen/MarkerInfo.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography;
 using Microsoft.Toolkit.Uwp.UI.Lottie.LottieMetadata;
 
 namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
@@ -48,6 +49,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
 
         internal static IEnumerable<MarkerInfo> GetMarkerInfos(IEnumerable<Marker> markers)
         {
+            // Nudge the markers to prevent them from referring to the previous frame
+            // as a result of floating point imprecision.
+            markers = NudgeMarkersUp(markers);
+
             // Ensure the names are valid and distinct.
             var nameMap = markers.ToDictionary(m => m, m => SanitizeMarkerName(m.Name));
             EnsureNamesAreDistinct(nameMap);
@@ -61,6 +66,27 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
                 var startConstant = isZeroDuration ? baseName : $"{baseName}_start";
                 var endConstant = isZeroDuration ? null : $"{baseName}_end";
                 yield return new MarkerInfo(m, name, startConstant, endConstant);
+            }
+        }
+
+        // Adjust the frame numbers up by 1/100 of a frame. This is done
+        // to nudge the marker past any errors caused by floating point imprecision.
+        // It's always better to nudge a marker forward than to allow it to be
+        // rounded down, because even a small amount of rounding down can result in
+        // the previous frame being shown, whereas rounding up won't show the next
+        // frame until the error is as big as a whole frame.
+        static IEnumerable<Marker> NudgeMarkersUp(IEnumerable<Marker> markers)
+        {
+            foreach (var marker in markers)
+            {
+                var adjustedFrame = marker.Frame;
+
+                if (adjustedFrame.Number > 0)
+                {
+                    adjustedFrame += new Duration(0.01, marker.Duration);
+                }
+
+                yield return new Marker(marker.Name, adjustedFrame, marker.Duration);
             }
         }
 

--- a/source/UIDataCodeGen/CodeGen/Tables/LottieMarkersMonospaceTableFormatter.cs
+++ b/source/UIDataCodeGen/CodeGen/Tables/LottieMarkersMonospaceTableFormatter.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen.Tables
                 select (Row)new Row.ColumnData(
                     ColumnData.Create(m.Name, TextAlignment.Left),
                     ColumnData.Create(m.StartConstant, TextAlignment.Left),
-                    ColumnData.Create(m.StartFrame),
+                    ColumnData.Create((int)m.StartFrame),
                     ColumnData.Create(m.StartTime.TotalMilliseconds),
                     ColumnData.Create(stringifier.Float(m.StartProgress), TextAlignment.Left)
                 );


### PR DESCRIPTION
Marker values refer to the start of a frame of interest. Due to floating point imprecision we could end up with a marker that refers  to a progress value that is effectively just before the frame of interest. This can result in showing content from a previous frame.
This change attempts to fix it by nudging the marker progress values by 1/100th of a frame. This should guarantee that the marker is pointing to a time slightly after the start of the frame, even after the error caused by floating point imprecision.