### PR TITLE
Fixes for AnimatedIcon

### DIFF
--- a/source/LottieMetadata/Duration.cs
+++ b/source/LottieMetadata/Duration.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieMetadata
 #endif
     readonly struct Duration
     {
-        internal Duration(double frames, double fps)
+        public Duration(double frames, double fps)
         {
             if (frames < 0 || fps < 0)
             {
@@ -27,7 +27,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieMetadata
             FPS = fps;
         }
 
-        internal Duration(double frames, Duration other)
+        public Duration(double frames, Duration other)
         {
             Frames = frames;
             FPS = other.FPS;

--- a/source/LottieMetadata/Marker.cs
+++ b/source/LottieMetadata/Marker.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieMetadata
 #endif
     readonly struct Marker
     {
-        internal Marker(string name, Frame frame, Duration duration)
+        public Marker(string name, Frame frame, Duration duration)
         {
             Name = name;
             Frame = frame;

--- a/source/UIData/Tools/VisibilityAtProgress.cs
+++ b/source/UIData/Tools/VisibilityAtProgress.cs
@@ -1,0 +1,86 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.Tools
+{
+    readonly struct VisibilityAtProgress
+    {
+        internal VisibilityAtProgress(bool isVisible, float progress)
+            => (IsVisible, Progress) = (isVisible, progress);
+
+        internal bool IsVisible { get; }
+
+        internal float Progress { get; }
+
+        internal void Deconstruct(out bool isVisible, out float progress)
+        {
+            isVisible = IsVisible;
+            progress = Progress;
+        }
+
+        // Composes 2 list sequences of VisibilityAtProgress by ANDing them together.
+        // The resulting sequence is initially invisible, then visible when both a and
+        // b are visible, and invisible if either a or b are invisible.
+        internal static IEnumerable<VisibilityAtProgress> Compose(
+            VisibilityAtProgress[] a,
+            VisibilityAtProgress[] b)
+        {
+            // Get the visibilities in order, with any redundant visibilities removed.
+            var items = SanitizeSequence(a).Concat(SanitizeSequence(b)).OrderBy(v => v.Progress).ThenBy(v => !v.IsVisible).ToArray();
+
+            // The output is visible any time both a and b are visible at the same time.
+            var visibilityCounter = 0;
+
+            var initialInvisibilityOutput = false;
+
+            foreach (var item in items)
+            {
+                visibilityCounter += item.IsVisible ? 1 : -1;
+                if (visibilityCounter == 2)
+                {
+                    // Both a and b are now visible.
+                    if (!initialInvisibilityOutput)
+                    {
+                        initialInvisibilityOutput = true;
+                        if (item.Progress != 0)
+                        {
+                            yield return new VisibilityAtProgress(false, 0);
+                        }
+                    }
+
+                    yield return new VisibilityAtProgress(true, item.Progress);
+                }
+                else if (visibilityCounter == 1 && !item.IsVisible)
+                {
+                    // We were visible, but now we're not.
+                    yield return new VisibilityAtProgress(false, item.Progress);
+                }
+            }
+        }
+
+        // Orders the items in the sequence by Progress, and removes any redundant items.
+        static IEnumerable<VisibilityAtProgress> SanitizeSequence(IEnumerable<VisibilityAtProgress> sequence)
+        {
+            // Sequences start implicitly invisible.
+            var previousVisibility = false;
+
+            foreach (var item in sequence.OrderBy(v => v.Progress).ThenBy(v => !v.IsVisible))
+            {
+                // Ignore any repeats of the same visibility state.
+                if (previousVisibility != item.IsVisible)
+                {
+                    yield return item;
+                    previousVisibility = item.IsVisible;
+                }
+            }
+        }
+
+        public override string ToString() => $"{(IsVisible ? "Visible" : "Invisible")} @ {Progress}";
+    }
+}

--- a/source/UIData/Tools/VisibilityDescription.cs
+++ b/source/UIData/Tools/VisibilityDescription.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
+using System.Linq;
+
+namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.Tools
+{
+    readonly struct VisibilityDescription
+    {
+        internal VisibilityDescription(TimeSpan duration, VisibilityAtProgress[] sequence)
+            => (Duration, Sequence) = (duration, sequence);
+
+        /// <summary>
+        /// The time over which the <see cref="VisibilityDescription"/> is valide.
+        /// </summary>
+        internal TimeSpan Duration { get; }
+
+        /// <summary>
+        /// The sequence of visibilites, ordered by progress. Initial visibility
+        /// is "not visible". Each entry in the sequence represents a change to
+        /// a different visibility.
+        /// </summary>
+        internal VisibilityAtProgress[] Sequence { get; }
+
+        /// <summary>
+        /// Composes the given <see cref="VisibilityDescription"/>s by ANDing them
+        /// together.
+        /// </summary>
+        /// <returns>A composed <see cref="VisibilityDescription"/>.</returns>
+        internal static VisibilityDescription Compose(
+            in VisibilityDescription a,
+            in VisibilityDescription b)
+        {
+            if (a.Sequence.Length == 0)
+            {
+                return b;
+            }
+
+            if (b.Sequence.Length == 0)
+            {
+                return a;
+            }
+
+            if (a.Duration != b.Duration)
+            {
+                throw new InvalidOperationException();
+            }
+
+            if (a.Sequence.SequenceEqual(b.Sequence))
+            {
+                // They're identical.
+                return a;
+            }
+
+            // Combine the 2 sequences.
+            var composedSequence = VisibilityAtProgress.Compose(a.Sequence, b.Sequence).ToArray();
+
+            return new VisibilityDescription(a.Duration, composedSequence);
+        }
+    }
+}

--- a/source/UIData/Tools/VisibilityDescription.cs
+++ b/source/UIData/Tools/VisibilityDescription.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.Tools
             => (Duration, Sequence) = (duration, sequence);
 
         /// <summary>
-        /// The time over which the <see cref="VisibilityDescription"/> is valide.
+        /// The time over which the <see cref="VisibilityDescription"/> is valid.
         /// </summary>
         internal TimeSpan Duration { get; }
 

--- a/source/UIData/UIData.projitems
+++ b/source/UIData/UIData.projitems
@@ -16,5 +16,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Tools\PropertyValueOptimizer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Tools\PropertyId.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Tools\Stats.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Tools\VisibilityAtProgress.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Tools\VisibilityDescription.cs" />
   </ItemGroup>
 </Project>

--- a/source/UIDataCodeGen/CodeGen/MarkerInfo.cs
+++ b/source/UIDataCodeGen/CodeGen/MarkerInfo.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Security.Cryptography;
 using Microsoft.Toolkit.Uwp.UI.Lottie.LottieMetadata;
 
 namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen

--- a/source/UIDataCodeGen/CodeGen/MarkerInfo.cs
+++ b/source/UIDataCodeGen/CodeGen/MarkerInfo.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography;
 using Microsoft.Toolkit.Uwp.UI.Lottie.LottieMetadata;
 
 namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
@@ -48,6 +49,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
 
         internal static IEnumerable<MarkerInfo> GetMarkerInfos(IEnumerable<Marker> markers)
         {
+            // Nudge the markers to prevent them from referring to the previous frame
+            // as a result of floating point imprecision.
+            markers = NudgeMarkersUp(markers);
+
             // Ensure the names are valid and distinct.
             var nameMap = markers.ToDictionary(m => m, m => SanitizeMarkerName(m.Name));
             EnsureNamesAreDistinct(nameMap);
@@ -61,6 +66,27 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
                 var startConstant = isZeroDuration ? baseName : $"{baseName}_start";
                 var endConstant = isZeroDuration ? null : $"{baseName}_end";
                 yield return new MarkerInfo(m, name, startConstant, endConstant);
+            }
+        }
+
+        // Adjust the frame numbers up by 1/100 of a frame. This is done
+        // to nudge the marker past any errors caused by floating point imprecision.
+        // It's always better to nudge a marker forward than to allow it to be
+        // rounded down, because even a small amount of rounding down can result in
+        // the previous frame being shown, whereas rounding up won't show the next
+        // frame until the error is as big as a whole frame.
+        static IEnumerable<Marker> NudgeMarkersUp(IEnumerable<Marker> markers)
+        {
+            foreach (var marker in markers)
+            {
+                var adjustedFrame = marker.Frame;
+
+                if (adjustedFrame.Number > 0)
+                {
+                    adjustedFrame += new Duration(0.01, marker.Duration);
+                }
+
+                yield return new Marker(marker.Name, adjustedFrame, marker.Duration);
             }
         }
 

--- a/source/UIDataCodeGen/CodeGen/Tables/LottieMarkersMonospaceTableFormatter.cs
+++ b/source/UIDataCodeGen/CodeGen/Tables/LottieMarkersMonospaceTableFormatter.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen.Tables
                 select (Row)new Row.ColumnData(
                     ColumnData.Create(m.Name, TextAlignment.Left),
                     ColumnData.Create(m.StartConstant, TextAlignment.Left),
-                    ColumnData.Create(m.StartFrame),
+                    ColumnData.Create((int)m.StartFrame),
                     ColumnData.Create(m.StartTime.TotalMilliseconds),
                     ColumnData.Create(stringifier.Float(m.StartProgress), TextAlignment.Left)
                 );


### PR DESCRIPTION
2 fixes for issues that became apparent as we started using markers more for AnimatedIcon.

1. Marker values refer to the start of a frame of interest. Due to floating point imprecision we could end up with a marker that refers to a progress value that is effectively just before the frame of interest. This can result in showing content from a previous frame.
This change attempts to fix it by nudging the marker progress values by 1/100th of a frame. This should guarantee that the marker is pointing to a time slightly after the start of the frame, even after the error caused by floating point imprecision.
2. There was a bug in the visibility optimizer that would cause some parts of the animation to remain visible when they should no longer be.