### PR TITLE
Fix some missing simplifications in Composition expressions.

### DIFF
--- a/source/WinCompData/Expressions/Boolean.cs
+++ b/source/WinCompData/Expressions/Boolean.cs
@@ -31,8 +31,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
                 _text = text;
             }
 
-            /// <inheritdoc/>
-            protected override bool IsAtomic => true;
+            internal override Precedence Precedence => Precedence.Atomic;
 
             /// <inheritdoc/>
             // We don't actually know the operation count because the text could
@@ -97,8 +96,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
                 Value = value;
             }
 
-            /// <inheritdoc/>
-            protected override bool IsAtomic => true;
+            internal override Precedence Precedence => Precedence.Atomic;
 
             /// <inheritdoc/>
             public override int OperationsCount => 0;

--- a/source/WinCompData/Expressions/Boolean.cs
+++ b/source/WinCompData/Expressions/Boolean.cs
@@ -78,9 +78,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
                     return new Literal(literalLeft.Value < literalRight.Value);
                 }
 
-                return left != Left || right != Right
-                    ? new LessThan(left, right)
-                    : this;
+                return ReferenceEquals(left, Left) && ReferenceEquals(right, Right)
+                    ? this
+                    : new LessThan(left, right);
             }
 
             /// <inheritdoc/>

--- a/source/WinCompData/Expressions/Color.cs
+++ b/source/WinCompData/Expressions/Color.cs
@@ -25,8 +25,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
                 _text = text;
             }
 
-            /// <inheritdoc/>
-            protected override bool IsAtomic => true;
+            internal override Precedence Precedence => Precedence.Atomic;
 
             /// <inheritdoc/>
             // We don't actually know the operation count because the text could
@@ -58,8 +57,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
 
             public Scalar A { get; }
 
-            /// <inheritdoc/>
-            protected override bool IsAtomic => true;
+            internal override Precedence Precedence => Precedence.Atomic;
 
             /// <inheritdoc/>
             public override int OperationsCount => R.OperationsCount + G.OperationsCount + B.OperationsCount + A.OperationsCount;

--- a/source/WinCompData/Expressions/Color.cs
+++ b/source/WinCompData/Expressions/Color.cs
@@ -72,9 +72,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
                 var b = B.Simplified;
                 var a = A.Simplified;
 
-                return r != R || g != G || b != B || a != A
-                            ? new Constructed(r, g, b, a)
-                            : this;
+                return
+                    ReferenceEquals(r, R) &&
+                    ReferenceEquals(g, G) &&
+                    ReferenceEquals(b, B) &&
+                    ReferenceEquals(a, A)
+                        ? this
+                        : new Constructed(r, g, b, a);
             }
 
             /// <inheritdoc/>

--- a/source/WinCompData/Expressions/Expression.cs
+++ b/source/WinCompData/Expressions/Expression.cs
@@ -71,10 +71,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
         public abstract string ToText();
 
         /// <summary>
-        /// Gets a value indicating whether the string form of the expression can be unambigiously
-        /// parsed without parentheses.
+        /// Gets a value indicating the relative precedence of the string form of the expression.
+        /// This is used to determine whether parentheses are necessary in order to
+        /// override the left-to-right evaluation of the parent expression.
         /// </summary>
-        protected virtual bool IsAtomic => false;
+        internal virtual Precedence Precedence => Precedence.Unknown;
 
         /// <summary>
         /// The number of operations in this <see cref="Expression"/>. An operation is something that
@@ -83,7 +84,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
         public abstract int OperationsCount { get; }
 
         protected static string Parenthesize(Expression expression)
-            => expression.IsAtomic
+            => expression.Precedence == Precedence.Atomic
                 ? expression.ToText()
                 : $"({expression.ToText()})";
 

--- a/source/WinCompData/Expressions/Matrix3x2.cs
+++ b/source/WinCompData/Expressions/Matrix3x2.cs
@@ -57,8 +57,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
                 _text = text;
             }
 
-            /// <inheritdoc/>
-            protected override bool IsAtomic => true;
+            internal override Precedence Precedence => Precedence.Atomic;
 
             /// <inheritdoc/>
             // We don't actually know the operation count because the text could
@@ -119,7 +118,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
             protected override string CreateExpressionText()
                 => $"Matrix3x2({Parenthesize(_11)},{Parenthesize(_12)},{Parenthesize(_21)},{Parenthesize(_22)},{Parenthesize(_31)},{Parenthesize(_32)})";
 
-            protected override bool IsAtomic => true;
+            internal override Precedence Precedence => Precedence.Atomic;
         }
 
         Scalar Channel(string channelName) => Expressions.Scalar.Channel(this, channelName);

--- a/source/WinCompData/Expressions/Matrix3x2.cs
+++ b/source/WinCompData/Expressions/Matrix3x2.cs
@@ -108,11 +108,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
                 var m32 = _32.Simplified;
 
                 return
-                    m11 != _11 || m12 != _12 ||
-                    m21 != _21 || m22 != _22 ||
-                    m31 != _31 || m32 != _32
-                        ? new Constructed(m11, m12, m21, m22, m31, m32)
-                        : this;
+                    ReferenceEquals(m11, _11) && ReferenceEquals(m12, _12) &&
+                    ReferenceEquals(m21, _21) && ReferenceEquals(m22, _22) &&
+                    ReferenceEquals(m31, _31) && ReferenceEquals(m32, _32)
+                        ? this
+                        : new Constructed(m11, m12, m21, m22, m31, m32);
             }
 
             /// <inheritdoc/>

--- a/source/WinCompData/Expressions/Precedence.cs
+++ b/source/WinCompData/Expressions/Precedence.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
+{
+    /// <summary>
+    /// Determines the relative precedence of an operation in the string
+    /// form of an expression. For example, multiplication has higher
+    /// precedence than addition.
+    /// </summary>
+    enum Precedence : uint
+    {
+        Unknown = 0,
+        Subtraction,
+        Addition,
+        Multiplication,
+        Division,
+        Atomic,
+    }
+}

--- a/source/WinCompData/Expressions/Scalar.cs
+++ b/source/WinCompData/Expressions/Scalar.cs
@@ -257,7 +257,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
                     ? Parenthesize(Right)
                     : Right.ToText();
 
-                return $"Max({left}, {right})";
+                return $"Max({left},{right})";
             }
         }
 
@@ -297,7 +297,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
                     ? Parenthesize(Right)
                     : Right.ToText();
 
-                return $"Min({left}, {right})";
+                return $"Min({left},{right})";
             }
         }
 

--- a/source/WinCompData/Expressions/Scalar.cs
+++ b/source/WinCompData/Expressions/Scalar.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.ComponentModel;
 using System.Globalization;
 
 namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
@@ -72,9 +73,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
                     return new Literal(literalLeft.Value + literalRight.Value);
                 }
 
-                return left != Left || right != Right
-                    ? new Add(left, right)
-                    : this;
+                return ReferenceEquals(left, Left) && ReferenceEquals(right, Right)
+                    ? this
+                    : new Add(left, right);
             }
 
             /// <inheritdoc/>
@@ -157,9 +158,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
                     return new Literal(literalLeft.Value / literalRight.Value);
                 }
 
-                return left != Left || right != Right
-                    ? new Divide(left, right)
-                    : this;
+                return ReferenceEquals(left, Left) && ReferenceEquals(right, Right)
+                    ? this
+                    : new Divide(left, right);
             }
 
             /// <inheritdoc/>
@@ -217,9 +218,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
                     return new Literal(Math.Max(literalLeft.Value, literalRight.Value));
                 }
 
-                return left != Left || right != Right
-                    ? new Max(left, right)
-                    : this;
+                return ReferenceEquals(left, Left) && ReferenceEquals(right, Right)
+                    ? this
+                    : new Max(left, right);
             }
 
             /// <inheritdoc/>
@@ -246,9 +247,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
                     return new Literal(Math.Min(literalLeft.Value, literalRight.Value));
                 }
 
-                return left != Left || right != Right
-                    ? new Min(left, right)
-                    : this;
+                return ReferenceEquals(left, Left) && ReferenceEquals(right, Right)
+                    ? this
+                    : new Min(left, right);
             }
 
             /// <inheritdoc/>
@@ -300,9 +301,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
                     return new Literal(literalLeft.Value * literalRight.Value);
                 }
 
-                return left != Left || right != Right
-                    ? new Multiply(left, right)
-                    : this;
+                return ReferenceEquals(left, Left) && ReferenceEquals(right, Right)
+                    ? this
+                    : new Multiply(left, right);
             }
 
             /// <inheritdoc/>
@@ -360,9 +361,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
                     }
                 }
 
-                return value != Value || power != Power
-                    ? new Pow(value, power)
-                    : this;
+                return ReferenceEquals(value, Value) && ReferenceEquals(power, Power)
+                    ? this
+                    : new Pow(value, power);
             }
 
             protected override bool IsAtomic => true;
@@ -417,9 +418,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
             protected override Scalar Simplify()
             {
                 var valueSimplified = _value.Simplified;
-                return valueSimplified != _value
-                    ? new Subchannel<T>(valueSimplified, _channelName)
-                    : this;
+                return ReferenceEquals(valueSimplified, _value)
+                    ? this
+                    : new Subchannel<T>(valueSimplified, _channelName);
             }
 
             /// <inheritdoc/>
@@ -453,9 +454,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
                     return new Literal(literalLeft.Value - literalRight.Value);
                 }
 
-                return left != Left || right != Right
-                    ? new Subtract(left, right)
-                    : this;
+                return ReferenceEquals(left, Left) && ReferenceEquals(right, Right)
+                    ? this
+                    : new Subtract(left, right);
             }
 
             /// <inheritdoc/>
@@ -497,12 +498,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
                     return f;
                 }
 
-                if (c != Condition || t != TrueValue || f != FalseValue)
-                {
-                    return new Ternary(c, t, f);
-                }
-
-                return this;
+                return
+                    ReferenceEquals(c, Condition) &&
+                    ReferenceEquals(t, TrueValue) &&
+                    ReferenceEquals(f, FalseValue)
+                        ? this
+                        : new Ternary(c, t, f);
             }
 
             /// <inheritdoc/>

--- a/source/WinCompData/Expressions/Vector2.cs
+++ b/source/WinCompData/Expressions/Vector2.cs
@@ -61,9 +61,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
                     return left;
                 }
 
-                return left != Left || right != Right
-                    ? new Add(left, right)
-                    : this;
+                return ReferenceEquals(left, Left) && ReferenceEquals(right, Right)
+                    ? this
+                    : new Add(left, right);
             }
 
             /// <inheritdoc/>
@@ -133,9 +133,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
                 var x = X.Simplified;
                 var y = Y.Simplified;
 
-                return x != X || y != Y
-                    ? new Constructed(x, y)
-                    : this;
+                return ReferenceEquals(x, X) && ReferenceEquals(y, Y)
+                    ? this
+                    : new Constructed(x, y);
             }
 
             /// <inheritdoc/>
@@ -173,9 +173,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
                     return left;
                 }
 
-                return left != Left || right != Right
-                    ? new Divide(left, right)
-                    : this;
+                return ReferenceEquals(left, Left) && ReferenceEquals(right, Right)
+                    ? this
+                    : new Divide(left, right);
             }
 
             /// <inheritdoc/>
@@ -216,9 +216,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
                     return left;
                 }
 
-                return left != Left || right != Right
-                    ? new Multiply(left, right)
-                    : this;
+                return ReferenceEquals(left, Left) && ReferenceEquals(right, Right)
+                    ? this
+                    : new Multiply(left, right);
             }
 
             /// <inheritdoc/>
@@ -261,9 +261,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
                     return right;
                 }
 
-                return left != Left || right != Right
-                    ? new ScalarMultiply(left, right)
-                    : this;
+                return ReferenceEquals(left, Left) && ReferenceEquals(right, Right)
+                    ? this
+                    : new ScalarMultiply(left, right);
             }
 
             /// <inheritdoc/>
@@ -291,9 +291,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
                     return left;
                 }
 
-                return left != Left || right != Right
-                    ? new Subtract(left, right)
-                    : this;
+                return ReferenceEquals(left, Left) && ReferenceEquals(right, Right)
+                    ? this
+                    : new Subtract(left, right);
             }
 
             /// <inheritdoc/>

--- a/source/WinCompData/Expressions/Vector3.cs
+++ b/source/WinCompData/Expressions/Vector3.cs
@@ -41,6 +41,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
             {
             }
 
+            private protected override string ExpressionOperator => "+";
+
+            internal override Precedence Precedence => Precedence.Addition;
+
             /// <inheritdoc/>
             protected override Vector3 Simplify()
             {
@@ -61,14 +65,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
                     ? this
                     : new Add(left, right);
             }
-
-            /// <inheritdoc/>
-            protected override string CreateExpressionText()
-            {
-                var left = Left is Add ? Left.ToText() : Parenthesize(Left);
-                var right = Right is Add ? Right.ToText() : Parenthesize(Right);
-                return $"{left}+{right}";
-            }
         }
 
         internal sealed class Asserted : Vector3
@@ -80,8 +76,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
                 _text = text;
             }
 
-            /// <inheritdoc/>
-            protected override bool IsAtomic => true;
+            internal override Precedence Precedence => Precedence.Atomic;
 
             /// <inheritdoc/>
             // We don't actually know the operation count because the text could
@@ -104,8 +99,24 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
 
             public Vector3 Right { get; }
 
+            private protected abstract string ExpressionOperator { get; }
+
             /// <inheritdoc/>
             public override int OperationsCount => Left.OperationsCount + Right.OperationsCount;
+
+            /// <inheritdoc/>
+            protected override sealed string CreateExpressionText()
+            {
+                var left = Left.Precedence == Precedence.Unknown
+                    ? Parenthesize(Left)
+                    : Left.ToText();
+
+                var right = Right.Precedence != Precedence && Right.Precedence != Precedence.Atomic
+                    ? Parenthesize(Right)
+                    : Right.ToText();
+
+                return $"{left}{ExpressionOperator}{right}";
+            }
         }
 
         internal sealed class Constructed : Vector3
@@ -126,6 +137,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
             /// <inheritdoc/>
             public override int OperationsCount => X.OperationsCount + Y.OperationsCount + Z.OperationsCount;
 
+            internal override Precedence Precedence => Precedence.Atomic;
+
             /// <inheritdoc/>
             protected override Vector3 Simplify()
             {
@@ -141,8 +154,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
             /// <inheritdoc/>
             protected override string CreateExpressionText()
                 => $"Vector3({X},{Y},{Z})";
-
-            protected override bool IsAtomic => true;
         }
 
         internal sealed class ScalarMultiply : Vector3
@@ -159,6 +170,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
 
             /// <inheritdoc/>
             public override int OperationsCount => Left.OperationsCount + Right.OperationsCount;
+
+            internal override Precedence Precedence => Precedence.Multiplication;
 
             /// <inheritdoc/>
             protected override Vector3 Simplify()
@@ -183,9 +196,17 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
 
             /// <inheritdoc/>
             protected override string CreateExpressionText()
-                => Left is Scalar.BinaryExpression.Multiply left
-                    ? $"{left.ToText()}*{Parenthesize(Right)}"
-                    : $"{Parenthesize(Left)}*{Parenthesize(Right)}";
+            {
+                var left = Left.Precedence == Precedence.Unknown
+                    ? Parenthesize(Left)
+                    : Left.ToText();
+
+                var right = Right.Precedence != Precedence && Right.Precedence != Precedence.Atomic
+                    ? Parenthesize(Right)
+                    : Right.ToText();
+
+                return $"{left}*{right}";
+            }
         }
 
         Scalar Channel(string channelName) => Expressions.Scalar.Channel(this, channelName);

--- a/source/WinCompData/Expressions/Vector3.cs
+++ b/source/WinCompData/Expressions/Vector3.cs
@@ -57,9 +57,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
                     return left;
                 }
 
-                return left != Left || right != Right
-                    ? new Add(left, right)
-                    : this;
+                return ReferenceEquals(left, Left) && ReferenceEquals(right, Right)
+                    ? this
+                    : new Add(left, right);
             }
 
             /// <inheritdoc/>
@@ -133,7 +133,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
                 var y = Y.Simplified;
                 var z = Z.Simplified;
 
-                return x == X && y == Y && z == Z
+                return ReferenceEquals(x, X) && ReferenceEquals(y, Y) && ReferenceEquals(z, Z)
                     ? this
                     : Vector3(x, y, z);
             }
@@ -176,9 +176,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
                     return right;
                 }
 
-                return left != Left || right != Right
-                    ? new ScalarMultiply(left, right)
-                    : this;
+                return ReferenceEquals(left, Left) && ReferenceEquals(right, Right)
+                    ? this
+                    : new ScalarMultiply(left, right);
             }
 
             /// <inheritdoc/>

--- a/source/WinCompData/Expressions/Vector4.cs
+++ b/source/WinCompData/Expressions/Vector4.cs
@@ -82,9 +82,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
                 var z = Z.Simplified;
                 var w = W.Simplified;
 
-                return x == X && y == Y && z == Z && w == W
-                    ? this
-                    : new Constructed(x, y, z, w);
+                return
+                    ReferenceEquals(x, X) &&
+                    ReferenceEquals(y, Y) &&
+                    ReferenceEquals(z, Z) &&
+                    ReferenceEquals(w, W)
+                        ? this
+                        : new Constructed(x, y, z, w);
             }
 
             /// <inheritdoc/>

--- a/source/WinCompData/Expressions/Vector4.cs
+++ b/source/WinCompData/Expressions/Vector4.cs
@@ -41,8 +41,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
                 _text = text;
             }
 
-            /// <inheritdoc/>
-            protected override bool IsAtomic => true;
+            internal override Precedence Precedence => Precedence.Atomic;
 
             /// <inheritdoc/>
             // We don't actually know the operation count because the text could
@@ -71,6 +70,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
 
             public override Scalar W { get; }
 
+            internal override Precedence Precedence => Precedence.Atomic;
+
             /// <inheritdoc/>
             public override int OperationsCount => X.OperationsCount + Y.OperationsCount + Z.OperationsCount + W.OperationsCount;
 
@@ -94,8 +95,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
             /// <inheritdoc/>
             protected override string CreateExpressionText()
                 => $"Vector4({X},{Y},{Z},{W})";
-
-            protected override bool IsAtomic => true;
         }
 
         Scalar Channel(string channelName) => Expressions.Scalar.Channel(this, channelName);

--- a/source/WinCompData/WinCompData.projitems
+++ b/source/WinCompData/WinCompData.projitems
@@ -54,6 +54,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Expressions\Boolean.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Expressions\Color.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Expressions\Expression_.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Expressions\Precedence.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Expressions\Scalar.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Expressions\Expression.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Expressions\ExpressionType.cs" />

--- a/tests/LottieGenCorpus.ps1
+++ b/tests/LottieGenCorpus.ps1
@@ -24,9 +24,12 @@ Param(
 )
 
 # Find the most recently built LottieGen.dll.
+# Sort by LastWriteTime rather than CreationTime because the compiler will
+#  reuse existing output files such that the CreationTime does not represent
+#  the time when the compilation was done.
 $lottieGenExe = 
-    Get-ChildItem LottieGen.exe -r -path "$PSScriptRoot\..\LottieGen\bin\" | 
-    Sort-Object -Property 'CreationTime' -Desc | 
+    Get-ChildItem LottieGen.exe -r -path "$PSScriptRoot\..\LottieGen\dotnettool\bin\" | 
+    Sort-Object -Property 'LastWriteTime' -Desc | 
     Select-Object -first 1
 
 if (!$lottieGenExe)


### PR DESCRIPTION
The logic for determining whether an expression could be simplified was sometimes wrong because it ended up hitting an overridden equality operator which compared the already-simplified values.

Also fixed the test script to look at last write time when determining which is the latest build of LottieGen.exe to run. We were looking at creation time, but it turns out that when the compiler builds, it doesn't cause the creation time to be updated if the output file previously existed. Our test script could accidentally use a release build when the latest build was actually a debug build, resulting in the test running on an old build.