### PR TITLE
Fix for security issue in System.Text.Encodings.Web v4.7.1.

### DIFF
--- a/Lottie-Windows/Lottie-Windows.csproj
+++ b/Lottie-Windows/Lottie-Windows.csproj
@@ -29,7 +29,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.UI.Xaml">
-      <Version>2.4.2</Version>
+      <Version>2.5.0</Version>
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </PackageReference>
@@ -37,8 +37,8 @@
     <PackageReference Include="System.Numerics.Vectors">
       <Version>4.5.0</Version>
     </PackageReference>
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
-    <PackageReference Include="System.Text.Json" Version="4.7.2" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
+    <PackageReference Include="System.Text.Json" Version="5.0.1" />
     <PackageReference Include="System.ValueTuple">
       <Version>4.5.0</Version>
     </PackageReference>

--- a/LottieGen/MSBuildTask/LottieGen.MsBuild.csproj
+++ b/LottieGen/MSBuildTask/LottieGen.MsBuild.csproj
@@ -21,7 +21,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.8.0" />
+        <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.9.0" />
     </ItemGroup>
 
     <!--
@@ -29,7 +29,7 @@
       been built and published so we can copy its outputs.
     -->
     <Target Name="EnsureLottieGenExeIsBuilt">
-        <MSBuild Projects="..\win-x64\LottieGen.win-x64.csproj" Targets="Publish"/>
+        <MSBuild Projects="..\win-x64\LottieGen.win-x64.csproj" Targets="Publish" />
     </Target>
 
     <!-- Generates the .nuspec file. -->

--- a/LottieViewer/LottieViewer.csproj
+++ b/LottieViewer/LottieViewer.csproj
@@ -212,19 +212,19 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.10</Version>
+      <Version>6.2.12</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml">
-      <Version>2.4.2</Version>
+      <Version>2.5.0</Version>
     </PackageReference>
     <PackageReference Include="System.Memory">
       <Version>4.5.4</Version>
     </PackageReference>
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
-      <Version>4.7.1</Version>
+      <Version>5.0.0</Version>
     </PackageReference>
     <PackageReference Include="System.Text.Json">
-      <Version>4.7.2</Version>
+      <Version>5.0.1</Version>
     </PackageReference>
     <PackageReference Include="Win2D.uwp">
       <Version>1.25.0</Version>

--- a/dlls/GenericData/GenericData.dll.csproj
+++ b/dlls/GenericData/GenericData.dll.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Memory" Version="4.5.4" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/dlls/LottieData/LottieData.dll.csproj
+++ b/dlls/LottieData/LottieData.dll.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Memory" Version="4.5.4" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dlls/LottieMetadata/LottieMetadata.dll.csproj
+++ b/dlls/LottieMetadata/LottieMetadata.dll.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Memory" Version="4.5.4" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/dlls/LottieReader/LottieReader.dll.csproj
+++ b/dlls/LottieReader/LottieReader.dll.csproj
@@ -10,7 +10,7 @@
   <Import Project="..\..\source\LottieReader\LottieReader.projitems" Label="Shared" />
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="4.7.2" />
+    <PackageReference Include="System.Text.Json" Version="5.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/LottieSamples/LottieSamples.csproj
+++ b/samples/LottieSamples/LottieSamples.csproj
@@ -259,13 +259,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.10</Version>
+      <Version>6.2.12</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Lottie">
-      <Version>6.1.0</Version>
+      <Version>7.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml">
-      <Version>2.4.2</Version>
+      <Version>2.5.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.0.0-build.{height}",
+  "version": "7.0.1-build.{height}",
   "publicReleaseRefSpec": [
     "^refs/heads/master$", // we release out of master
     "^refs/heads/dev$", // we release out of dev


### PR DESCRIPTION
Error reported:
Microsoft.Toolkit.Uwp.UI.Lottie v7 uses System.Text.Encodings.Web v4.7.1 which has a high severity security vulnerability and as such doesn't pass component governance

This upgrades all of the runtime NuGet packages to the latest version.