### PR TITLE
Update Lottie to use 5.0.1 of System.Text.Encodings.Web

### DIFF
--- a/Lottie-Windows/Lottie-Windows.csproj
+++ b/Lottie-Windows/Lottie-Windows.csproj
@@ -38,6 +38,7 @@
       <Version>4.5.0</Version>
     </PackageReference>
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />
     <PackageReference Include="System.Text.Json" Version="5.0.1" />
     <PackageReference Include="System.ValueTuple">
       <Version>4.5.0</Version>


### PR DESCRIPTION
Certain versions of System.Text.Encodings.Web are flagged as having possible security vulnerabilities. Version 5.0.1 is the newest version that is marked as safe.