### PR TITLE
Fixes for MSBuild task

### DIFF
--- a/LottieGen/MSBuildTask/LottieGen.MsBuild.props
+++ b/LottieGen/MSBuildTask/LottieGen.MsBuild.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask
     TaskName="LottieGen.Task.LottieGen"
-    AssemblyFile="$(MsBuildThisFileDirectory)..\bin\LottieGen.MsBuild.dll"/>
+    AssemblyFile="$(MsBuildThisFileDirectory)..\..\bin\LottieGen.MsBuild.dll"/>
 </Project>
 


### PR DESCRIPTION
- Parameter validation no longer fails on valid params
- Fixed props file path to LottieGen dll (#443)
- Fixed path generation for LottieGen exe
- Converted parameter types which are not supported by MSBuild to acceptable types
- Added escaping to command-line args to avoid mangling file paths