### PR TITLE
Fix issue with nullable

### DIFF
--- a/source/UIDataCodeGen/CodeGen/InstantiatorGeneratorBase.cs
+++ b/source/UIDataCodeGen/CodeGen/InstantiatorGeneratorBase.cs
@@ -2911,7 +2911,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
                 WriteCreateAssignment(builder, node, $"effectFactory{Deref}CreateBrush()");
                 InitializeCompositionBrush(builder, obj, node);
 
-                IEnumerable<CompositionEffectSourceParameter> sources = effect.Type switch
+                IEnumerable<CompositionEffectSourceParameter?> sources = effect.Type switch
                 {
                     Mgce.GraphicsEffectType.CompositeEffect => ((Mgce.CompositeEffect)effect).Sources,
                     Mgce.GraphicsEffectType.GaussianBlurEffect => new[] { ((Mgce.GaussianBlurEffect)effect).Source },


### PR DESCRIPTION
An issue was found with a recent PR build where we were returning "((Mgce.GaussianBlurEffect)effect).Source" for list that was not of nullable types. 