### PR TITLE
Gradient fill for rectangle(rounded rectangle) shape fixed

### DIFF
--- a/source/LottieToWinComp/Brushes.cs
+++ b/source/LottieToWinComp/Brushes.cs
@@ -431,7 +431,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 
             if (!offset.IsAnimated && !value.IsAnimated)
             {
-                return ConvertTo.Vector2(value.InitialValue) + offset.OffsetValue!;
+                return ConvertTo.Vector2(value.InitialValue) + offset.OffsetValue;
             }
 
             // Animate source property first.
@@ -443,8 +443,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 
             // Create expression that offsets source property by origin offset.
             WinCompData.Expressions.Vector2 expression = offset.IsAnimated ?
-                ExpressionFactory.OriginOffsetExressionAdded(sourcePropertyName, offset.OffsetExpression!) :
-                ExpressionFactory.OriginOffsetValueAdded(sourcePropertyName, (Sn.Vector2)offset.OffsetValue!);
+                ExpressionFactory.OriginOffsetExressionAdded(sourcePropertyName, offset.OffsetExpression) :
+                ExpressionFactory.OriginOffsetValueAdded(sourcePropertyName, offset.OffsetValue);
 
             var expressionAnimation = context.ObjectFactory.CreateExpressionAnimation(expression);
             expressionAnimation.SetReferenceParameter("my", obj);

--- a/source/LottieToWinComp/Brushes.cs
+++ b/source/LottieToWinComp/Brushes.cs
@@ -257,8 +257,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         public static CompositionBrush? TranslateShapeFill(
             LayerContext context,
             ShapeFill? shapeFill,
-            CompositeOpacity opacity,
-            Rectangles.OriginOffset? originOffset)
+            CompositeOpacity opacity)
         {
             if (shapeFill is null)
             {
@@ -270,9 +269,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                 ShapeFill.ShapeFillKind.SolidColor =>
                     TranslateSolidColorFill(context, (SolidColorFill)shapeFill, opacity),
                 ShapeFill.ShapeFillKind.LinearGradient =>
-                    TranslateLinearGradient(context, (LinearGradientFill)shapeFill, opacity, originOffset),
+                    TranslateLinearGradient(context, (LinearGradientFill)shapeFill, opacity),
                 ShapeFill.ShapeFillKind.RadialGradient =>
-                    TranslateRadialGradient(context, (RadialGradientFill)shapeFill, opacity, originOffset),
+                    TranslateRadialGradient(context, (RadialGradientFill)shapeFill, opacity),
                 _ => throw new InvalidOperationException(),
             };
         }
@@ -419,10 +418,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             LayerContext context,
             CompositionObject obj,
             string propertyName,
-            TrimmedAnimatable<Vector2> value,
-            Rectangles.OriginOffset? offset)
+            TrimmedAnimatable<Vector2> value)
         {
-            if (offset is null)
+            if (context is not ShapeLayerContext || ((ShapeLayerContext)context).OriginOffset is null)
             {
                 if (value.IsAnimated)
                 {
@@ -434,6 +432,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                     return ConvertTo.Vector2(value.InitialValue);
                 }
             }
+
+            var offset = ((ShapeLayerContext)context).OriginOffset!;
 
             if (!offset.IsAnimated && !value.IsAnimated)
             {
@@ -469,8 +469,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         static CompositionLinearGradientBrush? TranslateLinearGradient(
             LayerContext context,
             IGradient linearGradient,
-            CompositeOpacity opacity,
-            Rectangles.OriginOffset? originOffset = null)
+            CompositeOpacity opacity)
         {
             var result = context.ObjectFactory.CreateLinearGradientBrush();
 
@@ -480,13 +479,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             var startPoint = Optimizer.TrimAnimatable(context, linearGradient.StartPoint);
             var endPoint = Optimizer.TrimAnimatable(context, linearGradient.EndPoint);
 
-            var startPointValue = AnimateVector2WithOriginOffsetOrGetValue(context, result, nameof(result.StartPoint), startPoint, originOffset);
+            var startPointValue = AnimateVector2WithOriginOffsetOrGetValue(context, result, nameof(result.StartPoint), startPoint);
             if (startPointValue is not null)
             {
                 result.StartPoint = startPointValue!;
             }
 
-            var endPointValue = AnimateVector2WithOriginOffsetOrGetValue(context, result, nameof(result.EndPoint), endPoint, originOffset);
+            var endPointValue = AnimateVector2WithOriginOffsetOrGetValue(context, result, nameof(result.EndPoint), endPoint);
             if (endPointValue is not null)
             {
                 result.EndPoint = endPointValue!;
@@ -508,14 +507,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         static CompositionGradientBrush? TranslateRadialGradient(
             LayerContext context,
             IRadialGradient gradient,
-            CompositeOpacity opacity,
-            Rectangles.OriginOffset? originOffset = null)
+            CompositeOpacity opacity)
         {
             if (!context.ObjectFactory.IsUapApiAvailable(nameof(CompositionRadialGradientBrush), versionDependentFeatureDescription: "Radial gradient fill"))
             {
                 // CompositionRadialGradientBrush didn't exist until UAP v8. If the target OS doesn't support
                 // UAP v8 then fall back to linear gradients as a compromise.
-                return TranslateLinearGradient(context, gradient, opacity, originOffset);
+                return TranslateLinearGradient(context, gradient, opacity);
             }
 
             var result = context.ObjectFactory.CreateRadialGradientBrush();
@@ -526,7 +524,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             var startPoint = Optimizer.TrimAnimatable(context, gradient.StartPoint);
             var endPoint = Optimizer.TrimAnimatable(context, gradient.EndPoint);
 
-            var startPointValue = AnimateVector2WithOriginOffsetOrGetValue(context, result, nameof(result.EllipseCenter), startPoint, originOffset);
+            var startPointValue = AnimateVector2WithOriginOffsetOrGetValue(context, result, nameof(result.EllipseCenter), startPoint);
             if (startPointValue is not null)
             {
                 result.EllipseCenter = startPointValue!;

--- a/source/LottieToWinComp/Brushes.cs
+++ b/source/LottieToWinComp/Brushes.cs
@@ -254,10 +254,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             sprite.StrokeBrush = brush;
         }
 
-        public static CompositionBrush? TranslateShapeFill(
-            LayerContext context,
-            ShapeFill? shapeFill,
-            CompositeOpacity opacity)
+        public static CompositionBrush? TranslateShapeFill(LayerContext context, ShapeFill? shapeFill, CompositeOpacity opacity)
         {
             if (shapeFill is null)
             {
@@ -266,12 +263,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 
             return shapeFill.FillKind switch
             {
-                ShapeFill.ShapeFillKind.SolidColor =>
-                    TranslateSolidColorFill(context, (SolidColorFill)shapeFill, opacity),
-                ShapeFill.ShapeFillKind.LinearGradient =>
-                    TranslateLinearGradient(context, (LinearGradientFill)shapeFill, opacity),
-                ShapeFill.ShapeFillKind.RadialGradient =>
-                    TranslateRadialGradient(context, (RadialGradientFill)shapeFill, opacity),
+                ShapeFill.ShapeFillKind.SolidColor => TranslateSolidColorFill(context, (SolidColorFill)shapeFill, opacity),
+                ShapeFill.ShapeFillKind.LinearGradient => TranslateLinearGradient(context, (LinearGradientFill)shapeFill, opacity),
+                ShapeFill.ShapeFillKind.RadialGradient => TranslateRadialGradient(context, (RadialGradientFill)shapeFill, opacity),
                 _ => throw new InvalidOperationException(),
             };
         }

--- a/source/LottieToWinComp/ExpressionFactory.cs
+++ b/source/LottieToWinComp/ExpressionFactory.cs
@@ -47,9 +47,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                                                                         MyPosition.Y - MyAnchor.Y,
                                                                         0);
 
-        internal static Vector2 InternalOffsetExressionAdded(string property, Vector2 offsetExpression) => MyVector2(property) + offsetExpression;
+        internal static Vector2 OriginOffsetExressionAdded(string property, Vector2 offsetExpression) => MyVector2(property) + offsetExpression;
 
-        internal static Vector2 InternalOffsetValueAdded(string property, Sn.Vector2 offsetValue) => MyVector2(property) + Vector2(offsetValue);
+        internal static Vector2 OriginOffsetValueAdded(string property, Sn.Vector2 offsetValue) => MyVector2(property) + Vector2(offsetValue);
 
         internal static Color ThemedColorMultipliedByOpacity(string bindingName, Animatables.Opacity opacity)
             => ColorAsVector4MultipliedByOpacity(ThemedColor4Property(bindingName), opacity.Value);

--- a/source/LottieToWinComp/ExpressionFactory.cs
+++ b/source/LottieToWinComp/ExpressionFactory.cs
@@ -33,7 +33,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         internal static readonly Scalar RootProgress = RootScalar(TranslationContext.ProgressPropertyName);
         internal static readonly Scalar MaxTStartTEnd = Max(MyTStart, MyTEnd);
         internal static readonly Scalar MinTStartTEnd = Min(MyTStart, MyTEnd);
-        static readonly Vector2 HalfMySize = MySize / Vector2(2, 2);
+        internal static readonly Vector2 HalfMySize = MySize / Vector2(2, 2);
+        internal static readonly Vector2 GeometryHalfSize = NamedVector2("geometry", "Size") / Vector2(2, 2);
         internal static readonly Color AnimatedColorWithAnimatedOpacity =
             ColorAsVector4MultipliedByOpacities(MyColor, new[] { MyOpacity });
 
@@ -45,6 +46,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                                                                         MyPosition.X - MyAnchor.X,
                                                                         MyPosition.Y - MyAnchor.Y,
                                                                         0);
+
+        internal static Vector2 InternalOffsetExressionAdded(string property, Vector2 offsetExpression) => MyVector2(property) + offsetExpression;
+
+        internal static Vector2 InternalOffsetValueAdded(string property, Sn.Vector2 offsetValue) => MyVector2(property) + Vector2(offsetValue);
 
         internal static Color ThemedColorMultipliedByOpacity(string bindingName, Animatables.Opacity opacity)
             => ColorAsVector4MultipliedByOpacity(ThemedColor4Property(bindingName), opacity.Value);
@@ -248,9 +253,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 
         static Vector2 MyVector2(string propertyName) => Vector2(My(propertyName));
 
+        static Vector2 NamedVector2(string name, string propertyName) => Vector2(Named(name, propertyName));
+
         static Vector4 MyVector4(string propertyName) => Vector4(My(propertyName));
 
         static string My(string propertyName) => $"my.{propertyName}";
+
+        static string Named(string name, string propertyName) => $"{name}.{propertyName}";
 
         // A property on the root property set. Used to bind to the property set that contains the Progress property.
         static string RootProperty(string propertyName) => $"{RootName}.{propertyName}";

--- a/source/LottieToWinComp/Rectangles.cs
+++ b/source/LottieToWinComp/Rectangles.cs
@@ -330,8 +330,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                 rectangle.DrawingDirection == DrawingDirection.Reverse,
                 trimOffsetDegrees: trimOffsetDegrees);
 
-            context.LayerContext.OriginOffset = null;
-
             compositionRectangle.SetDescription(context, () => rectangle.Name);
             compositionRectangle.Geometry.SetDescription(context, () => $"{rectangle.Name}.RectangleGeometry");
         }
@@ -426,8 +424,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                 compositionRectangle,
                 rectangle.DrawingDirection == DrawingDirection.Reverse,
                 trimOffsetDegrees: trimOffsetDegrees);
-
-            context.LayerContext.OriginOffset = null;
 
             compositionRectangle.SetDescription(context, () => rectangle.Name);
             compositionRectangle.Geometry.SetDescription(context, () => $"{rectangle.Name}.RectangleGeometry");

--- a/source/LottieToWinComp/Rectangles.cs
+++ b/source/LottieToWinComp/Rectangles.cs
@@ -21,31 +21,29 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         // Rectangles are implemented differently in WinComp API
         // and Lottie. In WinComp API coordinates inside rectangle start in
         // top left corner and in Lottie they start in the middle
-        // To account for this we need to offset all the internal points
-        // for (Rectangle.Size / 2)
+        // To account for this we need to offset all the points inside 
+        // the rectangle for (Rectangle.Size / 2).
         // This class represents this offset (static or animated)
-        public class InternalOffset
+        public class OriginOffset
         {
             public RectangleOrRoundedRectangleGeometry Geometry { get; }
 
             // Use expression if size is animated
-#nullable enable
             public Expressions.Vector2? OffsetExpression { get; }
-#nullable disable
 
             // Use constant value if size if static
             public Sn.Vector2? OffsetValue { get; }
 
-            public bool IsAnimated => OffsetExpression is not null;
+            public bool IsAnimated => OffsetValue is null;
 
-            public InternalOffset(RectangleOrRoundedRectangleGeometry geometry, Expressions.Vector2 expression)
+            public OriginOffset(RectangleOrRoundedRectangleGeometry geometry, Expressions.Vector2 expression)
             {
                 Geometry = geometry;
                 OffsetExpression = expression;
                 OffsetValue = null;
             }
 
-            public InternalOffset(RectangleOrRoundedRectangleGeometry geometry, Sn.Vector2 value)
+            public OriginOffset(RectangleOrRoundedRectangleGeometry geometry, Sn.Vector2 value)
             {
                 Geometry = geometry;
                 OffsetExpression = null;
@@ -353,15 +351,16 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             var height = size.InitialValue.Y;
             var trimOffsetDegrees = (width / (2 * (width + height))) * 360;
 
-            InternalOffset internalOffset = size.IsAnimated ?
-                new InternalOffset(geometry, ExpressionFactory.GeometryHalfSize) :
-                new InternalOffset(geometry, ConvertTo.Vector2(size.InitialValue / 2));
+            // If offset is not animated then other computations for fill brush can be optimized.
+            OriginOffset originOffset = size.IsAnimated ?
+                new OriginOffset(geometry, ExpressionFactory.GeometryHalfSize) :
+                new OriginOffset(geometry, ConvertTo.Vector2(size.InitialValue / 2));
 
             Shapes.TranslateAndApplyShapeContextWithTrimOffset(
                 context,
                 compositionRectangle,
                 rectangle.DrawingDirection == DrawingDirection.Reverse,
-                internalOffset,
+                originOffset,
                 trimOffsetDegrees: trimOffsetDegrees);
 
             compositionRectangle.SetDescription(context, () => rectangle.Name);
@@ -448,15 +447,16 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             var initialHeight = height.InitialValue;
             var trimOffsetDegrees = (initialWidth / (2 * (initialWidth + initialHeight))) * 360;
 
-            InternalOffset internalOffset = width.IsAnimated || height.IsAnimated ?
-                new InternalOffset(geometry, ExpressionFactory.GeometryHalfSize) :
-                new InternalOffset(geometry, ConvertTo.Vector2(width.InitialValue / 2, height.InitialValue / 2));
+            // If offset is not animated then other computations for fill brush can be optimized.
+            OriginOffset originOffset = width.IsAnimated || height.IsAnimated ?
+                new OriginOffset(geometry, ExpressionFactory.GeometryHalfSize) :
+                new OriginOffset(geometry, ConvertTo.Vector2(width.InitialValue / 2, height.InitialValue / 2));
 
             Shapes.TranslateAndApplyShapeContextWithTrimOffset(
                 context,
                 compositionRectangle,
                 rectangle.DrawingDirection == DrawingDirection.Reverse,
-                internalOffset,
+                originOffset,
                 trimOffsetDegrees: trimOffsetDegrees);
 
             compositionRectangle.SetDescription(context, () => rectangle.Name);

--- a/source/LottieToWinComp/ShapeLayerContext.cs
+++ b/source/LottieToWinComp/ShapeLayerContext.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Toolkit.Uwp.UI.Lottie.LottieData;
+using Sn = System.Numerics;
 
 namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 {
@@ -13,6 +14,41 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         {
             Layer = layer;
         }
+
+        // Rectangles are implemented differently in WinComp API
+        // and Lottie. In WinComp API coordinates inside rectangle start in
+        // top left corner and in Lottie they start in the middle
+        // To account for this we need to offset all the points inside
+        // the rectangle for (Rectangle.Size / 2).
+        // This class represents this offset (static or animated)
+        public class OriginOffsetContainer
+        {
+            public RectangleOrRoundedRectangleGeometry Geometry { get; }
+
+            // Use expression if size is animated
+            public WinCompData.Expressions.Vector2? OffsetExpression { get; }
+
+            // Use constant value if size is static
+            public Sn.Vector2? OffsetValue { get; }
+
+            public bool IsAnimated => OffsetValue is null;
+
+            public OriginOffsetContainer(RectangleOrRoundedRectangleGeometry geometry, WinCompData.Expressions.Vector2 expression)
+            {
+                Geometry = geometry;
+                OffsetExpression = expression;
+                OffsetValue = null;
+            }
+
+            public OriginOffsetContainer(RectangleOrRoundedRectangleGeometry geometry, Sn.Vector2 value)
+            {
+                Geometry = geometry;
+                OffsetExpression = null;
+                OffsetValue = value;
+            }
+        }
+
+        internal OriginOffsetContainer? OriginOffset { get; set; }
 
         public new ShapeLayer Layer { get; }
     }

--- a/source/LottieToWinComp/ShapeLayerContext.cs
+++ b/source/LottieToWinComp/ShapeLayerContext.cs
@@ -26,24 +26,28 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             public RectangleOrRoundedRectangleGeometry Geometry { get; }
 
             // Use expression if size is animated
-            public WinCompData.Expressions.Vector2? OffsetExpression { get; }
+            public WinCompData.Expressions.Vector2 OffsetExpression { get; }
 
             // Use constant value if size is static
-            public Sn.Vector2? OffsetValue { get; }
+            public Sn.Vector2 OffsetValue { get; }
 
-            public bool IsAnimated => OffsetValue is null;
+            // IsAnimated = true means that we have to use OffsetExpression.
+            // IsAnimated = false means that we can use OffsetValue instead of OffsetExpression to optimize the code.
+            public bool IsAnimated { get; }
 
             public OriginOffsetContainer(RectangleOrRoundedRectangleGeometry geometry, WinCompData.Expressions.Vector2 expression)
             {
+                IsAnimated = true;
                 Geometry = geometry;
                 OffsetExpression = expression;
-                OffsetValue = null;
+                OffsetValue = new Sn.Vector2(0, 0);
             }
 
             public OriginOffsetContainer(RectangleOrRoundedRectangleGeometry geometry, Sn.Vector2 value)
             {
+                IsAnimated = false;
                 Geometry = geometry;
-                OffsetExpression = null;
+                OffsetExpression = new WinCompData.Expressions.Vector2.Constructed(value.X, value.Y);
                 OffsetValue = value;
             }
         }

--- a/source/LottieToWinComp/ShapeLayerContext.cs
+++ b/source/LottieToWinComp/ShapeLayerContext.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Toolkit.Uwp.UI.Lottie.LottieData;
+using Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions;
 using Sn = System.Numerics;
 
 namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
@@ -47,7 +48,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             {
                 IsAnimated = false;
                 Geometry = geometry;
-                OffsetExpression = new WinCompData.Expressions.Vector2.Constructed(value.X, value.Y);
+                OffsetExpression = Expression.Vector2(value.X, value.Y);
                 OffsetValue = value;
             }
         }

--- a/source/LottieToWinComp/Shapes.cs
+++ b/source/LottieToWinComp/Shapes.cs
@@ -38,19 +38,17 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                 context,
                 shape,
                 reverseDirection,
-                originOffset: null,
                 trimOffsetDegrees: 0);
 
         public static void TranslateAndApplyShapeContextWithTrimOffset(
             ShapeContext context,
             CompositionSpriteShape shape,
             bool reverseDirection,
-            Rectangles.OriginOffset? originOffset,
             double trimOffsetDegrees)
         {
             Debug.Assert(shape.Geometry is not null, "Precondition");
 
-            shape.FillBrush = Brushes.TranslateShapeFill(context, context.Fill, context.Opacity, originOffset);
+            shape.FillBrush = Brushes.TranslateShapeFill(context, context.Fill, context.Opacity);
             Brushes.TranslateAndApplyStroke(context, context.Stroke, shape, context.Opacity);
 
             TranslateAndApplyTrimPath(

--- a/source/LottieToWinComp/Shapes.cs
+++ b/source/LottieToWinComp/Shapes.cs
@@ -34,18 +34,23 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             ShapeContext context,
             CompositionSpriteShape shape,
             bool reverseDirection) =>
-            TranslateAndApplyShapeContextWithTrimOffset(context, shape, reverseDirection, null, 0);
+            TranslateAndApplyShapeContextWithTrimOffset(
+                context,
+                shape,
+                reverseDirection,
+                originOffset: null,
+                trimOffsetDegrees: 0);
 
         public static void TranslateAndApplyShapeContextWithTrimOffset(
             ShapeContext context,
             CompositionSpriteShape shape,
             bool reverseDirection,
-            Rectangles.InternalOffset? internalOffset,
+            Rectangles.OriginOffset? originOffset,
             double trimOffsetDegrees)
         {
             Debug.Assert(shape.Geometry is not null, "Precondition");
 
-            shape.FillBrush = Brushes.TranslateShapeFill(context, context.Fill, context.Opacity, internalOffset);
+            shape.FillBrush = Brushes.TranslateShapeFill(context, context.Fill, context.Opacity, originOffset);
             Brushes.TranslateAndApplyStroke(context, context.Stroke, shape, context.Opacity);
 
             TranslateAndApplyTrimPath(

--- a/source/LottieToWinComp/Shapes.cs
+++ b/source/LottieToWinComp/Shapes.cs
@@ -34,17 +34,18 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             ShapeContext context,
             CompositionSpriteShape shape,
             bool reverseDirection) =>
-            TranslateAndApplyShapeContextWithTrimOffset(context, shape, reverseDirection, 0);
+            TranslateAndApplyShapeContextWithTrimOffset(context, shape, reverseDirection, null, 0);
 
         public static void TranslateAndApplyShapeContextWithTrimOffset(
             ShapeContext context,
             CompositionSpriteShape shape,
             bool reverseDirection,
+            Rectangles.InternalOffset? internalOffset,
             double trimOffsetDegrees)
         {
             Debug.Assert(shape.Geometry is not null, "Precondition");
 
-            shape.FillBrush = Brushes.TranslateShapeFill(context, context.Fill, context.Opacity);
+            shape.FillBrush = Brushes.TranslateShapeFill(context, context.Fill, context.Opacity, internalOffset);
             Brushes.TranslateAndApplyStroke(context, context.Stroke, shape, context.Opacity);
 
             TranslateAndApplyTrimPath(

--- a/source/LottieToWinComp/Shapes.cs
+++ b/source/LottieToWinComp/Shapes.cs
@@ -34,11 +34,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             ShapeContext context,
             CompositionSpriteShape shape,
             bool reverseDirection) =>
-            TranslateAndApplyShapeContextWithTrimOffset(
-                context,
-                shape,
-                reverseDirection,
-                trimOffsetDegrees: 0);
+            TranslateAndApplyShapeContextWithTrimOffset(context, shape, reverseDirection, 0);
 
         public static void TranslateAndApplyShapeContextWithTrimOffset(
             ShapeContext context,

--- a/source/LottieToWinComp/Shapes.cs
+++ b/source/LottieToWinComp/Shapes.cs
@@ -45,6 +45,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             Debug.Assert(shape.Geometry is not null, "Precondition");
 
             shape.FillBrush = Brushes.TranslateShapeFill(context, context.Fill, context.Opacity);
+
+            // OriginOffset is used to adjust cordinates of FillBrush for Rectangle shapes.
+            // It is not needed afterwards, so we clean it up to not affect other code.
+            context.LayerContext.OriginOffset = null;
+
             Brushes.TranslateAndApplyStroke(context, context.Stroke, shape, context.Opacity);
 
             TranslateAndApplyTrimPath(

--- a/source/UIDataCodeGen/CodeGen/InstantiatorGeneratorBase.cs
+++ b/source/UIDataCodeGen/CodeGen/InstantiatorGeneratorBase.cs
@@ -2130,7 +2130,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
 
                 // Call the helper and initialize the remaining CompositionShape properties.
                 WriteMatrixComment(builder, obj.TransformMatrix);
-                builder.WriteLine($"{ConstVar} result = CreateSpriteShape({CallFactoryFromFor(node, obj.Geometry)}, {Matrix3x2(transformMatrix)}, {CallFactoryFromFor(node, obj.FillBrush)});");
+
+                // We need to instantiate geometry first because sometimes it initializes fields
+                // that are used in FillBrush, but CreateSpriteShape(GetGeometry(), ..., GetFillBrush()) code
+                // will result in evaluating GetFillBrush() first which may cause null dereferencing
+                builder.WriteLine($"{ConstVar} geometry = {CallFactoryFromFor(node, obj.Geometry)};");
+
+                builder.WriteLine($"{ConstVar} result = CreateSpriteShape(geometry, {Matrix3x2(transformMatrix)}, {CallFactoryFromFor(node, obj.FillBrush)});");
                 InitializeCompositionObject(builder, obj, node);
                 WriteSetPropertyStatement(builder, nameof(obj.CenterPoint), obj.CenterPoint);
                 WriteSetPropertyStatement(builder, nameof(obj.Offset), obj.Offset);


### PR DESCRIPTION
Because of the difference in how gradient fill for rectangles works in **WinComp API** and Lottie, previously it was displayed incorrectly.

**WinComp API** uses top left corner of rectangle as point [0, 0] while Lottie uses middle-middle instead. To account for this difference we need to add **(Rectangle.Size/2)** to Start and End points of gradients. We can't add a constant value since **Rectangle.Size** can also be animated, and if it is animated, we need to use expression animation.

In this change, I added InternalOffset class for rectangle shapes, which propagates information about offset to the gradients and then this offset is applied to Start and End points.

Examples below show how it works now:
#### Lottie-windows old
<img src="https://user-images.githubusercontent.com/83784664/121609884-a9f73900-ca09-11eb-92bf-6459f9b28c6d.gif" width="200px">

#### Lottie web viewer (https://lottiefiles.com/preview)
<img src="https://user-images.githubusercontent.com/83784664/121609864-a19efe00-ca09-11eb-8223-4965b2517f8e.gif" width="200px">


#### Lottie-windows with this PR
<img src="https://user-images.githubusercontent.com/83784664/121609889-ad8ac000-ca09-11eb-85e6-067b5f02f4e4.gif" width="200px">


