### PR TITLE
Add support for round corners if there is no animations

### DIFF
--- a/source/Animatables/Vector2.cs
+++ b/source/Animatables/Vector2.cs
@@ -67,5 +67,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.Animatables
 
         /// <inheritdoc/>
         public override string ToString() => $"{{{X},{Y}}}";
+
+        public double Length() => Math.Sqrt((X * X) + (Y * Y));
+
+        public Vector2 Normalized() => this / Length();
     }
 }

--- a/source/LottieToWinComp/Paths.cs
+++ b/source/LottieToWinComp/Paths.cs
@@ -482,9 +482,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                 else if (canRoundBegin && canRoundEnd)
                 {
                     // Both ends are not curved, so we can make them rounded.
-                    var length = (segment.ControlPoint0 - segment.ControlPoint3).Length();
-
-                    var radiusVector = (segment.ControlPoint3 - segment.ControlPoint0) / length * radius;
+                    var cp0cp3 = segment.ControlPoint3 - segment.ControlPoint0;
+                    var length = cp0cp3.Length();
+                    var radiusVector = cp0cp3.Normalized() * radius;
 
                     Vector2 point0 = segment.ControlPoint0 + radiusVector;
                     Vector2 point1 = segment.ControlPoint3 - radiusVector;
@@ -541,7 +541,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 
                 if (i == -1)
                 {
-                    // If i = -1 then is was special pre-pass to get the valid value of prevControlPoint,
+                    // If i = -1 then it was special pre-pass to get the valid value of prevControlPoint,
                     // all generated segments should be ignored.
                     resultSegments.Clear();
                 }

--- a/source/LottieToWinComp/Paths.cs
+++ b/source/LottieToWinComp/Paths.cs
@@ -436,7 +436,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         }
 
         // The way this function works is it detects if two segments form a corner (if they do not have smooth connection)
-        // Then it duplicates this point (shared by two segments) and moves newlt generated points in different directions
+        // Then it duplicates this point (shared by two segments) and moves newly generated points in different directions
         // for "radius" pixels along the segment.
         // After that we are joining both new points with a bezier curve to make the corner look rounded.
         //


### PR DESCRIPTION
Implemented After Effects algorithm for **"Round Corners"** effect. (There is a comment in Shapes.cs:634 that mentioned this _// TODO - can round corners be implemented by composing cubic Beziers?_)

For now I added support only for one-path + no-animations scenario, in following PR will also add support for multiple paths and animated path/radius. Just to keep this PR small.
 
.
.
.

To make a round corner we are stepping `radius` pixels in both directions from the corner, and joining resulting points together with a bezier curve (`MakeCubicBezier` takes 3 points and creates a bezier curve). But also there is a tricky case, when one end of the segment is already curved, this case described on picture 2.

Algorithm loops over segments and creates new array of segments, there are several cases that can happen when we are processing current segment:
0 If current segment has both ends curved we do not need to change anything, just add current segment to the result
1 If current segment has both ends that are not curved:
<img src="https://user-images.githubusercontent.com/83784664/123132153-41de2500-d403-11eb-9c19-1cc1e85ec9b3.png" width="400px">
On this step we are creating new segments `(prevControlPoint, point0)` and `(point0, point1)`


2 If current segment has first end curved:
<img src="https://user-images.githubusercontent.com/83784664/123133342-7bfbf680-d404-11eb-81b3-29375ff40613.png" width="400px">
New point will be created on distance `radius` from the second end of the segment, on the line that connects second end of the segment and controlPoint1 of original bezier curve

.
.
.

Here how it looks in lottie (it is pixel-perfect with how it looks in After Effects) :
<img src="https://user-images.githubusercontent.com/83784664/123013861-db60f480-d379-11eb-98c3-a9e1398df0f7.gif" width="400px">
(red - original shape, green - with round corners)