### PR TITLE
[LottieViewer] PixelView bug fixed. We should not update pixel view when it is not on the screen.

### DIFF
--- a/LottieViewer/MainPage.xaml.cs
+++ b/LottieViewer/MainPage.xaml.cs
@@ -421,6 +421,11 @@ namespace LottieViewer
                 ControlPanel.Children.Add(ColorPanel);
             }
 
+            // PixelView should be active only when Info page is open.
+            // Otherwise changing surface that is not yet on the screen
+            // will throw an exception.
+            _pixelView.Active = sender == InfoButton;
+
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsControlPanelVisible)));
         }
 
@@ -432,6 +437,11 @@ namespace LottieViewer
             // Remove all the children from the control pane Grid. This is done to
             // trigger the PaneThemeTransition so that the pane slides in and out.
             ControlPanel.Children.Clear();
+
+            // PixelView should be active only when Info page is open.
+            // Otherwise changing surface that is not yet on the screen
+            // will throw an exception.
+            _pixelView.Active = false;
 
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsControlPanelVisible)));
         }

--- a/LottieViewer/PixelViewElement.cs
+++ b/LottieViewer/PixelViewElement.cs
@@ -33,6 +33,9 @@ namespace LottieViewer
         readonly SpriteVisual _spriteVisual;
         Visual? _capturedVisual = null;
 
+        // Indicates if PixelView should update the image.
+        public bool Active { get; set; } = false;
+
         // Checkerboard pattern bitmap.
         static CanvasBitmap? _patternBitmap = null;
 
@@ -171,10 +174,13 @@ namespace LottieViewer
 
         void OnFrameArrived(Direct3D11CaptureFramePool sender, object args)
         {
-            using (var frame = sender.TryGetNextFrame())
+            if (Active)
             {
-                CanvasBitmap bitmap = CanvasBitmap.CreateFromDirect3D11Surface(_canvasDevice!, frame.Surface);
-                _ = ShowBitmapOnTargetAsync(bitmap);
+                using (var frame = sender.TryGetNextFrame())
+                {
+                    CanvasBitmap bitmap = CanvasBitmap.CreateFromDirect3D11Surface(_canvasDevice!, frame.Surface);
+                    _ = ShowBitmapOnTargetAsync(bitmap);
+                }
             }
         }
 


### PR DESCRIPTION
Because of this bug PixelView generated a lot of exceptions that were not visible to the user but slowed down the LottieViewer. We should update PixelView only when it is open on the screen, otherwise we will get an exception because we are trying to update the surface that is not visible.